### PR TITLE
Correct the npm whitelist history (dejadb-*, not areev-*)

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -164,13 +164,14 @@ jobs:
             name=$(node -p "require('./$dir/package.json').name")
             ver=$(node -p "require('./$dir/package.json').version")
             if ! publish_if_absent "$name" "$ver" "$dir"; then
-              # areev-win32-x64-msvc is blocked by npm's spam/similarity
-              # filter pending a support exception (see the release runbook
-              # and CLAUDE.md "Naming"). Its absence is the accepted 1.0.x
-              # posture — Windows users build from source — so the one
-              # blocked platform package must not abort the loop and leave
-              # the MAIN package unpublished (exactly how v1.1.0's first
-              # publish run failed). Any other failure still hard-fails.
+              # areev-win32-x64-msvc is blocked by npm's spam filter. The
+              # prior whitelist (2026-07-17) covered the FORMER name
+              # dejadb-win32-x64-msvc only; the areev-* exception is a new
+              # request, user-tracked with npm support (see CLAUDE.md
+              # "Naming"). Windows users build from source meanwhile — the
+              # one blocked platform package must not abort the loop and
+              # leave the MAIN package unpublished (exactly how v1.1.0's
+              # first publish run failed). Any other failure hard-fails.
               if [ "$name" = "areev-win32-x64-msvc" ]; then
                 echo "::warning::$name@$ver rejected by npm spam filter (pending support exception) — continuing without the Windows prebuild"
               else

--- a/crates/areev-js/scripts/prepare-npm.mjs
+++ b/crates/areev-js/scripts/prepare-npm.mjs
@@ -16,8 +16,13 @@
 // release-npm (the publish step skips packages already on the registry, so
 // only the newly-undeferred one goes out).
 //
-// `areev-win32-x64-msvc` was deferred here (403 on publish; support ticket
-// open) and unblocked 2026-07-17 — npm whitelisted the name.
+// History, corrected 2026-08-17: the 2026-07-17 whitelist was granted for
+// this package's FORMER name — `dejadb-win32-x64-msvc` (published at 1.2.0,
+// the frozen pre-rename release). `areev-win32-x64-msvc` has never been
+// whitelisted; the v1.1.0 publish 403 is a fresh spam-filter rejection of a
+// new name, not a regression. Exception request for the areev-* names is
+// user-tracked with npm support; the release-npm workflow skips this one
+// name loudly until it lands.
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 
 const DEFER = new Set();


### PR DESCRIPTION
The prepare-npm.mjs comment was mechanically renamed during the DejaDB→Areev rebrand and falsely claims `areev-win32-x64-msvc` was whitelisted on 2026-07-17. npm shows the exception actually covered `dejadb-win32-x64-msvc@1.2.0` (and unscoped `dejadb`). Corrects both comments so the support ticket gets filed as a rename-carry-over request, not a false regression claim.