### PR TITLE
release-npm: scoped-main fallback when the unscoped name is filtered

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -180,7 +180,20 @@ jobs:
           done
           main_name=$(node -p "require('./package.json').name")
           main_ver=$(node -p "require('./package.json').version")
-          publish_if_absent "$main_name" "$main_ver" "."
+          if ! publish_if_absent "$main_name" "$main_ver" "."; then
+            # The unscoped main name is still behind npm's similarity filter
+            # ("too similar to existing package argv"; support exception
+            # pending — see CLAUDE.md "Naming"). Ship the scoped package
+            # instead: the shape every release since 1.0.0 actually has on
+            # the registry. The day npm unblocks the unscoped name, the
+            # publish above simply succeeds and this fallback stops firing.
+            # Safe to rename here: prepare-npm.mjs already wired the version
+            # and optionalDependencies, and binary loading keys on
+            # napi.binaryName, not the registry name.
+            echo "::warning::unscoped $main_name@$main_ver rejected by npm similarity filter — publishing @areev/areev instead"
+            node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.name='@areev/areev';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+            publish_if_absent "@areev/areev" "$main_ver" "."
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Second half of unblocking the v1.1.0 npm publish: the win32 skip (#17) worked; the rerun then failed publishing the MAIN package because npm's similarity filter rejects unscoped `areev` — while the registry's real shape since 1.0.0 is scoped `@areev/areev`. Unscoped is tried first (self-heals when the pending exception lands), falling back to the scoped name on that refusal. Also records that npm's 2026-07-17 win32 whitelist regressed (today's 403), which #17's skip tolerates.