### PR TITLE
Release v1.2.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -252,6 +252,12 @@ maintained on write. The store keeps, among others:
   for entity-valued objects). This is the "hexastore-equivalent" the spec
   permits — the permutations CAL's bounded traversal actually needs, rather
   than the full six.
+  A grain that names a `subject` but asserts no relation or object is indexed
+  too, as a subject-anchored row with both other positions NULL. Requiring a
+  complete triple dropped such grains from the index entirely, and because
+  erasure and DSAR disclosure select through these same indexes, the cost was
+  not only a silent empty recall but an identity's own Event surviving
+  `forget_subject` — see `docs/erasure.md`.
 - **`entity_latest`** — the current head(s) per `(subject, relation)`, so
   "current value of X" is a point read.
 - **A full-text index** (BM25) and a **vector index** for hybrid recall.
@@ -274,6 +280,16 @@ hash-verified. Recall never scans bytes — searchability comes from *derived
 text* (transcripts, extractions) stored in grain content and from embedding
 references. See the [security model](docs/security-model.md) for the current
 plaintext-sidecar limitation.
+
+Because the payloads live *beside* the file rather than in it, a blob can be
+read **without opening the memory** (`read_blob_offline`, `areev blob get`).
+That is not a convenience: the embedded backend's file lock is exclusive, so
+while a run holds a memory even a reader is refused — which would put an
+attachment out of reach of the very `--tool-cmd` subprocess the run spawned to
+process it. No read-only open mode is needed to fix that, because a blob has
+nothing to be consistent *with*: it is immutable, and its address is its
+checksum, which the read re-verifies. An encrypted memory is the exception —
+decrypting the sidecar needs the derived key, so that path still opens.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,83 @@ the pre-rename release history lives in that repository's `CHANGELOG.md`.
 
 ## [Unreleased]
 
+## [1.2.1] — 2026-08-17
+
+### Fixed
+
+- **A grain carrying a `subject` without a relation or object reached no
+  index at all** (#23). Structural indexing required all three positions, so
+  an Event *about* a message id or a person was invisible to
+  `recall(ns, subject, …)` — a silent empty result on a filter every surface
+  accepts. The same root cause was the serious one: `forget_subject` and
+  `subject_report` select through those indexes, so the identity's own grain
+  survived erasure and went **undisclosed in a DSAR**, while the erasure
+  reported success. Such grains now get a subject-anchored row (relation and
+  object NULL, because the grain asserts neither — which also keeps the row
+  inert to every relation-bound query). Never written to `heads`/
+  `entity_latest`: a log entry about a subject has no "current value". Existing
+  files are healed on open by a `link_index` stamp bump; the rebuild replays
+  the rows and reconstructs `cur` from supersession state, so a reindex neither
+  duplicates a grain nor resurrects a superseded one. Pinned on both backends
+  (`subject_without_relation_is_indexed`).
+- **`DEFINE QUERY` stored bodies that could never `RUN`** (#24). Define-time
+  validation skipped parsing entirely whenever the body contained `$` — the
+  shape most saved queries have — and fell back to a keyword blocklist, so any
+  syntax error was stored and first surfaced when a caller ran it, typically an
+  unattended agent long after the author had moved on. The body is now parsed
+  at `DEFINE`. Bodies whose parameters sit in positions demanding a literal
+  (`RECENT $limit`) are still accepted: the check re-parses with the parameters
+  standing in, so only a body malformed *however* it is bound is refused
+  (`CAL-E059`). The read-only and destructive guards are unchanged.
+- **A Skill's `instructions` could not be reached through any rendered path**
+  (#25). The field that *is* the skill was absent from the grain type's
+  queryable fields (`PROJECT name, instructions` → `CAL-E060`) and no format
+  emitted it, leaving raw JSON recall — which defeats budgeted assembly — as
+  the only way to read it. `instructions` and `when_to_use` are now projectable
+  and render at full disclosure.
+
+### Added
+
+- **`WITH progressive_disclosure(summary|headlines|full)` now executes**
+  (#25). It was documented in `docs/cal-reference.md` but parsed and discarded,
+  warning `CAL-W004`. It is the *body* axis, orthogonal to metadata: `summary`
+  and `headlines` clip free-text bodies (40/80 chars, the same ladder budgeted
+  template renders already use), and `full` leaves them whole **and** adds the
+  long-form definition bodies no other tier carries — a Skill's `when_to_use`
+  and `instructions`, so they reach a budgeted `ASSEMBLE` instead of being
+  injected around it. Omitting the option renders exactly as before, byte for
+  byte.
+- **The CAS blob store reaches the CLI and both bindings** (#27):
+  `areev blob put <FILE>|--stdin` prints the `cas://` URI (idempotent by
+  construction), `areev blob get <cas-uri>` writes hash-verified bytes to
+  stdout, and `put_blob`/`get_blob` ship in Python and Node — bytes in, bytes
+  out, the one documented exception to the scalars-in/JSON-out convention.
+  `blob get` deliberately **does not open the memory**: the embedded backend's
+  file lock is exclusive, so while a run holds a memory even a reader is
+  refused, which put an attachment out of reach of the very `--tool-cmd`
+  subprocess the run spawned to process it. Reading the sidecar needs no lock
+  and answers no consistency question — a blob is immutable and its address is
+  its checksum, re-verified on read. Encrypted memories still open, since
+  decryption needs the derived key. No MCP tool, deliberately: blob bytes would
+  have to be base64'd into a tool result and land whole in the model's context.
+- **Evalset-backed outcome metrics** (#29). A recommendation may carry
+  `metric = "evalset:<EVALSET_HASH>:<field>"`, resolved by `areev loop outcomes`
+  from the summaries `areev eval run` journals — `passed`, `failed`, `total`
+  and `error_rate` work against any evalset, and any other field is read from
+  the summary the harness wrote. This moves the honesty boundary legitimately
+  rather than breaking it: an evalset run is itself an internal, bounded,
+  attributable measurement. Two safeguards are load-bearing. A run journaled
+  **before** the apply is never evidence (no run since → not yet measurable,
+  and the checkpoint stays due; scoring the baseline against itself would
+  report `held` forever, a fabricated receipt). And `MetricSnapshot.higher_is_better`
+  states the direction, because the built-in metrics are recurrence counts
+  where lower is better while an accuracy is the opposite — read the wrong way,
+  the Verify gate would propose reverting the rules that worked. The regression
+  comparison now lives in one function both the engine and `outcome_review`
+  call. The apply gate (`--gating-run`) and the outcome edge read those
+  summaries through one shared reader, so a rule cannot be admitted on one
+  reading of an evalset and judged on another.
+
 ## [1.2.0] — 2026-08-17
 
 ### Added
@@ -268,7 +345,9 @@ plane), renamed on every surface.
   `crates/areev-bench` (`RESULTS.md` has the numbers), with perf gates
   (`bench`, `voice_loop`) run as examples.
 
-[Unreleased]: https://github.com/AreevAI/areev/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/AreevAI/areev/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/AreevAI/areev/compare/v1.2.0...v1.2.1
+[1.2.0]: https://github.com/AreevAI/areev/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/AreevAI/areev/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/AreevAI/areev/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/AreevAI/areev/compare/v1.0.0...v1.0.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "areev"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-context",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "areev-bench"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-context",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "areev-cal"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-core",
  "areev-store",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "areev-conformance"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "areev-context"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "areev-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "insta",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "areev-llm"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-core",
  "areev-loop",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop-adapter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "areev-mcp"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "areev-py"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-core",
  "serde",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "areev-server"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "areev-store"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "areev-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/areev-core", "crates/areev-store", "crates/areev-cal", "crates/areev-cli", "crates/areev-mcp", "crates/areev-context", "crates/areev-server", "crates/areev-py", "crates/areev-bench", "crates/areev-loop", "crates/areev-loop-adapter", "crates/areev-llm", "crates/areev-conformance", "crates/areev-run-core", "crates/areev-run"]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["MindGryd Software Private Limited"]

--- a/crates/areev-bench/Cargo.toml
+++ b/crates/areev-bench/Cargo.toml
@@ -11,14 +11,14 @@ homepage.workspace = true
 publish = false
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
 # `cargo run -p areev-bench --features postgres --bin pg_bench` — the
 # server-tier latency harness (needs DATABASE_URL).
 
-areev-store = { path = "../areev-store", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
-areev-context = { path = "../areev-context", version = "1.2.0" }
-areev-server = { path = "../areev-server", version = "1.2.0" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-context = { path = "../areev-context", version = "1.2.1" }
+areev-server = { path = "../areev-server", version = "1.2.1" }
 areev-loop = { path = "../areev-loop" }
 areev-llm = { path = "../areev-llm" }
 serde_json = "1"

--- a/crates/areev-cal/CLAUDE.md
+++ b/crates/areev-cal/CLAUDE.md
@@ -52,7 +52,16 @@ on the latter two, optional-but-recorded on the hash form.
    `FORGET SUBJECT` — classifies `Read` and is `read`-gated, deliberately
    NOT behind the destructive cap.
 Saved-query bodies get an extra `check_statement_read_only` pass (destructive
-statements are refused there regardless of the gate). `cal_forget_scope`
+statements are refused there regardless of the gate), and `validate_query_body`
+also **parses** the body at DEFINE. It used to stop at the word-level keyword
+scan whenever the body contained `$` — i.e. for most saved queries — so any
+syntax error was stored and first surfaced at RUN. The reason for that skip was
+real but narrow (a parameter in a numeric position like `RECENT $limit` is not a
+literal until RUN substitutes it), so the check parses the body as written and,
+on failure, retries with `params_as_literals` standing the parameters in; only a
+body that fails BOTH is refused (`CAL-E059`). The reported error is always the
+one from the body as the author wrote it — the placeholder form is an internal
+probe whose spans would point at text nobody typed. `cal_forget_scope`
 remains an unwired stub.
 
 Security invariants in the lexer: **S-1** bidi-control rejection
@@ -98,6 +107,17 @@ the audit hash.
   assembler both call it (parity pinned by areev-context's
   `tests/render_parity.rs`) — never grow a second implementation of a
   format name.
+  **`Disclosure`** (OMS §4 `WITH progressive_disclosure`) is the body axis,
+  orthogonal to `MetadataDetail`'s envelope axis: `summary`/`headlines` clip
+  free-text bodies (40/80 chars, the same ladder `templates::effective_truncate`
+  uses), `full` leaves them whole AND emits the long-form definition bodies no
+  other tier carries — a Skill's `instructions`/`when_to_use`, which otherwise
+  reach no rendered path at all. `None` (nothing requested) is the historical
+  render, byte for byte; the `*_at` entry points take the tier and the bare
+  `render_grain_sml`/`render_grain_markdown` delegate with `None`, which is what
+  keeps render parity honest. Gating the definition body behind `full` is
+  deliberate: a recall of twenty skills must stay a listing, not twenty
+  playbooks.
 - `templates.rs` — Mustache-subset engine (closed variable set, 10 filters,
   F1–F7 security invariants, 1MB output cap). Builtins are exactly the three
   §10.1 sectioned presets (`structured`/`readable`/`compact`); a builtin must

--- a/crates/areev-cal/Cargo.toml
+++ b/crates/areev-cal/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["query-language", "parser", "memory", "cal", "ai-agents"]
 categories = ["parser-implementations", "database-implementations"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-store = { path = "../areev-store", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 logos = "0.14"

--- a/crates/areev-cal/src/executor.rs
+++ b/crates/areev-cal/src/executor.rs
@@ -735,8 +735,11 @@ impl CalExecutor {
             payload,
             &query.format,
             grouped_by.as_deref(),
-            &query.user_vars,
-            store,
+            RenderInputs {
+                user_vars: &query.user_vars,
+                store,
+                disclosure: disclosure_of(&query.with_options),
+            },
             None,
             &mut exec_warnings,
         )?;
@@ -814,8 +817,11 @@ impl CalExecutor {
             payload,
             &query.format,
             grouped_by.as_deref(),
-            &query.user_vars,
-            store,
+            RenderInputs {
+                user_vars: &query.user_vars,
+                store,
+                disclosure: disclosure_of(&query.with_options),
+            },
             None,
             &mut exec_warnings,
         )?;
@@ -2382,7 +2388,18 @@ impl CalExecutor {
         // propagate its metadata to the renderer.
         if query.pipeline.is_empty() {
             if let Some(ref fmt) = query.format {
-                return apply_format_clause_to_grains(&grains, fmt, None, &query.user_vars, store, &Default::default(), exec_warnings);
+                return apply_format_clause_to_grains(
+                    &grains,
+                    fmt,
+                    None,
+                    RenderInputs {
+                        user_vars: &query.user_vars,
+                        store,
+                        disclosure: disclosure_of(&query.with_options),
+                    },
+                    &Default::default(),
+                    exec_warnings,
+                );
             }
         }
 
@@ -4043,8 +4060,11 @@ impl CalExecutor {
             payload,
             &entry.format,
             grouped_by.as_deref(),
-            &entry.user_vars,
-            store,
+            RenderInputs {
+                user_vars: &entry.user_vars,
+                store,
+                disclosure: disclosure_of(&entry.with_options),
+            },
             None,
             exec_warnings,
         )?;
@@ -4406,8 +4426,15 @@ impl CalExecutor {
                     result,
                     &assemble.format,
                     None,
-                    &query.user_vars,
-                    store,
+                    RenderInputs {
+                        user_vars: &query.user_vars,
+                        store,
+                        // An ASSEMBLE holds its own WITH options so they scope
+                        // to this assembly even when nested; fall back to the
+                        // enclosing query's.
+                        disclosure: disclosure_of(&assemble.with_options)
+                            .or_else(|| disclosure_of(&query.with_options)),
+                    },
                     // `context_name` is the explicit `ASSEMBLE "name"`
                     // override; `topic` is the bare name. `for_whom` is the
                     // FOR clause, which is what §10.5 calls the intent.
@@ -4599,8 +4626,11 @@ impl CalExecutor {
                 &grains,
                 clause,
                 None,
-                &query.user_vars,
-                store,
+                RenderInputs {
+                    user_vars: &query.user_vars,
+                    store,
+                    disclosure: disclosure_of(&query.with_options),
+                },
                 &plan,
                 exec_warnings,
             )?
@@ -5588,12 +5618,42 @@ fn extract_hash_from_condition(condition: Option<&Condition>) -> Option<String> 
 ///
 /// When `grouped_by` is `Some`, the grains have been reordered by `| GROUP BY`
 /// and FORMAT renderers emit group headers.
+/// The ambient inputs a FORMAT render needs beyond the grains themselves.
+/// Grouped because all three stages of the format path take the same set, and
+/// threading them one by one pushed each signature past what is readable.
+#[derive(Clone, Copy)]
+struct RenderInputs<'a> {
+    /// `WITH VARS` bindings, for template rendering.
+    user_vars: &'a HashMap<String, String>,
+    /// Store access — templates are host metadata read through the facade.
+    store: &'a dyn CalStoreFacade,
+    /// OMS §4 `WITH progressive_disclosure(level)`. `None` = not asked for, and
+    /// every render then keeps its historical output byte for byte.
+    disclosure: Option<crate::render::Disclosure>,
+}
+
+/// The progressive-disclosure tier a `WITH` clause asks for (OMS §4).
+///
+/// The parser has already refused any level word outside
+/// `summary | headlines | full`, so the fallthrough only ever catches the bare
+/// `WITH progressive_disclosure` form — read as "everything", since `full` is
+/// the only tier that adds anything a caller could be asking for.
+fn disclosure_of(opts: &[super::ast::WithOption]) -> Option<crate::render::Disclosure> {
+    opts.iter().find_map(|o| match o {
+        super::ast::WithOption::ProgressiveDisclosure { level } => Some(match level.as_deref() {
+            Some("summary") => crate::render::Disclosure::Summary,
+            Some("headlines") => crate::render::Disclosure::Headlines,
+            _ => crate::render::Disclosure::Full,
+        }),
+        _ => None,
+    })
+}
+
 fn apply_format_clause(
     payload: CalResultPayload,
     format: &Option<FormatClause>,
     grouped_by: Option<&str>,
-    user_vars: &HashMap<String, String>,
-    store: &dyn CalStoreFacade,
+    inputs: RenderInputs<'_>,
     // `(context name, FOR intent)` — only an ASSEMBLE has them, and they feed
     // `{{assembly.name}}` / `{{assembly.intent}}`.
     assemble_ident: Option<(&str, &str)>,
@@ -5655,7 +5715,9 @@ fn apply_format_clause(
         sources: (!render_sources.is_empty()).then_some(render_sources.as_slice()),
     };
 
-    apply_format_clause_to_grains(grains, clause, grouped_by, user_vars, store, &plan, warnings)
+    apply_format_clause_to_grains(
+        grains, clause, grouped_by, inputs, &plan, warnings,
+    )
 }
 
 /// Apply a `FormatClause` to a slice of grains, producing either
@@ -5671,8 +5733,7 @@ fn apply_format_clause_to_grains(
     grains: &[CalGrainResult],
     clause: &FormatClause,
     grouped_by: Option<&str>,
-    user_vars: &HashMap<String, String>,
-    store: &dyn CalStoreFacade,
+    inputs: RenderInputs<'_>,
     plan: &super::templates::RenderPlan<'_>,
     warnings: &mut Vec<String>,
 ) -> std::result::Result<CalResultPayload, CalError> {
@@ -5687,13 +5748,17 @@ fn apply_format_clause_to_grains(
             })
         }
         FormatClause::Single(spec) => {
-            format_grain_results(grains, spec, grouped_by, user_vars, store, plan, warnings)
+            format_grain_results(
+                grains, spec, grouped_by, inputs, plan, warnings,
+            )
         }
         FormatClause::Multi(entries) => {
             let mut formats = HashMap::new();
             for entry in entries {
                 let rendered =
-                    format_grain_results(grains, &entry.spec, grouped_by, user_vars, store, plan, warnings)?;
+                    format_grain_results(
+                        grains, &entry.spec, grouped_by, inputs, plan, warnings,
+                    )?;
                 if let CalResultPayload::Formatted { text, format, .. } = rendered {
                     let key = entry.alias.clone().unwrap_or(format);
                     formats.insert(key, text);
@@ -5747,11 +5812,11 @@ fn format_grain_results(
     grains: &[CalGrainResult],
     format: &super::ast::FormatSpec,
     grouped_by: Option<&str>,
-    user_vars: &HashMap<String, String>,
-    store: &dyn CalStoreFacade,
+    inputs: RenderInputs<'_>,
     plan: &super::templates::RenderPlan<'_>,
     warnings: &mut Vec<String>,
 ) -> std::result::Result<CalResultPayload, CalError> {
+    let RenderInputs { user_vars, store, disclosure } = inputs;
     let (text, format_name) = match format {
         super::ast::FormatSpec::Json => {
             if let Some(field) = grouped_by {
@@ -5789,7 +5854,10 @@ fn format_grain_results(
                         }
                     ));
                     for grain in members {
-                        md.push_str(&crate::render::render_grain_markdown(&grain_view(grain)));
+                        md.push_str(&crate::render::render_grain_markdown_at(
+                            &grain_view(grain),
+                            disclosure,
+                        ));
                         md.push('\n');
                     }
                 }
@@ -5798,7 +5866,10 @@ fn format_grain_results(
                 // line is noise in a prompt, and the assertion already names
                 // what it is about.
                 for grain in grains {
-                    md.push_str(&crate::render::render_grain_markdown(&grain_view(grain)));
+                    md.push_str(&crate::render::render_grain_markdown_at(
+                        &grain_view(grain),
+                        disclosure,
+                    ));
                     md.push('\n');
                 }
             }
@@ -5878,7 +5949,11 @@ fn format_grain_results(
                     ));
                     for grain in members {
                         sml.push_str("    ");
-                        sml.push_str(&crate::render::render_grain_sml(&grain_view(grain), level));
+                        sml.push_str(&crate::render::render_grain_sml_at(
+                            &grain_view(grain),
+                            level,
+                            disclosure,
+                        ));
                         sml.push('\n');
                     }
                     sml.push_str("  </group>\n");
@@ -5886,7 +5961,11 @@ fn format_grain_results(
             } else {
                 for grain in grains {
                     sml.push_str("  ");
-                    sml.push_str(&crate::render::render_grain_sml(&grain_view(grain), level));
+                    sml.push_str(&crate::render::render_grain_sml_at(
+                        &grain_view(grain),
+                        level,
+                        disclosure,
+                    ));
                     sml.push('\n');
                 }
             }

--- a/crates/areev-cal/src/parser.rs
+++ b/crates/areev-cal/src/parser.rs
@@ -158,11 +158,55 @@ pub fn parse_with_params(input: &str, _params: &HashMap<String, Value>) -> CalRe
     parser.parse_query()
 }
 
+/// Rewrite every `$param` reference to a bare literal so a body whose
+/// parameters sit in positions that demand one (`RECENT $limit`) can still be
+/// parsed for SHAPE at DEFINE time. Only ever fed to the parser — never stored,
+/// never executed.
+///
+/// String literals are stepped over: a `"$5.00"` in a WHERE value is data, not
+/// a parameter, and rewriting it could fail a body that is perfectly valid.
+fn params_as_literals(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut chars = body.chars().peekable();
+    let mut quote: Option<char> = None;
+    while let Some(c) = chars.next() {
+        match quote {
+            Some(q) => {
+                out.push(c);
+                if c == '\\' {
+                    // The escaped character cannot close the literal.
+                    if let Some(n) = chars.next() {
+                        out.push(n);
+                    }
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None if c == '"' || c == '\'' => {
+                quote = Some(c);
+                out.push(c);
+            }
+            None if c == '$' => {
+                while chars.peek().is_some_and(|n| n.is_ascii_alphanumeric() || *n == '_') {
+                    chars.next();
+                }
+                // `1` parses in both a numeric and a value position; the type
+                // mismatch it can imply (CAL-E020) belongs to the executor, so
+                // a shape check never sees it.
+                out.push('1');
+            }
+            None => out.push(c),
+        }
+    }
+    out
+}
+
 /// Recursively check that a statement is read-only (no writes, no RUN) — the
 /// enforcement behind the "saved-query bodies stay read-only" invariant. A free
 /// function so the executor can re-check a parsed RUN body at execution time,
 /// not only the parser at DEFINE time (defense in depth: the DEFINE-time scan
-/// is skipped for `$`-parameterized bodies, so RUN is the precise gate).
+/// runs a word-level guard BEFORE the parse, so it holds even for a body the
+/// parser has to see through placeholders).
 pub(crate) fn check_read_only_statement(stmt: &CalStatement, span: &Span) -> CalResult<()> {
     let write = |s: &str| {
         Err(CalError::WriteInQueryBody {
@@ -2701,13 +2745,7 @@ impl Parser {
                 } else {
                     None
                 };
-                // Recognized syntactically but not yet wired into the
-                // recall engine — surface a CAL-W004 hint so callers
-                // don't believe the option is honored.
-                self.warnings.push(CalWarning::UnknownExtensionOption {
-                    option: "progressive_disclosure (parsed but executor no-op)".into(),
-                    span: Some(span),
-                });
+                let _ = span;
                 Ok(Some(WithOption::ProgressiveDisclosure { level }))
             }
             // OMS §4 `consistency(level)` where level ∈ eventual|bounded|linearizable.
@@ -6865,12 +6903,15 @@ impl Parser {
         self.input[start_byte..end_byte].trim().to_string()
     }
 
-    /// Validate that a query body contains only read-tier statements.
+    /// Validate that a query body contains only read-tier statements, and that
+    /// it can actually parse.
     fn validate_query_body(&self, body: &str, span: &Span) -> CalResult<()> {
-        // If the body contains parameter references ($name), skip parse-time
-        // validation. Parameters are substituted at RUN time, so the body
-        // may not parse correctly until then (e.g., RECENT $limit is not a
-        // valid number literal). The body will be validated when RUN executes.
+        // A `$`-bearing body still gets the evade-proof keyword scan below, and
+        // then a real parse. It used to get ONLY the keyword scan, so any
+        // syntax error in a parameterized body — the shape most saved queries
+        // have — was stored unverified and first surfaced when a caller ran it.
+        // A stored query that can never run is a landmine, and its first caller
+        // is often an unattended agent.
         if body.contains('$') {
             // Word-level lexical scan (a `$`-body can't fully parse until RUN
             // substitutes params, so this guard must not be evadable). Split on
@@ -6897,7 +6938,31 @@ impl Parser {
                     });
                 }
             }
-            return Ok(());
+            // Now the shape. The reason the parse used to be skipped here is
+            // real but narrow: a parameter in a NUMERIC position (`RECENT
+            // $limit`) is not a valid number literal until RUN substitutes it,
+            // so the body as written genuinely does not parse. Value positions
+            // (`WHERE x = $p`) do. So try it as written, then retry with every
+            // parameter standing in as a literal — a body that fails BOTH is
+            // malformed no matter what RUN eventually substitutes.
+            match super::parser::parse(body) {
+                Ok(q) => return self.check_statement_read_only(&q.statement, span),
+                Err(strict) => {
+                    let filled = params_as_literals(body);
+                    match super::parser::parse(&filled) {
+                        Ok(q) => return self.check_statement_read_only(&q.statement, span),
+                        // Report the error from the body as the author wrote
+                        // it; the placeholder form is an internal probe and its
+                        // spans would point at text the author never typed.
+                        Err(_) => {
+                            return Err(CalError::InvalidQueryBody {
+                                detail: strict.to_string(),
+                                span: Some(*span),
+                            })
+                        }
+                    }
+                }
+            }
         }
 
         // No parameters — safe to parse and validate fully.

--- a/crates/areev-cal/src/render.rs
+++ b/crates/areev-cal/src/render.rs
@@ -39,6 +39,50 @@ pub enum MetadataDetail {
     Full,
 }
 
+/// OMS §4 progressive disclosure: how much of a grain's BODY a render carries.
+/// Deliberately orthogonal to [`MetadataDetail`], which governs the envelope
+/// (hash, namespace, confidence) rather than the content.
+///
+/// The distinction that matters is at [`Disclosure::Full`]: some grain types
+/// carry a long-form definition body that no other tier renders — a Skill's
+/// `instructions` is the field that *is* the skill, and until `full` existed it
+/// could not be reached through any rendered path at all, only through raw JSON
+/// recall, which defeats budgeted assembly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Disclosure {
+    /// Terse: bodies clipped hard, long-form definitions omitted.
+    Summary,
+    /// Middle: bodies clipped, long-form definitions still omitted.
+    Headlines,
+    /// Everything, long-form definition bodies included.
+    Full,
+}
+
+impl Disclosure {
+    /// Character cap for a free-text body at this tier. Mirrors the ladder
+    /// `templates::effective_truncate` already applies to budgeted template
+    /// renders, so one word means one thing across both.
+    fn body_cap(self) -> usize {
+        match self {
+            Disclosure::Summary => 40,
+            Disclosure::Headlines => 80,
+            Disclosure::Full => usize::MAX,
+        }
+    }
+
+    /// Whether this tier carries long-form definition bodies.
+    fn carries_definitions(self) -> bool {
+        matches!(self, Disclosure::Full)
+    }
+}
+
+/// Body cap for a render, given an optional requested tier. `None` — no
+/// `progressive_disclosure` asked for — keeps each arm's established default,
+/// so an unannotated query renders byte-for-byte as it always has.
+fn body_cap(disclosure: Option<Disclosure>, default: usize) -> usize {
+    disclosure.map_or(default, Disclosure::body_cap)
+}
+
 /// A borrowed, surface-neutral view of one grain. The CAL executor builds it
 /// from a `CalGrainResult`, `areev-context` from a `DeserializedGrain`; both
 /// views of the same stored grain render to the same bytes.
@@ -212,6 +256,16 @@ fn truncate(s: &str, max_chars: usize) -> &str {
 /// …); unknown types fall back to a generic `<grain type="…">` element with
 /// the fields as child tags, so an unusual grain still renders truthfully.
 pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
+    render_grain_sml_at(view, level, None)
+}
+
+/// [`render_grain_sml`] at an explicit progressive-disclosure tier. `None` is
+/// the historical render, unchanged byte for byte.
+pub fn render_grain_sml_at(
+    view: &GrainView,
+    level: MetadataDetail,
+    disclosure: Option<Disclosure>,
+) -> String {
     let meta = extract_metadata(view, level);
     let attrs = meta
         .as_ref()
@@ -232,7 +286,7 @@ pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
         }
         "event" => {
             let content = view.get_str("content").unwrap_or("");
-            let display = truncate(content, 500);
+            let display = truncate(content, body_cap(disclosure, 500));
             // The speaker matters: `relation` carries it on CAL results,
             // `role`/`speaker` on raw event fields. A conversation whose
             // turns lose their speakers is unreadable.
@@ -281,7 +335,7 @@ pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
             };
             let mut sml = format!("<tool tool=\"{}\" status=\"{status}\"{attrs}>", sml_escape(tool));
             if !result_str.is_empty() {
-                sml.push_str(&sml_escape(truncate(result_str, 300)));
+                sml.push_str(&sml_escape(truncate(result_str, body_cap(disclosure, 300))));
             }
             if let Some(d) = view.get_u64("duration_ms") {
                 sml.push_str(&format!(" ({d}ms)"));
@@ -294,7 +348,7 @@ pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
             format!(
                 "<observation observer=\"{}\"{attrs}>{}</observation>",
                 sml_escape(observer),
-                sml_escape(&observation_content(view))
+                sml_escape(truncate(&observation_content(view), body_cap(disclosure, usize::MAX)))
             )
         }
         "goal" => {
@@ -305,7 +359,7 @@ pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
                 "<goal state=\"{}\" priority=\"{}\"{attrs}>{}</goal>",
                 sml_escape(state),
                 sml_escape(priority),
-                sml_escape(desc)
+                sml_escape(truncate(desc, body_cap(disclosure, usize::MAX)))
             );
             if let Some(c) = view.get_str("criteria") {
                 sml = sml.replace(
@@ -322,7 +376,7 @@ pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
             if !conclusion.is_empty() {
                 sml.push_str(&format!(
                     "<conclusion>{}</conclusion>",
-                    sml_escape(conclusion)
+                    sml_escape(truncate(conclusion, body_cap(disclosure, usize::MAX)))
                 ));
             }
             if premise_count > 0 {
@@ -337,7 +391,7 @@ pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
             let dissent_count = view.get_i64("dissent_count").unwrap_or(0);
             format!(
                 "<consensus agreed=\"{agree_count}\" dissent=\"{dissent_count}\"{attrs}>{}</consensus>",
-                sml_escape(agreed)
+                sml_escape(truncate(agreed, body_cap(disclosure, usize::MAX)))
             )
         }
         "consent" => {
@@ -369,6 +423,18 @@ pub fn render_grain_sml(view: &GrainView, level: MetadataDetail) -> String {
             let mut sml = format!("<skill name=\"{}\"{domain_attr}{attrs}>", sml_escape(name));
             if let Some(desc) = view.get_str("description").filter(|d| !d.is_empty()) {
                 sml.push_str(&sml_escape(desc));
+            }
+            // `instructions` is the field that IS the skill, and `when_to_use`
+            // is what tells a model whether to read it. Both are long-form, so
+            // they ride only at full disclosure — a recall of twenty skills at
+            // the default tier must stay a listing, not twenty playbooks.
+            if disclosure.is_some_and(Disclosure::carries_definitions) {
+                if let Some(w) = view.get_str("when_to_use").filter(|w| !w.is_empty()) {
+                    sml.push_str(&format!("<when_to_use>{}</when_to_use>", sml_escape(w)));
+                }
+                if let Some(i) = view.get_str("instructions").filter(|i| !i.is_empty()) {
+                    sml.push_str(&format!("<instructions>{}</instructions>", sml_escape(i)));
+                }
             }
             sml.push_str("</skill>");
             sml
@@ -703,6 +769,12 @@ const RENDER_SKIP: [&str; 8] = [
 /// field shape, matching the golden-pinned output
 /// (`**john** likes jazz *(0.80, 2026-01-05)*`).
 pub fn render_grain_markdown(view: &GrainView) -> String {
+    render_grain_markdown_at(view, None)
+}
+
+/// [`render_grain_markdown`] at an explicit progressive-disclosure tier. `None`
+/// is the historical render, unchanged byte for byte.
+pub fn render_grain_markdown_at(view: &GrainView, disclosure: Option<Disclosure>) -> String {
     let serde_json::Value::Object(map) = view.fields else {
         return String::new();
     };
@@ -817,6 +889,18 @@ pub fn render_grain_markdown(view: &GrainView) -> String {
                         .and_then(serde_json::Value::as_i64)
                         .unwrap_or(0);
                     line.push_str(&format!(" (proficiency {p:.2}, practised {practised}×)"));
+                }
+                // The long-form definition, at full disclosure only — same rule
+                // as the SML arm, so a skill discloses identically in both.
+                if disclosure.is_some_and(Disclosure::carries_definitions) {
+                    let when = map.get("when_to_use").and_then(|v| v.as_str()).unwrap_or("");
+                    if !when.is_empty() {
+                        line.push_str(&format!("\n\n*Use when*: {when}"));
+                    }
+                    let instr = map.get("instructions").and_then(|v| v.as_str()).unwrap_or("");
+                    if !instr.is_empty() {
+                        line.push_str(&format!("\n\n{instr}"));
+                    }
                 }
                 line
             } else if !subject.is_empty() && !text.is_empty() {

--- a/crates/areev-cal/tests/progressive_disclosure_tests.rs
+++ b/crates/areev-cal/tests/progressive_disclosure_tests.rs
@@ -1,0 +1,162 @@
+//! Issue #25 — `WITH progressive_disclosure(level)` executes, and a Skill's
+//! definition body is reachable through a rendered path.
+//!
+//! Two failures shared one shape: the option was documented in
+//! `docs/cal-reference.md` but parsed-and-discarded (the executor even said so
+//! in a comment), and `instructions` — the field that IS the skill — could not
+//! be projected or rendered at all, so the only way to read it was raw JSON
+//! recall, which defeats budgeted assembly.
+
+use areev_cal::executor::CalResultPayload;
+use areev_cal::{CalExecutor, CalExecutorConfig, AreevFacade};
+use tempfile::TempDir;
+
+const INSTRUCTIONS: &str = "STEP 1: read the email. STEP 2: classify the vendor.";
+const WHEN: &str = "when an invoice email arrives";
+
+fn setup() -> (CalExecutor, AreevFacade, TempDir) {
+    let dir = TempDir::new().unwrap();
+    let m = areev_store::Areev::open(dir.path().join("m.db").to_str().unwrap()).unwrap();
+    let facade = AreevFacade::with_session(m, Some("caller".to_string()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+    ex.execute(
+        &format!(
+            r#"ADD skill SET name = "triage" SET description = "Triage invoices"
+               SET instructions = "{INSTRUCTIONS}" SET when_to_use = "{WHEN}"
+               SET namespace = "caller" REASON "seed""#
+        ),
+        &facade,
+    )
+    .unwrap();
+    (ex, facade, dir)
+}
+
+fn text_of(ex: &CalExecutor, facade: &AreevFacade, cal: &str) -> String {
+    match ex.execute(cal, facade).unwrap().result {
+        CalResultPayload::Formatted { text, .. } => text,
+        other => panic!("expected Formatted, got {other:?}"),
+    }
+}
+
+#[test]
+fn full_disclosure_surfaces_a_skills_definition_body() {
+    let (ex, facade, _d) = setup();
+    let full = text_of(
+        &ex,
+        &facade,
+        "RECALL skills FORMAT sml WITH progressive_disclosure(full)",
+    );
+    assert!(full.contains(INSTRUCTIONS), "instructions must render at full: {full}");
+    assert!(full.contains(WHEN), "when_to_use must render at full: {full}");
+    assert!(full.contains("<instructions>"), "as its own element: {full}");
+}
+
+#[test]
+fn the_default_render_is_unchanged() {
+    // The whole point of gating the body behind `full`: a recall of many skills
+    // must stay a listing, not become many playbooks. This is also the
+    // backward-compatibility pin — an unannotated query renders as it always
+    // has, which is what keeps areev-context's render parity honest.
+    let (ex, facade, _d) = setup();
+    let default = text_of(&ex, &facade, "RECALL skills FORMAT sml");
+    assert!(!default.contains(INSTRUCTIONS), "default must NOT carry instructions: {default}");
+    assert!(!default.contains(WHEN), "default must NOT carry when_to_use: {default}");
+    assert!(default.contains("Triage invoices"), "description still renders: {default}");
+
+    // Below full, too — the tier has to actually gate, not just exist.
+    for lvl in ["summary", "headlines"] {
+        let t = text_of(
+            &ex,
+            &facade,
+            &format!("RECALL skills FORMAT sml WITH progressive_disclosure({lvl})"),
+        );
+        assert!(!t.contains(INSTRUCTIONS), "{lvl} must not carry instructions: {t}");
+    }
+}
+
+#[test]
+fn the_option_no_longer_warns_that_it_is_a_no_op() {
+    // It used to emit CAL-W004 "parsed but executor no-op" while the reference
+    // documented it as supported. Whichever way that contradiction resolved,
+    // it must not survive.
+    let (ex, facade, _d) = setup();
+    let r = ex
+        .execute("RECALL skills FORMAT sml WITH progressive_disclosure(full)", &facade)
+        .unwrap();
+    assert!(
+        !r.warnings.iter().any(|w| w.contains("progressive_disclosure")),
+        "no no-op warning expected, got {:?}",
+        r.warnings
+    );
+}
+
+#[test]
+fn lower_tiers_clip_free_text_bodies() {
+    let dir = TempDir::new().unwrap();
+    let m = areev_store::Areev::open(dir.path().join("m.db").to_str().unwrap()).unwrap();
+    let facade = AreevFacade::with_session(m, Some("caller".to_string()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+    let body = "This is a deliberately long observation body that should be clipped at the lower tiers.";
+    ex.execute(
+        &format!(
+            r#"ADD observation SET subject = "vendor" SET content = "{body}"
+               SET namespace = "caller" REASON "seed""#
+        ),
+        &facade,
+    )
+    .unwrap();
+
+    let summary = text_of(
+        &ex,
+        &facade,
+        "RECALL observations FORMAT sml WITH progressive_disclosure(summary)",
+    );
+    let headlines = text_of(
+        &ex,
+        &facade,
+        "RECALL observations FORMAT sml WITH progressive_disclosure(headlines)",
+    );
+    let default = text_of(&ex, &facade, "RECALL observations FORMAT sml");
+
+    assert!(default.contains("clipped at the lower tiers."), "default keeps the body: {default}");
+    assert!(!summary.contains("clipped at the lower tiers."), "summary clips: {summary}");
+    assert!(!headlines.contains("clipped at the lower tiers."), "headlines clips: {headlines}");
+    // The ladder must be ordered, not merely "shorter than default".
+    assert!(
+        summary.len() < headlines.len() && headlines.len() < default.len(),
+        "summary < headlines < default; got {} / {} / {}",
+        summary.len(),
+        headlines.len(),
+        default.len()
+    );
+}
+
+#[test]
+fn instructions_is_projectable() {
+    // `PROJECT name, instructions` used to be CAL-E060 "not available on grain
+    // type skills", because the field was missing from the type's registry row.
+    let (ex, facade, _d) = setup();
+    let r = ex
+        .execute("RECALL skills | PROJECT name, instructions", &facade)
+        .unwrap();
+    let CalResultPayload::Grains { grains, .. } = r.result else {
+        panic!("expected Grains");
+    };
+    let v = serde_json::to_value(&grains[0]).unwrap();
+    assert_eq!(v["fields"]["instructions"].as_str(), Some(INSTRUCTIONS));
+    assert_eq!(v["fields"]["name"].as_str(), Some("triage"));
+}
+
+#[test]
+fn full_disclosure_reaches_a_budgeted_assemble() {
+    // The reported workaround was fetching instructions via raw JSON recall
+    // before `run start` and injecting them outside the assembly budget. This
+    // is the path that makes that unnecessary.
+    let (ex, facade, _d) = setup();
+    let out = text_of(
+        &ex,
+        &facade,
+        r#"ASSEMBLE "agent boot" FROM skills: (RECALL skills) BUDGET 4000 tokens WITH progressive_disclosure(full) FORMAT sml"#,
+    );
+    assert!(out.contains(INSTRUCTIONS), "instructions must reach an ASSEMBLE: {out}");
+}

--- a/crates/areev-cal/tests/readonly_query_body_tests.rs
+++ b/crates/areev-cal/tests/readonly_query_body_tests.rs
@@ -26,3 +26,55 @@ fn read_only_param_body_still_accepted() {
     assert!(parse(r#"DEFINE QUERY "ok2" AS { RECALL facts WHERE subject = "john" }"#).is_ok());
     assert!(parse(r#"DEFINE QUERY "bad" AS { DROP TEMPLATE "x" }"#).is_err());
 }
+
+// ── Issue #24: a parameterized body that can never RUN ─────────────────────
+// The DEFINE-time check used to stop at the keyword scan above whenever the
+// body contained `$`, so a body with a genuine syntax error was stored and only
+// exploded on the first caller — which is typically an unattended agent, long
+// after whoever wrote the query left. The body is now parsed at DEFINE.
+
+#[test]
+fn param_body_with_a_syntax_error_is_refused_at_define() {
+    // The reported shape: THREAD is a lexer token no production consumes, so
+    // this body cannot parse at DEFINE or at RUN.
+    let e = parse(
+        r#"DEFINE QUERY "triage" ($session) AS { ASSEMBLE "t" FROM thread: (RECALL events THREAD $session) BUDGET 4000 tokens FORMAT sml }"#,
+    )
+    .expect_err("a body that can never RUN must not be stored");
+    assert!(e.to_string().starts_with("CAL-E059"), "got {e}");
+
+    // Trailing garbage after an otherwise valid statement.
+    assert!(
+        parse(r#"DEFINE QUERY "g" ($s) AS { RECALL facts WHERE subject = $s THIS IS GARBAGE }"#)
+            .is_err(),
+        "trailing garbage in a parameterized body must be refused"
+    );
+}
+
+#[test]
+fn params_in_positions_that_demand_a_literal_still_define() {
+    // Why the parse used to be skipped: a parameter in a NUMERIC position is
+    // not a valid number literal until RUN substitutes it. These must NOT
+    // regress into false rejections — that would break every saved query that
+    // parameterizes a limit.
+    assert!(parse(r#"DEFINE QUERY "n1" ($limit) AS { RECALL facts WHERE subject = "a" RECENT $limit }"#).is_ok());
+    assert!(parse(r#"DEFINE QUERY "n2" ($k) AS { RECALL facts WHERE subject = "a" LIMIT $k }"#).is_ok());
+    // Value positions were always parseable and must stay accepted.
+    assert!(parse(r#"DEFINE QUERY "v1" ($s) AS { RECALL events WHERE session_id = $s RECENT 10 }"#).is_ok());
+    // Multi-source ASSEMBLE with a parameterized source — the shape the report
+    // was actually reaching for.
+    assert!(parse(
+        r#"DEFINE QUERY "a1" ($s) AS { ASSEMBLE "t" FROM thread: (RECALL events WHERE session_id = $s RECENT 10) BUDGET 4000 tokens FORMAT sml }"#
+    )
+    .is_ok());
+}
+
+#[test]
+fn a_dollar_inside_a_string_literal_is_data_not_a_parameter() {
+    // The placeholder rewrite the shape check uses must step over string
+    // literals, or a perfectly valid body gets refused for containing money.
+    assert!(parse(
+        r#"DEFINE QUERY "money" ($s) AS { RECALL facts WHERE subject = $s AND object = "costs $5.00" }"#
+    )
+    .is_ok());
+}

--- a/crates/areev-cli/Cargo.toml
+++ b/crates/areev-cli/Cargo.toml
@@ -25,9 +25,9 @@ postgres = ["areev-store/postgres"]
 tls = ["areev-server/tls"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-store = { path = "../areev-store", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
 serde_json = "1"
 sha2 = "0.10"
 hex = "0.4"
@@ -36,14 +36,14 @@ zeroize = "1"
 # ISO-8601 transcript timestamps so capture-stop can pin created_at.
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 
-areev-mcp = { path = "../areev-mcp", version = "1.2.0" }
-areev-context = { path = "../areev-context", version = "1.2.0" }
-areev-server = { path = "../areev-server", version = "1.2.0" }
-areev-loop = { path = "../areev-loop", version = "1.2.0" }
-areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.0" }
-areev-llm = { path = "../areev-llm", version = "1.2.0" }
-areev-run = { path = "../areev-run", version = "1.2.0" }
-areev-run-core = { path = "../areev-run-core", version = "1.2.0" }
+areev-mcp = { path = "../areev-mcp", version = "1.2.1" }
+areev-context = { path = "../areev-context", version = "1.2.1" }
+areev-server = { path = "../areev-server", version = "1.2.1" }
+areev-loop = { path = "../areev-loop", version = "1.2.1" }
+areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.1" }
+areev-llm = { path = "../areev-llm", version = "1.2.1" }
+areev-run = { path = "../areev-run", version = "1.2.1" }
+areev-run-core = { path = "../areev-run-core", version = "1.2.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/areev-cli/src/main.rs
+++ b/crates/areev-cli/src/main.rs
@@ -81,6 +81,15 @@ COMMANDS:
                                       policy is a file-truth that travels
                                       with the memory; `set` declares,
                                       `sweep --yes` enforces (audited)
+  blob     put <FILE> | put --stdin   store bytes in the content-addressed
+                                      blob store; prints the cas:// URI
+                                      (idempotent — the address IS the content)
+           get <cas-uri>              write those bytes to stdout, hash-verified.
+                                      Reads the .blobs sidecar WITHOUT opening
+                                      the memory, so a --tool-cmd subprocess can
+                                      fetch an attachment while its run holds
+                                      the single writer (an encrypted memory
+                                      still needs --passphrase-env)
   blobs encrypt                       encrypt CAS attachments written before
                                       sidecar encryption landed (needs the
                                       memory's key; new blobs are sealed on
@@ -989,6 +998,25 @@ Nothing was written — apply the snippet yourself (or rerun with your own paths
             .ok_or_else(|| format!("--telemetry: unknown mode '{v}' (off|aggregate|full)"))?,
         None => areev_store::TelemetryMode::Aggregate,
     };
+
+    // `areev blob get` is served BEFORE the open, from the `.blobs` sidecar.
+    // The embedded backend's file lock is exclusive — while a run holds a
+    // memory, a second process is refused even for a read — which would put an
+    // attachment out of reach of the very `--tool-cmd` subprocess the run
+    // spawned to process it. Blobs are immutable, live beside the file, and
+    // carry their checksum as their address, so reading one needs neither the
+    // database nor a lock. A sealed blob still needs the memory's derived key,
+    // so that case falls through to the normal open below.
+    if cmd == "blob" && positional.first().map(String::as_str) == Some("get") && !is_pg_url {
+        let uri = positional
+            .get(1)
+            .ok_or("usage: areev blob get <cas-uri> --db <file>")?;
+        if let Some(bytes) = areev_store::read_blob_offline(&db, uri).map_err(|e| e.to_string())? {
+            use std::io::Write;
+            std::io::stdout().write_all(&bytes).map_err(|e| e.to_string())?;
+            return Ok(());
+        }
+    }
 
     // Files carry their own declarations (meta table); a bare open honors
     // them. --index-text is an explicit, deliberate re-stamp; encryption is a
@@ -2538,6 +2566,45 @@ Nothing was written — apply the snippet yourself (or rerun with your own paths
             }
             return run_tool_provenance(m, &ns, &hash_arg.unwrap(), &flags);
         }
+        "blob" => {
+            // `blob put` writes; `blob get` normally never reaches here (it is
+            // served pre-open above) — it lands here only for a sealed blob or
+            // a Postgres memory, both of which genuinely need the open handle.
+            match positional.first().map(String::as_str).unwrap_or("") {
+                "put" => {
+                    let bytes = match positional.get(1) {
+                        Some(path) => std::fs::read(path)
+                            .map_err(|e| format!("blob put: reading {path}: {e}"))?,
+                        None => {
+                            if !flags.contains_key("stdin") {
+                                return Err("usage: areev blob put <FILE> --db <file>  (or --stdin)".into());
+                            }
+                            use std::io::Read;
+                            let mut buf = Vec::new();
+                            std::io::stdin()
+                                .read_to_end(&mut buf)
+                                .map_err(|e| format!("blob put: reading stdin: {e}"))?;
+                            buf
+                        }
+                    };
+                    // Idempotent by construction: the address is the content.
+                    println!("{}", m.put_blob(&bytes).map_err(|e| e.to_string())?);
+                }
+                "get" => {
+                    let uri = positional
+                        .get(1)
+                        .ok_or("usage: areev blob get <cas-uri> --db <file>")?;
+                    use std::io::Write;
+                    let bytes = m.get_blob(uri).map_err(|e| e.to_string())?;
+                    std::io::stdout().write_all(&bytes).map_err(|e| e.to_string())?;
+                }
+                other => {
+                    return Err(format!(
+                        "unknown blob subcommand '{other}' — try `areev blob put|get`"
+                    ))
+                }
+            }
+        }
         "blobs" => {
             // `areev blobs encrypt` — migrate CAS attachments written before
             // sidecar encryption landed (GDPR Art. 32; docs/gdpr.md §4).
@@ -3804,7 +3871,6 @@ fn load_gating_evidence(
     rec_hash: &str,
     run_id: &str,
 ) -> Result<areev_loop::GatingEvidence, String> {
-    use areev_loop::SubstrateRead;
     let rec = engine
         .recommendations(sub, None)
         .map_err(|e| e.to_string())?
@@ -3814,34 +3880,22 @@ fn load_gating_evidence(
     let pin = rec
         .evalset_hash
         .ok_or_else(|| "this recommendation pins no evalset — --gating-run only applies to code revisions".to_string())?;
-    let facts = sub
-        .grains_of_type("fact", Some("agent:harness"), Default::default())
-        .map_err(|e| e.to_string())?;
-    for f in facts {
-        if f.str_field("relation") != Some("mg:eval_run")
-            || f.str_field("subject") != Some(format!("evalset:{pin}").as_str())
-        {
-            continue;
-        }
-        let Some(summary) = f
-            .str_field("object")
-            .and_then(|o| serde_json::from_str::<serde_json::Value>(o).ok())
-        else {
-            continue;
-        };
-        if summary.get("run_id").and_then(|v| v.as_str()) == Some(run_id) {
-            return Ok(areev_loop::GatingEvidence {
-                evalset_hash: pin,
-                run_id: run_id.to_string(),
-                passed: summary.get("passed").and_then(|v| v.as_u64()).unwrap_or(0),
-                failed: summary.get("failed").and_then(|v| v.as_u64()).unwrap_or(u64::MAX),
-            });
-        }
+    // Read through the shared evalset reader, so the run that GATES an apply
+    // and the runs that later JUDGE it are parsed by exactly one piece of code.
+    // Two parsers of this summary drifting apart would let a rule be admitted
+    // on one reading of an evalset and measured on another.
+    match areev_loop::eval::eval_run_by_id(sub, &pin, run_id).map_err(|e| e.to_string())? {
+        Some(run) => Ok(areev_loop::GatingEvidence {
+            evalset_hash: pin,
+            run_id: run.run_id,
+            passed: run.passed,
+            failed: run.failed,
+        }),
+        None => Err(format!(
+            "no recorded gate run '{run_id}' for evalset {pin} — run `areev eval run \
+             --evalset {pin} ...` first"
+        )),
     }
-    Err(format!(
-        "no recorded gate run '{run_id}' for evalset {pin} — run `areev eval run \
-         --evalset {pin} ...` first"
-    ))
 }
 
 fn resolve_hash(engine: &Engine, sub: &AreevSubstrate, prefix: &str) -> Result<String, String> {

--- a/crates/areev-cli/tests/cli_smoke.rs
+++ b/crates/areev-cli/tests/cli_smoke.rs
@@ -1429,3 +1429,39 @@ fn ns_pattern_guards_through_the_binary() {
     assert!(!ok, "a wildcard purge must fail");
     assert!(err.contains("VAL-E001") || err.contains("exact namespace"), "{err}");
 }
+
+/// Issue #27 — the CAS blob store reaches the CLI, and `blob get` in
+/// particular works WITHOUT opening the memory, which is what lets a
+/// `--tool-cmd` subprocess fetch an attachment while its run holds the writer.
+#[test]
+fn blob_put_get_roundtrip() {
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("blob.db");
+    let db = db.to_str().unwrap();
+    let file = dir.path().join("att.txt");
+    std::fs::write(&file, b"invoice attachment payload").unwrap();
+    let file = file.to_str().unwrap();
+
+    let (ok, uri, err) = areev(&["blob", "put", file, "--db", db]);
+    assert!(ok, "blob put failed: {err}");
+    let uri = uri.trim().to_string();
+    assert!(uri.starts_with("cas://sha256:"), "expected a cas uri, got {uri:?}");
+
+    // Content addressing dedupes by construction.
+    let (ok, again, _) = areev(&["blob", "put", file, "--db", db]);
+    assert!(ok);
+    assert_eq!(again.trim(), uri, "the same bytes must yield the same address");
+
+    let (ok, out, err) = areev(&["blob", "get", &uri, "--db", db]);
+    assert!(ok, "blob get failed: {err}");
+    assert_eq!(out, "invoice attachment payload");
+
+    // Junk addresses refuse with a code rather than panicking on a byte slice.
+    let (ok, _, err) = areev(&["blob", "get", "cas://sha256:abc", "--db", db]);
+    assert!(!ok, "a malformed uri must fail");
+    assert!(err.contains("VAL-E001"), "refusal must carry the code: {err}");
+
+    let (ok, _, err) = areev(&["blob", "frobnicate", "--db", db]);
+    assert!(!ok, "an unknown subcommand must fail");
+    assert!(err.contains("blob put|get"), "the refusal should name the verbs: {err}");
+}

--- a/crates/areev-conformance/src/cases/add_recall.rs
+++ b/crates/areev-conformance/src/cases/add_recall.rs
@@ -64,3 +64,49 @@ pub fn reopen_preserves_state_and_counters(b: &dyn Backend) {
     sorted.dedup();
     assert_eq!(seqs, sorted, "op_seq strictly increasing, no reuse");
 }
+
+/// A grain may carry a `subject` without asserting a relation or object (an
+/// Event about a message id, an Observation about an entity). That subject has
+/// to reach the structural index on every backend: it is both the retrieval key
+/// AND — because `forget_subject`/`subject_report` select through the same
+/// index — the difference between erasing an identity and silently keeping it.
+pub fn subject_without_relation_is_indexed(b: &dyn Backend) {
+    let mut m = b.open();
+    let mut e = areev_core::types::Event::new("call transcript").subject("pat");
+    e.common.namespace = Some("ns".into());
+    m.add(&e).unwrap();
+    m.add(&fact("ns", "pat", "lives_in", "Berlin")).unwrap();
+    m.add(&fact("ns", "mara", "prefers", "tea")).unwrap();
+
+    // Retrieval leg.
+    assert_eq!(
+        m.recall("ns", "pat", None, 8).unwrap().len(),
+        2,
+        "[{}] subject-only grain must join the structural recall",
+        b.name()
+    );
+    // What it must exclude: the grain asserts no relation, so no relation
+    // filter may match it, and an unknown subject stays empty.
+    assert_eq!(
+        m.recall("ns", "pat", Some("lives_in"), 8).unwrap().len(),
+        1,
+        "[{}] a relation filter must not pick up the subject-only grain",
+        b.name()
+    );
+    assert!(m.recall("ns", "nobody", None, 8).unwrap().is_empty(), "[{}]", b.name());
+
+    // Disclosure and erasure legs — the pair that shares one selector.
+    assert_eq!(
+        m.subject_report("ns", "pat").unwrap().grains.len(),
+        2,
+        "[{}] DSAR must disclose the subject-only grain",
+        b.name()
+    );
+    assert_eq!(
+        m.forget_subject("ns", "pat").unwrap().grains_erased,
+        2,
+        "[{}] erasure must reach the subject-only grain",
+        b.name()
+    );
+    assert_eq!(m.recent("ns", None, 8).unwrap().len(), 1, "[{}] unrelated grain survives", b.name());
+}

--- a/crates/areev-conformance/src/lib.rs
+++ b/crates/areev-conformance/src/lib.rs
@@ -196,6 +196,7 @@ macro_rules! for_each_conformance_case {
         $per_case!(subject_erasure_replicates);
         $per_case!(retention_erases_only_older);
         $per_case!(subject_report_mirrors_erasure);
+        $per_case!(subject_without_relation_is_indexed);
         // run journal (the runtime's resume-correctness substrate)
         $per_case!(run_id_indexes_on_any_grain_type);
         $per_case!(run_grains_pages_completely);

--- a/crates/areev-context/Cargo.toml
+++ b/crates/areev-context/Cargo.toml
@@ -20,8 +20,8 @@ llm-rerank = []
 rerank = []
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/crates/areev-core/src/types/registry.rs
+++ b/crates/areev-core/src/types/registry.rs
@@ -249,6 +249,11 @@ pub const GRAIN_TYPES: &[GrainTypeMeta] = &[
             "transferable",
             "practice_count",
             "last_practiced_at",
+            // The definition body. Omitting these made the field that IS the
+            // skill unreachable through PROJECT, leaving raw JSON recall as the
+            // only way to read a skill's own instructions.
+            "instructions",
+            "when_to_use",
         ],
         toon_columns: &["name", "domain", "proficiency"],
     },

--- a/crates/areev-js/Cargo.lock
+++ b/crates/areev-js/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "areev-cal"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-core",
  "areev-store",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "areev-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "hex",
  "regex",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "areev-js"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "areev-llm"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-core",
  "areev-loop",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop-adapter"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run-core"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "areev-core",
  "serde",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "areev-store"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "areev-core",

--- a/crates/areev-js/Cargo.toml
+++ b/crates/areev-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "areev-js"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["MindGryd Software Private Limited"]
@@ -21,12 +21,12 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
 # The postgres backend ships ON in the binding: it is a server-side surface,
 # and `new Areev("postgres://…?schema=<name>")` must work from a stock
 # `npm install @areev/areev`. The dependency-light default stays with the CLI/store.
-areev-store = { path = "../areev-store", version = "1.2.0", features = ["postgres"] }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
+areev-store = { path = "../areev-store", version = "1.2.1", features = ["postgres"] }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
 areev-loop = { path = "../areev-loop" }
 areev-loop-adapter = { path = "../areev-loop-adapter" }
 areev-llm = { path = "../areev-llm" }

--- a/crates/areev-js/__test__/smoke.mjs
+++ b/crates/areev-js/__test__/smoke.mjs
@@ -866,3 +866,28 @@ test('wildcard namespaces refuse on writes and malformed patterns', async () => 
   await assert.rejects(() => m.recall('acme', undefined, 16, 'org*'), /VAL-E001/)
   m.close()
 })
+
+test('CAS blobs round-trip as bytes and dedupe by address', async () => {
+  const m = makeDb()
+  const payload = Buffer.from([0x69, 0x6e, 0x76, 0x00, 0x01, 0xff])
+
+  const uri = await m.putBlob(payload)
+  assert.ok(uri.startsWith('cas://sha256:'))
+  // Content addressing dedupes by construction: same bytes, same address.
+  assert.equal(await m.putBlob(payload), uri)
+  assert.notEqual(await m.putBlob(Buffer.from('other')), uri)
+
+  const got = await m.getBlob(uri)
+  assert.ok(Buffer.isBuffer(got), 'blobs come back as a Buffer')
+  assert.deepEqual(Buffer.from(got), payload)
+  m.close()
+})
+
+test('malformed cas uris reject rather than panic', async () => {
+  const m = makeDb()
+  await assert.rejects(() => m.getBlob('not-a-cas-uri'), /VAL-E001/)
+  // Short/truncated addresses must error, never panic on a byte slice.
+  await assert.rejects(() => m.getBlob('cas://sha256:abc'), /VAL-E001/)
+  await assert.rejects(() => m.getBlob('cas://sha256:' + 'a'.repeat(64)), /STO-E001/)
+  m.close()
+})

--- a/crates/areev-js/index.d.ts
+++ b/crates/areev-js/index.d.ts
@@ -182,6 +182,22 @@ export declare class Areev {
    * most similar first. Requires an installed embedder; never writes.
    */
   nearest(text: string, subject?: string | undefined | null, relation?: string | undefined | null, k?: number | undefined | null, ns?: string | undefined | null): Promise<string>
+  /**
+   * Store bytes in the content-addressed blob store; resolves to the
+   * `cas://sha256:<hex>` URI. Idempotent — the address IS the content.
+   *
+   * Bytes in, URI out: the "JSON strings out" convention covers *structured*
+   * results, and a blob is neither structured nor safely representable as
+   * one — base64 through JSON would inflate every payload by a third and
+   * lose the streaming property the CAS exists to provide.
+   */
+  putBlob(data: Uint8Array): Promise<string>
+  /**
+   * Fetch blob bytes by `cas://sha256:` URI. The content address is
+   * re-verified on read, so corruption surfaces as an error rather than as
+   * wrong bytes.
+   */
+  getBlob(uri: string): Promise<Buffer>
   /** Store statistics as JSON. */
   stats(): Promise<string>
   /** Incremental backup to a bundle file. Returns last_op_seq cursor. */

--- a/crates/areev-js/index.js
+++ b/crates/areev-js/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('areev-android-arm64')
         const bindingPackageVersion = require('areev-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('areev-android-arm-eabi')
         const bindingPackageVersion = require('areev-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-x64-gnu')
         const bindingPackageVersion = require('areev-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-x64-msvc')
         const bindingPackageVersion = require('areev-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-ia32-msvc')
         const bindingPackageVersion = require('areev-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-arm64-msvc')
         const bindingPackageVersion = require('areev-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('areev-darwin-universal')
       const bindingPackageVersion = require('areev-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('areev-darwin-x64')
         const bindingPackageVersion = require('areev-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('areev-darwin-arm64')
         const bindingPackageVersion = require('areev-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('areev-freebsd-x64')
         const bindingPackageVersion = require('areev-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('areev-freebsd-arm64')
         const bindingPackageVersion = require('areev-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-x64-musl')
           const bindingPackageVersion = require('areev-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-x64-gnu')
           const bindingPackageVersion = require('areev-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm64-musl')
           const bindingPackageVersion = require('areev-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm64-gnu')
           const bindingPackageVersion = require('areev-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm-musleabihf')
           const bindingPackageVersion = require('areev-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm-gnueabihf')
           const bindingPackageVersion = require('areev-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-loong64-musl')
           const bindingPackageVersion = require('areev-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-loong64-gnu')
           const bindingPackageVersion = require('areev-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-riscv64-musl')
           const bindingPackageVersion = require('areev-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-riscv64-gnu')
           const bindingPackageVersion = require('areev-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('areev-linux-ppc64-gnu')
         const bindingPackageVersion = require('areev-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('areev-linux-s390x-gnu')
         const bindingPackageVersion = require('areev-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('areev-openharmony-arm64')
         const bindingPackageVersion = require('areev-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('areev-openharmony-x64')
         const bindingPackageVersion = require('areev-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('areev-openharmony-arm')
         const bindingPackageVersion = require('areev-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('areev-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '1.2.0') {
-            throw new Error(`WASI binding package version mismatch, expected 1.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.1') {
+            throw new Error(`WASI binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('areev-wasm32-wasi')

--- a/crates/areev-js/package.json
+++ b/crates/areev-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "areev",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Node.js bindings for Areev, the embedded memory engine for AI agents.",
   "license": "MIT OR Apache-2.0",
   "author": "MindGryd Software Private Limited",

--- a/crates/areev-js/src/lib.rs
+++ b/crates/areev-js/src/lib.rs
@@ -13,6 +13,7 @@ use areev_store::{
     parse_relations, Axis, CommandEmbed, Areev as RustAreev, Direction, FactDraft, TelemetryMode,
 };
 use areev_loop_adapter::{now_ms, BorrowedSubstrate};
+use napi::bindgen_prelude::{Buffer, Uint8Array};
 use napi_derive::napi;
 use serde_json::json;
 use areev_loop::{Decision, Engine, ObserverType, RecStatus, RunOptions, ScopeSet};
@@ -237,6 +238,9 @@ job_types! {
     U32Job => u32,
     /// Store call returning an op-log cursor.
     I64Job => i64,
+    /// Store call returning raw bytes (`getBlob`). Blobs are binary, so the
+    /// JSON-out convention deliberately does not apply to them.
+    BufferJob => Buffer,
 }
 
 /// One memory = one file. Open with `new Areev("caller.db", "caller")`.
@@ -1164,6 +1168,36 @@ impl Areev {
                 .map(|(h, sim)| json!({"hash": h.to_hex(), "similarity": sim}))
                 .collect();
             serde_json::to_string(&out).map_err(err)
+        })
+    }
+
+    /// Store bytes in the content-addressed blob store; resolves to the
+    /// `cas://sha256:<hex>` URI. Idempotent — the address IS the content.
+    ///
+    /// Bytes in, URI out: the "JSON strings out" convention covers *structured*
+    /// results, and a blob is neither structured nor safely representable as
+    /// one — base64 through JSON would inflate every payload by a third and
+    /// lose the streaming property the CAS exists to provide.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn put_blob(&self, data: Uint8Array) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let slot = self.facade.clone();
+        let bytes: Vec<u8> = data.to_vec();
+        StringJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            facade.with_store(|m| m.put_blob(&bytes)).map_err(err)
+        })
+    }
+
+    /// Fetch blob bytes by `cas://sha256:` URI. The content address is
+    /// re-verified on read, so corruption surfaces as an error rather than as
+    /// wrong bytes.
+    #[napi(ts_return_type = "Promise<Buffer>")]
+    pub fn get_blob(&self, uri: String) -> napi::bindgen_prelude::AsyncTask<BufferJob> {
+        let slot = self.facade.clone();
+        BufferJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            let bytes = facade.with_store(|m| m.get_blob(&uri)).map_err(err)?;
+            Ok(bytes.into())
         })
     }
 

--- a/crates/areev-llm/Cargo.toml
+++ b/crates/areev-llm/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["ai-agents", "llm", "loop", "self-improvement", "areev"]
 categories = ["api-bindings"]
 
 [dependencies]
-areev-loop = { path = "../areev-loop", version = "1.2.0" }
+areev-loop = { path = "../areev-loop", version = "1.2.1" }
 # Wave 0 (governed-agents §6.11): the ToolCallLlm seam renders Tool
 # Definition grains to each provider's native tools format via core's
 # tool_schema module — workspace-internal, no new external surface.
-areev-core = { path = "../areev-core", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # A small BLOCKING HTTP client — matches the sync-over-private-runtime / std

--- a/crates/areev-loop-adapter/Cargo.toml
+++ b/crates/areev-loop-adapter/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["ai-agents", "memory", "loop", "self-improvement", "areev"]
 categories = ["algorithms"]
 
 [dependencies]
-areev-loop = { path = "../areev-loop", version = "1.2.0" }
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-store = { path = "../areev-store", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
+areev-loop = { path = "../areev-loop", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/areev-loop/src/analyzer.rs
+++ b/crates/areev-loop/src/analyzer.rs
@@ -22,6 +22,9 @@ pub struct OutcomeInput {
     pub baseline: f64,
     pub current: f64,
     pub unit: String,
+    /// Carried from the metric snapshot so the analyzer applies the SAME
+    /// direction the engine did — see `recommendation::is_regression`.
+    pub higher_is_better: bool,
 }
 
 /// The context handed to `analyze`. Read-only by construction.

--- a/crates/areev-loop/src/analyzers/contradiction_sweep.rs
+++ b/crates/areev-loop/src/analyzers/contradiction_sweep.rs
@@ -173,6 +173,8 @@ impl Analyzer for ContradictionSweep {
                     ),
                     review_after_ms: 86_400_000,
                     horizons_ms: vec![86_400_000, 7 * 86_400_000, 30 * 86_400_000],
+                    // A count of excess live values: fewer is better.
+                    higher_is_better: false,
                 }),
             );
         }

--- a/crates/areev-loop/src/analyzers/outcome_review.rs
+++ b/crates/areev-loop/src/analyzers/outcome_review.rs
@@ -6,7 +6,10 @@
 //! accountable to measured history.
 //!
 //! Our built-in metrics are lower-is-better (e.g. `tool_error_rate`), so a
-//! regression is `current > baseline` beyond a small epsilon.
+//! regression is `current > baseline` beyond a small epsilon. An evalset
+//! metric can be higher-is-better and inverts that, which is why the direction
+//! travels on the input and the comparison lives in ONE place
+//! (`recommendation::is_regression`).
 
 use crate::analyzer::{AnalyzeCtx, Analyzer};
 use crate::error::Result;
@@ -14,9 +17,6 @@ use crate::manifest::*;
 use crate::model::{ActionKind, Severity};
 use crate::recommendation::{Proposal, RecDraft, Summary};
 use serde_json::{json, Map};
-
-/// Minimum relative worsening to call a regression (avoids noise at n=1).
-const REGRESSION_EPSILON: f64 = 1e-9;
 
 pub struct OutcomeReview {
     manifest: AnalyzerManifest,
@@ -57,7 +57,11 @@ impl Analyzer for OutcomeReview {
     fn analyze(&self, ctx: &AnalyzeCtx) -> Result<Vec<RecDraft>> {
         let mut drafts = Vec::new();
         for input in ctx.outcome_inputs() {
-            let regressed = input.current > input.baseline + REGRESSION_EPSILON;
+            let regressed = crate::recommendation::is_regression(
+                input.baseline,
+                input.current,
+                input.higher_is_better,
+            );
             if !regressed {
                 continue;
             }
@@ -104,6 +108,18 @@ mod tests {
             baseline,
             current,
             unit: "ratio".into(),
+            higher_is_better: false,
+        }
+    }
+
+    /// A higher-is-better metric (an evalset accuracy) must invert the verdict.
+    /// Reading it the built-in way would propose reverting exactly the changes
+    /// that worked.
+    fn rising(baseline: f64, current: f64) -> OutcomeInput {
+        OutcomeInput {
+            metric: "evalset:abc123:category_accuracy".into(),
+            higher_is_better: true,
+            ..input(baseline, current)
         }
     }
 
@@ -121,5 +137,27 @@ mod tests {
         let mut sub = TestSubstrate::new();
         sub.set_outcome_inputs(vec![input(0.5, 0.2), input(0.3, 0.3)]);
         assert!(sub.analyze(&OutcomeReview::new(), 10_000).is_empty());
+    }
+
+    #[test]
+    fn a_higher_is_better_metric_regresses_when_it_falls() {
+        let mut sub = TestSubstrate::new();
+        // Accuracy dropped 0.92 -> 0.71: that IS the regression.
+        sub.set_outcome_inputs(vec![rising(0.92, 0.71)]);
+        let drafts = sub.analyze(&OutcomeReview::new(), 10_000);
+        assert_eq!(drafts.len(), 1, "a fall in accuracy must propose a revert");
+        assert_eq!(drafts[0].action_kind, ActionKind::Revert);
+    }
+
+    #[test]
+    fn a_higher_is_better_metric_holds_when_it_rises() {
+        let mut sub = TestSubstrate::new();
+        // The failure this pins: reading accuracy with the lower-is-better
+        // rule would revert the recommendation that improved it.
+        sub.set_outcome_inputs(vec![rising(0.71, 0.92), rising(0.8, 0.8)]);
+        assert!(
+            sub.analyze(&OutcomeReview::new(), 10_000).is_empty(),
+            "rising accuracy is the receipt, not a regression"
+        );
     }
 }

--- a/crates/areev-loop/src/analyzers/tool_failure.rs
+++ b/crates/areev-loop/src/analyzers/tool_failure.rs
@@ -212,6 +212,8 @@ impl Analyzer for ToolFailureClustering {
                     // Re-measure at 1 day, 1 week, 1 month — a late recurrence
                     // (held at 1d, regressed at 30d) is caught by the schedule.
                     horizons_ms: vec![86_400_000, 7 * 86_400_000, 30 * 86_400_000],
+                    // A count of recurrences: fewer is better.
+                    higher_is_better: false,
                 }),
             );
         }

--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -1574,7 +1574,11 @@ fn measure_outcomes<S: OmsSubstrate>(
         let Some(current) = measure_metric(sub, metric, applied.applied_at_ms)? else {
             continue; // metric kind not yet re-measurable
         };
-        let regressed = current > metric.baseline + f64::EPSILON;
+        let regressed = crate::recommendation::is_regression(
+            metric.baseline,
+            current,
+            metric.higher_is_better,
+        );
         p.outcomes.entry(rec_hash.clone()).or_default().push(
             crate::recommendation::OutcomeResult {
                 rec_hash: rec_hash.clone(),
@@ -1595,6 +1599,7 @@ fn measure_outcomes<S: OmsSubstrate>(
                 baseline: metric.baseline,
                 current,
                 unit: metric.unit.clone(),
+                higher_is_better: metric.higher_is_better,
             });
         }
     }
@@ -1602,7 +1607,7 @@ fn measure_outcomes<S: OmsSubstrate>(
 }
 
 /// Typed re-measurement for the fixed set of metric kinds the engine knows.
-fn measure_metric<S: SubstrateRead>(
+pub(crate) fn measure_metric<S: SubstrateRead>(
     sub: &S,
     metric: &crate::recommendation::MetricSnapshot,
     since_ms: i64,
@@ -1651,6 +1656,39 @@ fn measure_metric<S: SubstrateRead>(
                 .filter_map(|f| f.fact_object().map(normalize_ident))
                 .collect();
             Ok(Some(distinct.len().saturating_sub(1) as f64))
+        }
+        // `evalset:<hash>:<field>` — external correctness, measured the only
+        // way that keeps the honesty rule ("Areev Loop improves the agent's
+        // memory, not its outputs") intact: an evalset run is an INTERNAL,
+        // BOUNDED, ATTRIBUTABLE measurement. The engine never runs the evalset;
+        // it only reads summaries a host journaled with `areev eval run`.
+        //
+        // `since_ms` is the apply time, and it is load-bearing rather than an
+        // optimization: a run journaled BEFORE the apply cannot be evidence of
+        // what applying did. Comparing the baseline run against itself would
+        // report "held" forever — a fabricated receipt, which is worse than no
+        // receipt at all. No run since the apply → `None` → not yet
+        // measurable, and the checkpoint stays due.
+        m if m.starts_with("evalset:") => {
+            let Some((evalset, field)) = crate::eval::parse_evalset_metric(m) else {
+                return Ok(None);
+            };
+            let Some(run) = crate::eval::newest_eval_run(sub, evalset, Some(since_ms))? else {
+                return Ok(None);
+            };
+            // `failed`/`passed`/`total` are promoted so a metric can be written
+            // against any evalset without the host having to add fields;
+            // anything else is read from the summary the host did write.
+            Ok(match field {
+                "failed" => Some(run.failed as f64),
+                "passed" => Some(run.passed as f64),
+                "total" => Some(run.total() as f64),
+                "error_rate" => match run.total() {
+                    0 => None, // no cases ran: undefined, not zero
+                    t => Some(run.failed as f64 / t as f64),
+                },
+                other => run.field(other),
+            })
         }
         _ => Ok(None),
     }

--- a/crates/areev-loop/src/eval.rs
+++ b/crates/areev-loop/src/eval.rs
@@ -1,0 +1,157 @@
+//! Evalset runs — the one reader for the `evalset:<hash> mg:eval_run`
+//! summaries that `areev eval run` journals into `agent:harness`.
+//!
+//! Two edges consume these, and they deliberately share this code:
+//!
+//! - the **gating** edge (`areev loop apply --gating-run <id>`), which names one
+//!   run and reads its numbers rather than trusting the command line, and
+//! - the **outcome** edge (`measure_metric`'s `evalset:` kind), which re-reads
+//!   the newest run at each checkpoint.
+//!
+//! Sharing matters because the alternative is two parsers of the same JSON
+//! drifting apart, so a rule could be *admitted* on one reading of an evalset
+//! and *judged* on another.
+
+use crate::error::Result;
+use crate::substrate::{ReadOpts, SubstrateRead};
+use serde_json::Value;
+
+/// The relation an eval-run summary is recorded under.
+pub const EVAL_RUN_RELATION: &str = "mg:eval_run";
+
+/// The namespace those summaries live in.
+pub const HARNESS_NS: &str = "agent:harness";
+
+/// One recorded execution of an evalset.
+#[derive(Debug, Clone)]
+pub struct EvalRun {
+    /// The `eval-` run id the cases were journaled under.
+    pub run_id: String,
+    pub passed: u64,
+    pub failed: u64,
+    /// The whole summary object, so host-defined fields (`category_accuracy`,
+    /// …) are reachable without this module having to know them.
+    pub summary: serde_json::Map<String, Value>,
+    /// When the summary grain was written.
+    pub recorded_ms: i64,
+}
+
+impl EvalRun {
+    /// A numeric field of the summary. `passed`/`failed` are promoted to typed
+    /// fields but stay readable here too, so a metric string may name any of
+    /// them uniformly.
+    pub fn field(&self, name: &str) -> Option<f64> {
+        self.summary.get(name).and_then(Value::as_f64)
+    }
+
+    /// Cases that ran. `0` when the summary records neither.
+    pub fn total(&self) -> u64 {
+        self.passed.saturating_add(self.failed)
+    }
+}
+
+/// Every recorded run of `evalset_hash`, oldest first.
+///
+/// `since_ms` bounds the scan to summaries written at or after a moment —
+/// which is what keeps an outcome honest: a run journaled *before* a
+/// recommendation was applied cannot be evidence of what applying it did.
+pub fn eval_runs<S: SubstrateRead + ?Sized>(
+    sub: &S,
+    evalset_hash: &str,
+    since_ms: Option<i64>,
+) -> Result<Vec<EvalRun>> {
+    let subject = format!("evalset:{evalset_hash}");
+    let facts = sub.grains_of_type(
+        crate::model::grain_type::FACT,
+        Some(HARNESS_NS),
+        ReadOpts { live_only: true, since_ms },
+    )?;
+    let mut out: Vec<EvalRun> = facts
+        .iter()
+        .filter(|f| f.str_field("relation") == Some(EVAL_RUN_RELATION))
+        .filter(|f| f.str_field("subject") == Some(subject.as_str()))
+        .filter_map(|f| {
+            let obj = f.str_field("object")?;
+            let Ok(Value::Object(summary)) = serde_json::from_str::<Value>(obj) else {
+                // A summary we cannot parse is skipped, never guessed at: a
+                // fabricated number here would become a receipt.
+                return None;
+            };
+            // `areev eval run` always writes all three, so a summary missing
+            // one is malformed. Dropping it rather than defaulting keeps every
+            // consumer fail-CLOSED: at the apply gate an absent `failed` must
+            // never read as "zero failures", and an outcome must never score
+            // against numbers nobody recorded.
+            Some(EvalRun {
+                run_id: summary.get("run_id").and_then(Value::as_str)?.to_string(),
+                passed: summary.get("passed").and_then(Value::as_u64)?,
+                failed: summary.get("failed").and_then(Value::as_u64)?,
+                recorded_ms: f.created_at_ms,
+                summary,
+            })
+        })
+        .collect();
+    // Recording order, with the hash as a deterministic tiebreak for two
+    // summaries written in the same millisecond.
+    out.sort_by(|a, b| {
+        a.recorded_ms
+            .cmp(&b.recorded_ms)
+            .then_with(|| a.run_id.cmp(&b.run_id))
+    });
+    Ok(out)
+}
+
+/// The newest recorded run of `evalset_hash` at or after `since_ms`.
+pub fn newest_eval_run<S: SubstrateRead + ?Sized>(
+    sub: &S,
+    evalset_hash: &str,
+    since_ms: Option<i64>,
+) -> Result<Option<EvalRun>> {
+    Ok(eval_runs(sub, evalset_hash, since_ms)?.pop())
+}
+
+/// One recorded run by id, over all of history.
+pub fn eval_run_by_id<S: SubstrateRead + ?Sized>(
+    sub: &S,
+    evalset_hash: &str,
+    run_id: &str,
+) -> Result<Option<EvalRun>> {
+    Ok(eval_runs(sub, evalset_hash, None)?
+        .into_iter()
+        .find(|r| r.run_id == run_id))
+}
+
+/// Parse an `evalset:<hash>:<field>` metric string into its parts.
+///
+/// The hash is hex, so splitting on the LAST colon is unambiguous and lets a
+/// field name contain no colon by construction.
+pub fn parse_evalset_metric(metric: &str) -> Option<(&str, &str)> {
+    let rest = metric.strip_prefix("evalset:")?;
+    let (hash, field) = rest.rsplit_once(':')?;
+    if hash.is_empty() || field.is_empty() || hash.contains(':') {
+        return None;
+    }
+    Some((hash, field))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_strings_parse_into_hash_and_field() {
+        assert_eq!(
+            parse_evalset_metric("evalset:abc123:category_accuracy"),
+            Some(("abc123", "category_accuracy"))
+        );
+        assert_eq!(parse_evalset_metric("evalset:abc123:failed"), Some(("abc123", "failed")));
+        // Not an evalset metric at all.
+        assert_eq!(parse_evalset_metric("tool_error_recurrence"), None);
+        // Malformed shapes must fail rather than half-parse into a lookup that
+        // silently finds nothing.
+        assert_eq!(parse_evalset_metric("evalset:abc123"), None);
+        assert_eq!(parse_evalset_metric("evalset::field"), None);
+        assert_eq!(parse_evalset_metric("evalset:abc123:"), None);
+        assert_eq!(parse_evalset_metric("evalset:a:b:c"), None);
+    }
+}

--- a/crates/areev-loop/src/integration.rs
+++ b/crates/areev-loop/src/integration.rs
@@ -1822,3 +1822,153 @@ fn governed_code_change_applies_only_through_the_gate() {
         other => panic!("stale-pin apply must refuse (re-gate), got {other:?}"),
     }
 }
+
+// ── Issue #29: evalset-backed outcome metric ──────────────────────────────
+// `areev loop outcomes` could only close the receipt on internal recurrence
+// counts. An evalset run is ALSO internal, bounded and attributable, so it can
+// carry external correctness without breaking the honesty rule — provided the
+// measurement never scores against a run that predates the apply.
+mod evalset_outcome {
+    use super::*;
+    use crate::recommendation::MetricSnapshot;
+
+    const EVALSET: &str = "abc123";
+
+    fn snapshot(field: &str, baseline: f64, higher_is_better: bool) -> MetricSnapshot {
+        MetricSnapshot {
+            metric: format!("evalset:{EVALSET}:{field}"),
+            baseline,
+            unit: "ratio".into(),
+            n: 184,
+            window: "evalset".into(),
+            subject: None,
+            namespace: None,
+            relation: None,
+            query: String::new(),
+            review_after_ms: 86_400_000,
+            horizons_ms: vec![],
+            higher_is_better,
+        }
+    }
+
+    /// Journal a summary the way `areev eval run` does.
+    fn journal_run(sub: &mut TestSubstrate, run_id: &str, at_ms: i64, extra: serde_json::Value) {
+        let mut summary = serde_json::json!({"run_id": run_id, "passed": 1, "failed": 0});
+        if let (Some(o), Some(e)) = (summary.as_object_mut(), extra.as_object()) {
+            for (k, v) in e {
+                o.insert(k.clone(), v.clone());
+            }
+        }
+        sub.add_fact_at(
+            "agent:harness",
+            &format!("evalset:{EVALSET}"),
+            "mg:eval_run",
+            &summary.to_string(),
+            at_ms,
+        );
+    }
+
+    fn measure(sub: &TestSubstrate, m: &MetricSnapshot, since: i64) -> Option<f64> {
+        crate::engine::measure_metric(&sub.inner, m, since).unwrap()
+    }
+
+    #[test]
+    fn resolves_a_host_field_from_the_newest_run() {
+        let mut sub = TestSubstrate::new();
+        journal_run(&mut sub, "eval-1", 1_000, serde_json::json!({"category_accuracy": 0.71}));
+        journal_run(&mut sub, "eval-2", 2_000, serde_json::json!({"category_accuracy": 0.92}));
+        let m = snapshot("category_accuracy", 0.71, true);
+        assert_eq!(measure(&sub, &m, 500), Some(0.92), "the newest run is the current value");
+    }
+
+    #[test]
+    fn a_run_that_predates_the_apply_is_not_evidence() {
+        // The failure this prevents is a FABRICATED receipt: scoring the
+        // baseline run against itself reports "held" forever, which reads as
+        // proof the change worked.
+        let mut sub = TestSubstrate::new();
+        journal_run(&mut sub, "eval-1", 1_000, serde_json::json!({"category_accuracy": 0.71}));
+        let m = snapshot("category_accuracy", 0.71, true);
+        assert_eq!(
+            measure(&sub, &m, 5_000),
+            None,
+            "no run since the apply means NOT YET MEASURABLE, not 'held'"
+        );
+        // Once a fresh run lands, it measures.
+        journal_run(&mut sub, "eval-2", 6_000, serde_json::json!({"category_accuracy": 0.92}));
+        assert_eq!(measure(&sub, &m, 5_000), Some(0.92));
+    }
+
+    #[test]
+    fn promoted_fields_work_without_the_host_adding_any() {
+        let mut sub = TestSubstrate::new();
+        sub.add_fact_at(
+            "agent:harness",
+            &format!("evalset:{EVALSET}"),
+            "mg:eval_run",
+            &serde_json::json!({"run_id": "eval-1", "passed": 150, "failed": 34}).to_string(),
+            1_000,
+        );
+        assert_eq!(measure(&sub, &snapshot("failed", 0.0, false), 0), Some(34.0));
+        assert_eq!(measure(&sub, &snapshot("passed", 0.0, true), 0), Some(150.0));
+        assert_eq!(measure(&sub, &snapshot("total", 0.0, false), 0), Some(184.0));
+        let rate = measure(&sub, &snapshot("error_rate", 0.0, false), 0).unwrap();
+        assert!((rate - 34.0 / 184.0).abs() < 1e-9, "error_rate = failed/total, got {rate}");
+    }
+
+    #[test]
+    fn degenerate_and_malformed_inputs_measure_nothing_rather_than_guessing() {
+        let mut sub = TestSubstrate::new();
+        // An empty evalset must not divide by zero into NaN.
+        sub.add_fact_at(
+            "agent:harness",
+            &format!("evalset:{EVALSET}"),
+            "mg:eval_run",
+            &serde_json::json!({"run_id": "eval-0", "passed": 0, "failed": 0}).to_string(),
+            1_000,
+        );
+        assert_eq!(measure(&sub, &snapshot("error_rate", 0.0, false), 0), None);
+        // A field the summary never recorded is unmeasurable, not zero.
+        assert_eq!(measure(&sub, &snapshot("category_accuracy", 0.0, true), 0), None);
+        // A malformed metric string resolves to nothing.
+        let mut bad = snapshot("x", 0.0, false);
+        bad.metric = "evalset:onlyhash".into();
+        assert_eq!(measure(&sub, &bad, 0), None);
+        // A different evalset's runs never leak in.
+        let mut other = snapshot("failed", 0.0, false);
+        other.metric = "evalset:deadbeef:failed".into();
+        assert_eq!(measure(&sub, &other, 0), None);
+    }
+
+    #[test]
+    fn a_summary_missing_its_counts_is_dropped_not_defaulted() {
+        // Fail-closed: at the apply gate an absent `failed` must never read as
+        // "zero failures".
+        let mut sub = TestSubstrate::new();
+        sub.add_fact_at(
+            "agent:harness",
+            &format!("evalset:{EVALSET}"),
+            "mg:eval_run",
+            &serde_json::json!({"run_id": "eval-x", "category_accuracy": 0.99}).to_string(),
+            1_000,
+        );
+        assert_eq!(measure(&sub, &snapshot("category_accuracy", 0.5, true), 0), None);
+        assert!(crate::eval::eval_runs(&sub.inner, EVALSET, None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn the_gating_and_outcome_edges_read_the_same_runs() {
+        let mut sub = TestSubstrate::new();
+        journal_run(&mut sub, "eval-1", 1_000, serde_json::json!({}));
+        journal_run(&mut sub, "eval-2", 2_000, serde_json::json!({}));
+        let by_id = crate::eval::eval_run_by_id(&sub.inner, EVALSET, "eval-1")
+            .unwrap()
+            .expect("gating edge finds the named run");
+        assert_eq!(by_id.run_id, "eval-1");
+        let newest = crate::eval::newest_eval_run(&sub.inner, EVALSET, None)
+            .unwrap()
+            .expect("outcome edge finds the newest run");
+        assert_eq!(newest.run_id, "eval-2");
+        assert!(crate::eval::eval_run_by_id(&sub.inner, EVALSET, "eval-nope").unwrap().is_none());
+    }
+}

--- a/crates/areev-loop/src/lib.rs
+++ b/crates/areev-loop/src/lib.rs
@@ -28,6 +28,7 @@ pub mod cal;
 pub mod config;
 pub mod engine;
 pub mod error;
+pub mod eval;
 pub mod external;
 pub mod llm;
 pub mod manifest;

--- a/crates/areev-loop/src/recommendation.rs
+++ b/crates/areev-loop/src/recommendation.rs
@@ -160,6 +160,30 @@ pub struct MetricSnapshot {
     /// verdict is never final until the last horizon. Empty → `[review_after_ms]`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub horizons_ms: Vec<i64>,
+    /// Which direction is an improvement. The built-in metrics are all
+    /// recurrence counts, where lower is better — so this defaults to `false`
+    /// and every existing snapshot deserializes unchanged. An evalset accuracy
+    /// is the opposite, and getting it wrong does not merely misreport: the
+    /// Verify gate would read a rule that IMPROVED accuracy as a regression and
+    /// propose reverting it.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub higher_is_better: bool,
+}
+
+/// The one regression rule.
+///
+/// The verdict is computed in two places — once by the engine for the recorded
+/// `OutcomeResult`, once by `outcome_review` when it drafts the revert — and
+/// the two silently disagreeing would either revert a change that held or sit
+/// on one that regressed. So both call this.
+pub fn is_regression(baseline: f64, current: f64, higher_is_better: bool) -> bool {
+    /// Minimum worsening to call a regression (avoids noise at n=1).
+    const EPSILON: f64 = 1e-9;
+    if higher_is_better {
+        current < baseline - EPSILON
+    } else {
+        current > baseline + EPSILON
+    }
 }
 
 impl MetricSnapshot {

--- a/crates/areev-mcp/Cargo.toml
+++ b/crates/areev-mcp/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["mcp", "memory", "ai-agents", "llm", "protocol"]
 categories = ["api-bindings"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-store = { path = "../areev-store", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
-areev-loop = { path = "../areev-loop", version = "1.2.0" }
-areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.0" }
-areev-run = { path = "../areev-run", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-loop = { path = "../areev-loop", version = "1.2.1" }
+areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.1" }
+areev-run = { path = "../areev-run", version = "1.2.1" }
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/areev-py/Cargo.toml
+++ b/crates/areev-py/Cargo.toml
@@ -26,9 +26,9 @@ name = "areev"
 crate-type = ["cdylib"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-store = { path = "../areev-store", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
 areev-loop = { path = "../areev-loop" }
 areev-loop-adapter = { path = "../areev-loop-adapter" }
 areev-llm = { path = "../areev-llm" }

--- a/crates/areev-py/pyproject.toml
+++ b/crates/areev-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "areev"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python bindings for Areev, the embedded memory engine for AI agents."
 requires-python = ">=3.9"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/areev-py/src/lib.rs
+++ b/crates/areev-py/src/lib.rs
@@ -14,6 +14,7 @@ use areev_store::{
 use areev_loop_adapter::{now_ms, BorrowedSubstrate};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyBytes;
 use serde_json::json;
 use areev_loop::{Decision, Engine, ObserverType, RecStatus, RunOptions, ScopeSet};
 
@@ -1043,6 +1044,31 @@ impl Areev {
             })
             .collect();
         serde_json::to_string(&out).map_err(err)
+    }
+
+    /// Store bytes in the content-addressed blob store; returns the
+    /// `cas://sha256:<hex>` URI. Idempotent — the address IS the content, so
+    /// storing the same bytes twice stores them once.
+    ///
+    /// Bytes in, URI out: the "JSON strings out" convention covers *structured*
+    /// results, and a blob is neither structured nor safely representable as
+    /// one — base64 through JSON would inflate every payload by a third and
+    /// lose the streaming property the CAS exists to provide.
+    #[pyo3(signature = (data))]
+    fn put_blob(&self, py: Python<'_>, data: Vec<u8>) -> PyResult<String> {
+        py.detach(|| self.facade.with_store(|m| m.put_blob(&data)))
+            .map_err(err)
+    }
+
+    /// Fetch blob bytes by `cas://sha256:` URI. The content address is
+    /// re-verified on read, so corruption surfaces as an error rather than as
+    /// wrong bytes.
+    #[pyo3(signature = (uri))]
+    fn get_blob<'py>(&self, py: Python<'py>, uri: String) -> PyResult<Bound<'py, PyBytes>> {
+        let bytes = py
+            .detach(|| self.facade.with_store(|m| m.get_blob(&uri)))
+            .map_err(err)?;
+        Ok(PyBytes::new(py, &bytes))
     }
 
     /// Store statistics as JSON.

--- a/crates/areev-py/tests/test_areev.py
+++ b/crates/areev-py/tests/test_areev.py
@@ -1125,3 +1125,33 @@ def test_wildcard_namespace_refusals(tmp_path):
     # A malformed pattern errors instead of silently matching nothing.
     with pytest.raises(ValueError, match="VAL-E001"):
         m.recall("acme", ns="org*")
+
+
+# --------------------------------------------------------------------------
+# CAS blobs (issue #27) — bytes in, bytes out
+# --------------------------------------------------------------------------
+
+def test_blob_roundtrip_and_idempotence(tmp_path):
+    m = make_db(tmp_path)
+    payload = b"invoice attachment \x00\x01\xff bytes"
+
+    uri = m.put_blob(payload)
+    assert uri.startswith("cas://sha256:")
+    # Content addressing dedupes by construction: same bytes, same address.
+    assert m.put_blob(payload) == uri
+    assert m.put_blob(b"other") != uri
+
+    got = m.get_blob(uri)
+    assert isinstance(got, bytes), "blobs come back as bytes, not a list of ints"
+    assert got == payload
+
+
+def test_blob_bad_uris_raise(tmp_path):
+    m = make_db(tmp_path)
+    with pytest.raises(ValueError, match="VAL-E001"):
+        m.get_blob("not-a-cas-uri")
+    # Short/truncated addresses must error, never panic on a byte slice.
+    with pytest.raises(ValueError, match="VAL-E001"):
+        m.get_blob("cas://sha256:abc")
+    with pytest.raises(ValueError, match="STO-E001"):
+        m.get_blob("cas://sha256:" + "a" * 64)

--- a/crates/areev-run-core/Cargo.toml
+++ b/crates/areev-run-core/Cargo.toml
@@ -26,7 +26,7 @@ keywords = ["ai-agents", "workflow", "deterministic", "runtime", "areev"]
 categories = ["algorithms"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/areev-run/Cargo.toml
+++ b/crates/areev-run/Cargo.toml
@@ -17,12 +17,12 @@ keywords = ["ai-agents", "workflow", "runtime", "deterministic", "areev"]
 categories = ["development-tools"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-store = { path = "../areev-store", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
-areev-run-core = { path = "../areev-run-core", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-run-core = { path = "../areev-run-core", version = "1.2.1" }
 # The ToolCallLlm seam for abstract nodes (§6.2/§6.11).
-areev-llm = { path = "../areev-llm", version = "1.2.0" }
+areev-llm = { path = "../areev-llm", version = "1.2.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/areev-server/Cargo.toml
+++ b/crates/areev-server/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["memory", "server", "sync", "ai-agents", "http"]
 categories = ["web-programming::http-server"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
-areev-store = { path = "../areev-store", version = "1.2.0" }
-areev-cal = { path = "../areev-cal", version = "1.2.0" }
-areev-loop = { path = "../areev-loop", version = "1.2.0" }
-areev-run = { path = "../areev-run", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-loop = { path = "../areev-loop", version = "1.2.1" }
+areev-run = { path = "../areev-run", version = "1.2.1" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1.15", features = ["std"], optional = true }
-areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.0" }
+areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.1" }
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/areev-store/CLAUDE.md
+++ b/crates/areev-store/CLAUDE.md
@@ -60,6 +60,20 @@ Pg-only multi-writer race cases); extend it whenever store semantics change.
   object-anchored mirror of an anchored `recall_hybrid` ("what points at X"),
   and is what makes `WITH multi_hop` follow reverse edges — so it inherits the
   same entity-relations restriction.
+- **Subject anchors**: a grain carrying a `subject` but NOT a full `(s,p,o)`
+  triple (an Event about a message id, an Observation about an entity) still
+  gets one `triples` row — `(ns, s, NULL, NULL, seq, cur)`. Relation and object
+  are NULL because the grain asserts neither, which also makes the row inert to
+  every relation-bound query by construction; like links it never reaches
+  `heads`/`entity_latest` (a log entry about a subject has no "current value").
+  Requiring all three used to drop these grains from the index entirely, which
+  cost two things, the second far worse than the first: `recall(ns, subject, …)`
+  answered empty for a grain that plainly carried the subject, and — because
+  `forget_subject`/`subject_report` select through `triples` — the identity's
+  own grain was invisible to **erasure and DSAR disclosure**. Existing files are
+  healed by the `link_index` stamp bump (v3) on open; the rebuild replays the
+  rows and reconstructs `cur` from supersession state, so a reindex neither
+  duplicates a grain nor resurrects a superseded one.
 - **Cross-grain links**: `GrainCommon.related_to` entries index as triples
   subject-ed on the linking grain's *own* hash — `(own_hash, relation_type,
   target_hash)` — so `related()`/`path()` traverse them like any edge. They are
@@ -119,7 +133,16 @@ Pg-only multi-writer race cases); extend it whenever store semantics change.
   `tests/meta_tests.rs` covers persistence/reconciliation.
 - CAS blob sidecar at `"{path}.blobs"`, git-style `hex[..2]/hex[2..]` fan-out:
   `put_blob` (idempotent, tmp+rename), `get_blob` (re-verifies sha256),
-  `gc_blobs` (ref-count from live grains' `content_refs`).
+  `gc_blobs` (ref-count from live grains' `content_refs`). Free fn
+  **`read_blob_offline(db_path, uri)`** reads one blob WITHOUT opening the
+  database — the file lock is exclusive, so while a run holds a memory a second
+  process is refused even for a read, which would strand an attachment out of
+  reach of the `--tool-cmd` subprocess meant to process it. Safe without a lock
+  because a blob is immutable, lives beside the file, and its address is its
+  checksum (re-verified here too). `Ok(None)` = sealed, so the caller must open
+  with the key. Surfaces: `areev blob put|get` (get is served pre-open),
+  `put_blob`/`get_blob` in both bindings — **bytes in, bytes out**, the one
+  documented exception to the JSON-strings-out FFI convention.
 
 ## Core invariants
 

--- a/crates/areev-store/Cargo.toml
+++ b/crates/areev-store/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["database-implementations", "caching"]
 postgres = ["dep:tokio-postgres", "tokio/net", "tokio/time"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.0" }
+areev-core = { path = "../areev-core", version = "1.2.1" }
 # Pinned exactly: encryption-at-rest rides turso's experimental AES-256-GCM,
 # so the audited version is fixed until a deliberate, tested bump.
 turso = "=0.7.2"

--- a/crates/areev-store/src/lib.rs
+++ b/crates/areev-store/src/lib.rs
@@ -945,7 +945,13 @@ const LINK_INDEX_KEY: &str = "link_index";
 
 /// Bumped when a change to what the link indexes contain requires a rebuild of
 /// files stamped with an earlier value.
-const LINK_INDEX_VERSION: &str = "2";
+///
+/// `3` adds the subject-anchored rows for grains that carry a `subject` without
+/// a full triple. Files written before it are not merely missing a retrieval
+/// path — `forget_subject`/`subject_report` select through `triples`, so those
+/// grains were invisible to erasure and to DSAR disclosure. The rebuild is what
+/// closes that on an existing file, so it must run rather than be opt-in.
+const LINK_INDEX_VERSION: &str = "3";
 
 /// `meta` stamp for the namespace registry (`ns_reg`) — same
 /// stamp-not-emptiness reasoning as [`LINK_INDEX_KEY`]: a file can
@@ -1314,6 +1320,16 @@ struct GrainPrep {
     /// link is an annotation and MUST NOT change the target's supersession
     /// state. Empty for the overwhelming majority of grains.
     links: Vec<(i64, i64, i64)>,
+    /// Dictionary id of the grain's `subject` when it carries one but NOT a
+    /// complete `(s, p, o)` triple — an Event/Observation/… that is *about*
+    /// something without asserting a relation. Indexed as a subject-anchored
+    /// row `(ns, s, NULL, NULL, seq, cur)` so the structural leg and the
+    /// erasure selector can both find it; NULL relation/object because the
+    /// grain genuinely asserts neither, which also makes the row inert to
+    /// every relation-bound query by construction. Never written to
+    /// `heads`/`entity_latest`: a log entry about a subject has no "current
+    /// value" to be the head of (same reasoning as `links`).
+    subject_only: Option<i64>,
     /// Dictionary id of `run_id`, for the run index.
     run: Option<i64>,
     /// Raw 32-byte `derived_from` parent address, for reverse provenance.
@@ -1445,6 +1461,36 @@ fn projected_text(view: &DeserializedGrain) -> Option<String> {
     } else {
         Some(parts.join(" "))
     }
+}
+
+/// Read one CAS blob straight from a memory's `.blobs` sidecar, **without
+/// opening the database**.
+///
+/// This exists because the embedded backend's file lock is *exclusive*: while
+/// a run holds a memory, a second process is refused even for a read. That
+/// would leave an attachment unreachable to the very `--tool-cmd` subprocess
+/// the run spawned to process it.
+///
+/// Blobs need no database to be read, and no lock to be safe: they are
+/// immutable, they live beside the file rather than in it, and the address IS
+/// the checksum — which this re-verifies, exactly like [`Areev::get_blob`]. So
+/// there is no consistency question to answer here, only a lock to not take.
+///
+/// `Ok(None)` means the blob is sealed: decrypting needs the memory's derived
+/// sidecar key, so that caller has to open the memory with its passphrase.
+pub fn read_blob_offline(db_path: &str, uri: &str) -> Result<Option<Vec<u8>>> {
+    use sha2::{Digest, Sha256};
+    let hex = Areev::cas_hex(uri)?;
+    let dir = std::path::PathBuf::from(format!("{db_path}.blobs"));
+    let raw = std::fs::read(fs_blob_path(&dir, hex))
+        .map_err(|_| AreevError::Storage(format!("blob missing: {uri}")))?;
+    if blobcrypt::is_sealed(&raw) {
+        return Ok(None);
+    }
+    if hex::encode(Sha256::digest(&raw)) != hex {
+        return Err(AreevError::Storage(format!("blob corrupt: {uri}")));
+    }
+    Ok(Some(raw))
 }
 
 /// Where the CAS blob payloads live: a `.blobs` fan-out directory next to
@@ -3196,6 +3242,15 @@ impl Areev {
             // older entity-relations declaration predates this reserved edge.
             osp = rl == "mg:harness" || self.entity_rels.contains(rl.as_str());
         }
+        // A subject WITHOUT a full triple still has to reach the structural
+        // index. It used to be dropped entirely, so `recall(ns, subject, …)`
+        // returned empty for an Event that plainly carried the subject — and,
+        // far worse, `forget_subject`/`subject_report` (which select through
+        // `triples`) silently under-erased and under-disclosed it.
+        let subject_only = match (&gv.subject, s) {
+            (Some(sj), None) => Some(self.term_id(sj)?),
+            _ => None,
+        };
         let session = match &gv.session {
             Some(x) => Some(self.term_id(x)?),
             None => None,
@@ -3259,6 +3314,7 @@ impl Areev {
             tokens,
             doc_len,
             links,
+            subject_only,
             run,
             parent,
             corpus_export: gv.corpus_export,
@@ -3416,6 +3472,12 @@ impl Areev {
                     self.term_id(target)?;
                 }
             }
+            // A subject-only grain written before subject anchoring existed has
+            // its subject nowhere in the dictionary — intern it here or the
+            // lookup-only planning pass below can never find it.
+            if let (Some(sj), true) = (&gv.subject, gv.relation.is_none() || gv.object.is_none()) {
+                self.term_id(sj)?;
+            }
         }
 
         struct Row {
@@ -3425,6 +3487,11 @@ impl Areev {
             parent: Option<Vec<u8>>,
             corpus_export: bool,
             links: Vec<(i64, i64, i64)>,
+            /// Dictionary id of a subject carried without a full triple, and
+            /// whether the grain is superseded (so the rebuilt row lands with
+            /// the same `cur` the incremental path would have left it at).
+            subject_only: Option<i64>,
+            superseded: bool,
         }
         // One transaction for delete + corpus read + plan + writes,
         // serialized against concurrent writers by the zero-id reservation —
@@ -3436,19 +3503,19 @@ impl Areev {
             self.db.execute("DELETE FROM prov_idx", vec![])?;
             self.db.execute("DELETE FROM run_idx", vec![])?;
             self.db.execute("DELETE FROM corpus_idx", vec![])?;
-            let mut rows: Vec<(i64, i64, Vec<u8>)> = Vec::new();
+            let mut rows: Vec<(i64, i64, Vec<u8>, bool)> = Vec::new();
             for row in self
                 .db
-                .query("SELECT seq, ns, blob FROM grains ORDER BY seq", vec![])?
+                .query("SELECT seq, ns, blob, svt FROM grains ORDER BY seq", vec![])?
             {
                 let (Some(seq), Some(ns), Some(blob)) = (row.i64(0), row.i64(1), row.blob(2))
                 else {
                     continue;
                 };
-                rows.push((seq, ns, blob));
+                rows.push((seq, ns, blob, row.i64(3).is_some()));
             }
             let mut plan: Vec<Row> = Vec::with_capacity(rows.len());
-            for (seq, ns, blob) in &rows {
+            for (seq, ns, blob, superseded) in &rows {
                 let view = deserialize_blob(blob)?;
                 let gv = extract_view(&view);
                 // Lookup only: the warm pass interned this snapshot's terms,
@@ -3476,6 +3543,12 @@ impl Areev {
                         }
                     }
                 }
+                let subject_only = match &gv.subject {
+                    Some(sj) if gv.relation.is_none() || gv.object.is_none() => {
+                        self.term_lookup(sj)?
+                    }
+                    _ => None,
+                };
                 plan.push(Row {
                     seq: *seq,
                     ns: *ns,
@@ -3483,6 +3556,8 @@ impl Areev {
                     parent,
                     corpus_export: gv.corpus_export,
                     links,
+                    subject_only,
+                    superseded: *superseded,
                 });
             }
 
@@ -3506,6 +3581,26 @@ impl Areev {
                     self.db.execute(
                         "INSERT INTO corpus_idx(seq) VALUES (?1)",
                         vec![pi(r.seq)],
+                    )?;
+                    n += 1;
+                }
+                if let Some(s) = r.subject_only {
+                    // Replayed, not appended — same rule as links below. The
+                    // row carries the `cur` the incremental path would have
+                    // left it at, so a rebuild never resurrects a superseded
+                    // grain into a heads-only recall.
+                    self.db.execute(
+                        "DELETE FROM triples WHERE ns=?1 AND s=?2 AND p IS NULL AND o IS NULL AND seq=?3",
+                        vec![pi(r.ns), pi(s), pi(r.seq)],
+                    )?;
+                    self.db.execute(
+                        "INSERT INTO triples(ns,s,p,o,seq,cur) VALUES (?1,?2,NULL,NULL,?3,?4)",
+                        vec![
+                            pi(r.ns),
+                            pi(s),
+                            pi(r.seq),
+                            pi(if r.superseded { 0 } else { 1 }),
+                        ],
                     )?;
                     n += 1;
                 }
@@ -7468,6 +7563,21 @@ impl Areev {
 impl Areev {
     // ----- CAS blob store (`.blobs` fan-out dir / in-schema table) -----
 
+    /// Parse and validate a `cas://sha256:<hex>` URI into its hex address.
+    ///
+    /// Validation happens before anything byte-slices `hex[..2]`: an untrusted
+    /// or truncated URI (an imported `content_ref`, a hand-typed argument) must
+    /// return `Err`, never panic on a short or non-char-boundary slice.
+    fn cas_hex(uri: &str) -> Result<&str> {
+        let hex = uri
+            .strip_prefix("cas://sha256:")
+            .ok_or_else(|| AreevError::Validation(format!("not a cas uri: {uri}")))?;
+        if hex.len() != 64 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return Err(AreevError::Validation(format!("malformed cas uri: {uri}")));
+        }
+        Ok(hex)
+    }
+
     /// Store bytes in the per-memory CAS; returns the `cas://sha256:` URI.
     /// Idempotent — content addressing dedupes by construction.
     pub fn put_blob(&mut self, bytes: &[u8]) -> Result<String> {
@@ -7501,15 +7611,7 @@ impl Areev {
     /// Fetch bytes by `cas://sha256:` URI, verifying the hash on read.
     pub fn get_blob(&mut self, uri: &str) -> Result<Vec<u8>> {
         use sha2::{Digest, Sha256};
-        let hex = uri
-            .strip_prefix("cas://sha256:")
-            .ok_or_else(|| AreevError::Validation(format!("not a cas uri: {uri}")))?;
-        // Validate before anything byte-slices `hex[..2]` — an untrusted or
-        // truncated URI (e.g. from an imported content_ref) must return Err,
-        // never panic on a short or non-char-boundary slice.
-        if hex.len() != 64 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
-            return Err(AreevError::Validation(format!("malformed cas uri: {uri}")));
-        }
+        let hex = Self::cas_hex(uri)?;
         let bytes = match &self.blob_store {
             BlobStore::Fs(dir) => std::fs::read(fs_blob_path(dir, hex))
                 .map_err(|_| AreevError::Storage(format!("blob missing: {uri}")))?,
@@ -7835,6 +7937,13 @@ impl Areev {
                         vec![pi(pr.ns_id), pi(s), pi(p), pi(o), pi(seq), pb(pr.hash.as_bytes().to_vec())],
                     )?;
                 }
+            }
+            // Subject-anchored row — same treatment as the local write path.
+            if let Some(s) = pr.subject_only {
+                dbr.execute(
+                    "INSERT INTO triples(ns,s,p,o,seq,cur) VALUES (?1,?2,NULL,NULL,?3,1)",
+                    vec![pi(pr.ns_id), pi(s), pi(seq)],
+                )?;
             }
             // Cross-grain `related_to` links — same treatment as the local
             // write path: triples + osp for retrieval, never heads or
@@ -8336,6 +8445,16 @@ fn insert_prepped(
             db.execute_hot(
                 "INSERT INTO heads(ns,s,p,seq,hash,created_at) VALUES (?1,?2,?3,?4,?5,?6)",
                 vec![pi(pr.ns_id), pi(s), pi(p), pi(seq), pb(pr.hash.as_bytes().to_vec()), pi(pr.created)],
+            )?;
+        }
+        // Subject-anchored row for a grain that names a subject but asserts no
+        // relation. Same placement rule as links: `triples` only, never
+        // heads/entity_latest. No `osp` row — the object is NULL, so there is
+        // no reverse edge to traverse.
+        if let Some(s) = pr.subject_only {
+            db.execute_hot(
+                "INSERT INTO triples(ns,s,p,o,seq,cur) VALUES (?1,?2,NULL,NULL,?3,1)",
+                vec![pi(pr.ns_id), pi(s), pi(seq)],
             )?;
         }
         // Cross-grain `related_to` links (OMS §6.1), e.g. the §8.4 execution

--- a/crates/areev-store/tests/bugfix_regression_tests.rs
+++ b/crates/areev-store/tests/bugfix_regression_tests.rs
@@ -299,3 +299,133 @@ fn supersede_changed_key_reelection_ignores_link_rows() {
     assert!(!inserted, "value probe must match the re-elected head's true object");
     assert_eq!(h, h2a);
 }
+
+// ── Issue #23: a subject carried WITHOUT a relation/object ─────────────────
+// Structural indexing used to require all three of (subject, relation, object),
+// so a grain that merely named a subject reached no index at all. Two failures
+// fell out of that, and the second is the serious one:
+//   1. `recall(ns, subject, …)` answered empty for a grain that plainly carried
+//      the subject — a silent no-match on a filter every surface accepts.
+//   2. `forget_subject`/`subject_report` select through `triples`, so the same
+//      grain was invisible to erasure AND to DSAR disclosure.
+
+fn subject_event(ns: &str, subject: &str, content: &str) -> areev_core::types::Event {
+    let mut e = areev_core::types::Event::new(content).subject(subject);
+    e.common.namespace = Some(ns.to_string());
+    e
+}
+
+#[test]
+fn subject_only_grain_is_structurally_recallable() {
+    let (mut m, _d) = open_mem();
+    m.add(&subject_event("acct", "msg:inv-001", "first delivery")).unwrap();
+    m.add(&subject_event("acct", "msg:inv-002", "other message")).unwrap();
+
+    let got = m.recall("acct", "msg:inv-001", None, 8).unwrap();
+    assert_eq!(got.len(), 1, "a subject-only grain must match its own subject");
+    assert_eq!(
+        got[0].fields.get("content").and_then(|v| v.as_str()),
+        Some("first delivery")
+    );
+
+    // What the filter must EXCLUDE — a test that only checks presence passes
+    // against an index that matches everything.
+    assert!(
+        m.recall("acct", "msg:never-stored", None, 8).unwrap().is_empty(),
+        "an unknown subject must stay empty"
+    );
+    // The grain asserts no relation, so a relation-filtered probe must not
+    // invent one for it.
+    assert!(
+        m.recall("acct", "msg:inv-001", Some("mg:subject"), 8).unwrap().is_empty(),
+        "a subject-only row carries no relation and must not answer a relation filter"
+    );
+}
+
+#[test]
+fn subject_only_grain_is_erased_and_disclosed_with_its_subject() {
+    let (mut m, _d) = open_mem();
+    m.add(&subject_event("clinic", "pat", "call transcript")).unwrap();
+    m.add(&fact("clinic", "pat", "lives_in", "Berlin")).unwrap();
+    m.add(&fact("clinic", "mara", "prefers", "tea")).unwrap();
+
+    // The DSAR read must disclose exactly what the erasure removes (both, not
+    // just the Fact) — that pairing is the whole contract.
+    let report = m.subject_report("clinic", "pat").unwrap();
+    assert_eq!(report.grains.len(), 2, "DSAR must disclose the subject-only grain too");
+
+    let rep = m.forget_subject("clinic", "pat").unwrap();
+    assert_eq!(rep.grains_erased, 2, "erasure must reach the subject-only grain");
+
+    let left = m.recent("clinic", None, 8).unwrap();
+    assert_eq!(left.len(), 1, "only the unrelated grain survives");
+    assert_eq!(left[0].fields.get("subject").and_then(|v| v.as_str()), Some("mara"));
+}
+
+#[test]
+fn superseding_a_subject_only_grain_drops_it_from_heads_only_recall() {
+    let (mut m, _d) = open_mem();
+    let v1 = m.add(&subject_event("acct", "msg:inv-001", "draft")).unwrap();
+    let mut v2 = subject_event("acct", "msg:inv-001", "corrected");
+    m.supersede(&v1, &mut v2).unwrap();
+
+    let got = m.recall("acct", "msg:inv-001", None, 8).unwrap();
+    assert_eq!(got.len(), 1, "heads-only recall must not return the superseded version");
+    assert_eq!(
+        got[0].fields.get("content").and_then(|v| v.as_str()),
+        Some("corrected")
+    );
+}
+
+#[test]
+fn rebuilding_the_link_indexes_replays_subject_anchors_without_duplicating_them() {
+    // Existing files reach the anchors through the `link_index` stamp bump, so
+    // the rebuild is the migration — and it replays (DELETE+INSERT) rather than
+    // appends. If it appended, one reindex would double every subject-only
+    // grain in recall and inflate the erasure selector.
+    let d = TempDir::new().unwrap();
+    let path = d.path().join("m.db");
+    let path = path.to_str().unwrap();
+
+    let mut m = Areev::open(path).unwrap();
+    m.add(&subject_event("clinic", "pat", "call transcript")).unwrap();
+    assert_eq!(m.recall("clinic", "pat", None, 8).unwrap().len(), 1);
+
+    m.rebuild_link_indexes().unwrap();
+    assert_eq!(
+        m.recall("clinic", "pat", None, 8).unwrap().len(),
+        1,
+        "one grain must stay one result across a reindex"
+    );
+    m.rebuild_link_indexes().unwrap();
+    assert_eq!(m.recall("clinic", "pat", None, 8).unwrap().len(), 1);
+    assert_eq!(m.forget_subject("clinic", "pat").unwrap().grains_erased, 1);
+    drop(m);
+
+    // …and open() re-stamps the file as current so the migration runs once.
+    let m = Areev::open(path).unwrap();
+    assert_eq!(m.meta_get("link_index").unwrap().as_deref(), Some("3"));
+}
+
+#[test]
+fn rebuild_keeps_a_superseded_subject_only_grain_out_of_heads_only_recall() {
+    // The rebuild reconstructs `cur` from the grain's supersession state. Get
+    // that wrong and a reindex silently resurrects stale content into every
+    // heads-only recall — the exact failure mode `include_superseded` exists
+    // to make opt-in.
+    let d = TempDir::new().unwrap();
+    let path = d.path().join("m.db");
+    let mut m = Areev::open(path.to_str().unwrap()).unwrap();
+
+    let v1 = m.add(&subject_event("acct", "msg:inv-001", "draft")).unwrap();
+    let mut v2 = subject_event("acct", "msg:inv-001", "corrected");
+    m.supersede(&v1, &mut v2).unwrap();
+
+    m.rebuild_link_indexes().unwrap();
+    let got = m.recall("acct", "msg:inv-001", None, 8).unwrap();
+    assert_eq!(got.len(), 1, "the superseded version must not come back");
+    assert_eq!(
+        got[0].fields.get("content").and_then(|v| v.as_str()),
+        Some("corrected")
+    );
+}

--- a/crates/areev-store/tests/bundle_blob_tests.rs
+++ b/crates/areev-store/tests/bundle_blob_tests.rs
@@ -1,7 +1,7 @@
 //! CAS blob sidecar (§5.11) and bundle backup/sync (§5.10) tests.
 
 use areev_core::types::{Fact, Grain};
-use areev_store::Areev;
+use areev_store::{read_blob_offline, Areev};
 use tempfile::TempDir;
 
 fn fact(ns: &str, s: &str, r: &str, o: &str) -> Fact {
@@ -95,4 +95,84 @@ fn bundle_fast_forward_replication() {
         b.recall("ns", "alice", Some("speaks"), 16).unwrap().len(),
         1
     );
+}
+
+// ── Issue #27: reading a blob without opening the database ────────────────
+// The embedded backend's file lock is EXCLUSIVE — while a run holds a memory,
+// a second process is refused even for a read. That put an attachment out of
+// reach of the very `--tool-cmd` subprocess the run spawned to process it.
+// `read_blob_offline` answers that without a read-only open mode: blobs are
+// immutable, live in the `.blobs` sidecar rather than in the file, and carry
+// their checksum as their address, so there is no lock to take and no
+// consistency question to answer.
+
+#[test]
+fn blobs_are_readable_without_opening_the_database() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("m.db");
+    let path = path.to_str().unwrap().to_string();
+
+    let payload = b"invoice attachment \x00\x01\xff bytes".to_vec();
+    let uri = {
+        let mut m = Areev::open(&path).unwrap();
+        m.put_blob(&payload).unwrap()
+    };
+
+    // The handle above is dropped, but the point is that this call never opens
+    // the database at all — it is the same code path a subprocess takes while
+    // the writer is still held.
+    let got = read_blob_offline(&path, &uri).unwrap();
+    assert_eq!(got.as_deref(), Some(payload.as_slice()));
+}
+
+#[test]
+fn the_offline_read_holds_no_lock_against_a_live_handle() {
+    // The actual scenario: a handle is OPEN and holding the file when the read
+    // happens. A second `Areev::open` here would fail; this must not.
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("m.db");
+    let path = path.to_str().unwrap().to_string();
+
+    let mut held = Areev::open(&path).unwrap();
+    let uri = held.put_blob(b"held-open payload").unwrap();
+
+    assert!(Areev::open(&path).is_err(), "a second open must still be refused");
+    assert_eq!(
+        read_blob_offline(&path, &uri).unwrap().as_deref(),
+        Some(b"held-open payload".as_slice()),
+        "the sidecar read must not need the lock the writer holds"
+    );
+    drop(held);
+}
+
+#[test]
+fn the_offline_read_verifies_the_address_and_refuses_junk() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("m.db");
+    let path = path.to_str().unwrap().to_string();
+    {
+        let mut m = Areev::open(&path).unwrap();
+        m.put_blob(b"payload").unwrap();
+    }
+
+    for bad in ["not-a-uri", "cas://sha256:", "cas://sha256:abc", "cas://sha256:\u{20ac}"] {
+        assert!(read_blob_offline(&path, bad).is_err(), "must reject {bad:?}");
+    }
+    // Well-formed but absent is a clean Err, not a panic or a silent empty.
+    assert!(read_blob_offline(&path, &format!("cas://sha256:{}", "a".repeat(64))).is_err());
+
+    // A corrupted sidecar file must fail the content-address check rather than
+    // hand back wrong bytes — the address IS the integrity guarantee here,
+    // since no database row corroborates it.
+    let uri = {
+        let mut m = Areev::open(&path).unwrap();
+        m.put_blob(b"tamper me").unwrap()
+    };
+    let hex = uri.strip_prefix("cas://sha256:").unwrap();
+    let blob_file = std::path::PathBuf::from(format!("{path}.blobs"))
+        .join(&hex[..2])
+        .join(&hex[2..]);
+    std::fs::write(&blob_file, b"different bytes entirely").unwrap();
+    let e = read_blob_offline(&path, &uri).unwrap_err().to_string();
+    assert!(e.contains("corrupt"), "tampering must be caught: {e}");
 }

--- a/crates/areev-store/tests/run_join_tests.rs
+++ b/crates/areev-store/tests/run_join_tests.rs
@@ -289,7 +289,7 @@ fn open_heals_a_file_written_before_the_link_indexes_existed() {
         let m = Areev::open(path).unwrap();
         assert_eq!(
             m.meta_get("link_index").unwrap().as_deref(),
-            Some("2"),
+            Some("3"),
             "a file written by this build declares its link indexes current"
         );
         m.meta_put("link_index", "0").unwrap();

--- a/docs/cal-reference.md
+++ b/docs/cal-reference.md
@@ -475,6 +475,14 @@ Saved-query limits: 100 per namespace, 8 KiB body, 10 parameters. Saved-query
 bodies get an extra read-only verification pass, so a saved query can never
 smuggle in a write or a blocked keyword.
 
+`DEFINE` also **parses** the body, so a query that could never run is refused
+where it is written rather than stored as a landmine for its first caller —
+which is typically an unattended agent, long after whoever wrote the query has
+moved on. A body whose parameters sit in positions that demand a literal
+(`RECENT $limit`) is still accepted: the check re-parses it with the parameters
+standing in, so only a body that is malformed *however* it is bound is rejected
+(`CAL-E059`).
+
 Saved queries and custom templates are **host metadata carried by the memory
 file**, not memories: they persist as `meta` rows (`qry:<name>`, `tpl:<name>`)
 and so travel with the `.db` — the same set is visible from the CLI, MCP and
@@ -631,7 +639,7 @@ representative selection:
 | `WITH conflict_resolution` | Keep only the newest grain per `(subject, relation)` |
 | `WITH contradiction_detection` | Keep everything, but stamp `contested_by` on grains that are live tips of an open fork |
 | `WITH annotate_relative_time` | Add "2 weeks ago"-style labels |
-| `WITH progressive_disclosure(summary)` | OMS progressive-disclosure level |
+| `WITH progressive_disclosure(summary\|headlines\|full)` | OMS §4 disclosure level — how much of each grain's **body** a render carries (orthogonal to metadata). `summary` clips free-text bodies to 40 chars, `headlines` to 80, `full` leaves them whole **and** adds the long-form definition bodies no other tier carries: a Skill's `when_to_use` and `instructions`. Omitting the option keeps each format's established output unchanged. The bare form (no level) means `full` |
 
 ```sql
 RECALL facts ABOUT "dietary restrictions" WITH rerank, diversity(0.4), min_score(0.5)

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -901,6 +901,67 @@ tokens and the vault are file-backend + encryption features by design.
 
 ---
 
+## 17. Attach a file to a memory (CAS blobs)
+
+Grains stay small; media lives in the per-memory content-addressed store and is
+referenced by `cas://` URI. The address IS the content, so storing the same
+bytes twice stores them once.
+
+```bash
+# Store bytes, get the address back (idempotent).
+URI=$(areev blob put invoice-001.pdf --db acct.db)
+echo "$URI"          # cas://sha256:a0864a70...
+
+# …or from a pipe.
+pdftotext invoice-001.pdf - | areev blob put --stdin --db acct.db
+
+# Read them back, hash-verified.
+areev blob get "$URI" --db acct.db > roundtrip.pdf
+```
+
+Reference the blob from a grain's `content_refs` so erasure and GC can see it:
+a blob referenced by no live grain is reclaimed by `gc_blobs`, and a
+sole-referenced attachment is reclaimed by `forget-subject` along with the
+grain that named it.
+
+**`blob get` deliberately does not open the memory.** The embedded backend
+takes an *exclusive* file lock, so while `areev run` holds a memory every other
+verb is refused — including a read. A tool subprocess launched by that run
+would otherwise be unable to fetch the very attachment it was started to
+process:
+
+```bash
+# inside a --tool-cmd subprocess, while the run holds the writer:
+areev blob get "$attachment_uri" --db acct.db > /tmp/att.pdf   # works
+areev recall ... --db acct.db                                   # STO-E001, locked
+```
+
+This is safe rather than a loophole: blobs are immutable, live beside the file
+rather than in it, and carry their checksum as their address, which the read
+re-verifies. An **encrypted** memory is the exception — decrypting the sidecar
+needs the derived key, so `blob get` opens it and therefore needs
+`--passphrase-env` and an unheld file.
+
+Both bindings carry the pair, bytes in and bytes out (not the usual JSON-string
+return — base64 through JSON would inflate every payload by a third):
+
+```python
+uri = m.put_blob(open("invoice-001.pdf", "rb").read())
+data = m.get_blob(uri)          # bytes
+```
+
+```js
+const uri = await m.putBlob(await fs.readFile('invoice-001.pdf'))
+const data = await m.getBlob(uri)   // Buffer
+```
+
+There is no MCP tool for blobs, deliberately: MCP results are JSON over stdio,
+so a binary payload would have to be base64'd into the response and would blow
+the context window it landed in. Tools that need bytes should take the `cas://`
+URI from a grain's `content_refs` and shell out to `areev blob get`.
+
+---
+
 ## See also
 
 - [`../ARCHITECTURE.md`](../ARCHITECTURE.md) — how Areev is built

--- a/docs/erasure.md
+++ b/docs/erasure.md
@@ -139,7 +139,14 @@ references** in the namespace — for the identity itself AND every
 partition-style key carrying it as a boundary-guarded prefix
 (REQ-ERASE-7):
 
-- triple **subject** position (the grain is about the identity),
+- triple **subject** position (the grain is about the identity) —
+  including a grain that names a `subject` but asserts no relation or
+  object, such as an Event about a person or a message. Those used to
+  reach no index at all, which made them invisible to this selector: an
+  erasure reported success while the identity's own transcript stayed in
+  the file, and `subject_report` under-disclosed it by exactly the same
+  grains. Files written before the fix are healed by the `link_index`
+  stamp on open — see `areev-store/CLAUDE.md`, "Subject anchors",
 - triple **object** position (the grain points at the identity —
   over-deletion is the safe direction for erasure),
 - **thread events** whose session id is the identity (or an

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -323,6 +323,44 @@ depend on signals outside Areev and on a hundred factors that aren't the
 change, so the honest output is a **monitored trend a human judges**, never a
 machine verdict — the design suppresses causal claims at low sample sizes on
 purpose. Areev Loop improves the agent's *memory*, not its *outputs* (§2.4).
+
+### Evalset-backed outcomes — where that boundary legitimately moves
+
+If you have a **labeled ground-truth set**, external correctness stops being
+open-ended: an evalset run is itself internal, bounded and attributable. So a
+recommendation may carry a metric naming one:
+
+```
+metric = "evalset:<EVALSET_HASH>:<field>"
+```
+
+`<field>` is read from the summary `areev eval run` journals. Four names are
+promoted and work against any evalset — `passed`, `failed`, `total`,
+`error_rate` (`failed/total`) — and anything else is read from the summary your
+harness wrote, e.g. `evalset:abc123:category_accuracy`.
+
+**State the direction.** The built-in metrics are recurrence counts where lower
+is better; an accuracy is the opposite. `MetricSnapshot.higher_is_better` says
+which, and it is not cosmetic: read the wrong way, the Verify gate sees a rule
+that *improved* accuracy and proposes reverting it. The comparison lives in one
+function (`recommendation::is_regression`) that both the engine's recorded
+verdict and `outcome_review`'s revert draft call.
+
+**A run from before the apply is never evidence.** The lookup is scoped to
+summaries journaled at or after the apply. If no eval run has happened since,
+the metric is *not yet measurable* and the checkpoint stays due — the engine
+does not fall back to the baseline run. Scoring the baseline against itself
+would report `held` forever, which is a fabricated receipt and worse than none.
+
+No scheduler is implied: run `areev eval run` from cron or CI exactly as you run
+`areev loop run`; outcomes only ever **read** what it journaled. The apply gate
+(`areev loop apply --gating-run <id>`) and the outcome edge deliberately read
+those summaries through **one** function (`areev_loop::eval`), so a rule cannot
+be admitted on one reading of an evalset and judged on another.
+
+So for a learned vendor-alias rule, the receipt becomes exactly what it should
+be: *canonical-vendor accuracy on the 184-row ground truth went up, and stayed
+up at 1d, 7d and 30d.*
 Outcomes accrue over real calendar time as checkpoints elapse; the loop is
 exercised end-to-end by the engine test suite, which controls the clock.
 

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -429,6 +429,20 @@ Only the stdio (`--mcp`) transport is available; the server refuses any other
 that spawns it (see the [security model](security-model.md)), run it under a
 parent you trust.
 
+### What is deliberately not a tool: CAS blobs
+
+There is no `areev_blob_put` / `areev_blob_get`. MCP results are JSON over
+stdio, so blob bytes would have to be base64'd into a tool result and land
+whole in the model's context — a 2 MB attachment becomes ~2.7 MB of base64 in
+the window it was supposed to stay out of. The CAS exists precisely so that
+media is referenced rather than carried.
+
+A tool that needs the bytes should take the `cas://` URI from the grain's
+`content_refs` (which `areev_recall` already returns) and fetch them out of
+band with `areev blob get`, which reads the sidecar without opening the memory
+and therefore works even while a run holds the writer. See
+[cookbook §17](cookbook.md).
+
 ---
 
 ---


### PR DESCRIPTION
Patch release. Closes #23, #24, #25, #27, #29.

### Fixed

- **#23 — subject-only grains reached no index at all.** Worse than the ticket reported: `forget_subject`/`subject_report` select through the same indexes, so an identity's own Event **survived erasure and went undisclosed in a DSAR** while the erasure reported success. Subject-anchored rows now carry them (relation/object NULL, so the row stays inert to relation-bound queries; never written to `heads`/`entity_latest`). Existing files heal on open via a `link_index` v3 stamp bump — the rebuild replays rows and reconstructs `cur` from supersession state, so a reindex neither duplicates a grain nor resurrects a superseded one. Pinned on both backends.
- **#24 — `DEFINE QUERY` stored bodies that could never `RUN`.** Root cause was broader than reported: validation skipped parsing entirely for any body containing `$` (the shape most saved queries have). Bodies parameterizing a literal position (`RECENT $limit`) still define, via a placeholder retry.
- **#25 — a Skill's `instructions` reached no rendered path**, and `progressive_disclosure` was documented but a parsed no-op.

### Added

- **#25** — `WITH progressive_disclosure(summary|headlines|full)` executes. Unannotated renders are byte-identical, so `render_parity` stays honest.
- **#27** — `areev blob put|get` + `put_blob`/`get_blob` in both bindings. `blob get` deliberately does **not** open the memory: the embedded lock is exclusive, so a live run otherwise strands an attachment out of reach of the `--tool-cmd` subprocess spawned to process it. No read-only open mode needed — a blob is immutable and its address is its checksum.
- **#29** — `evalset:<hash>:<field>` outcome metrics, sharing one reader with the `--gating-run` edge.

### Two things worth a reviewer's eye

1. **`higher_is_better`** (#29). Every existing metric is a recurrence count where lower is better; an accuracy is the opposite, and the regression rule lived in **two** places. Read the wrong way the Verify gate would propose reverting exactly the rules that worked. The comparison now lives in one function both callers use.
2. **A run journaled before the apply is never evidence** (#29). Scoring the baseline run against itself would report `held` forever — a fabricated receipt. No run since the apply → not yet measurable, checkpoint stays due.

### Not done, deliberately

- **#24's THREAD half.** `THREAD` is a lexer token no parser production consumes — `RECALL events THREAD "x"` fails standalone too, and `cal-reference.md` documents no such syntax. Making it work is *new CAL grammar*, i.e. an OMS spec decision, so it is untouched.
- **`--outcome-run`** (#29). Naming a run is right for the *gate* (a human deciding to ship); for the *receipt* it lets the measured party pick its own scoreboard.
- **#26 and #28** stay open with implementation specs posted as comments.

### Gate

`cargo test --workspace` 108/108 binaries · clippy `-D warnings` clean (workspace + areev-js) · `cargo deny` advisories/bans/licenses/sources ok · perf gates PASS (recall p50 27.7µs vs 200µs budget; voice_loop 50ms cadence) · golden loop tests pass · pytest 90 passed · `node --test` 47/47 · `cargo doc` adds no new warnings.

Docs contract swept: `ARCHITECTURE.md`, `cal-reference.md`, `erasure.md`, `loop.md`, `cookbook.md` §17, `mcp-reference.md`, `areev-store`/`areev-cal` `CLAUDE.md`, CLI `USAGE`, `CHANGELOG.md`.