### PR TITLE
Fix kill_switch_drill flake: cancel detection now journals a fresh clock reading

### DIFF
--- a/crates/areev-run-core/tests/scheduler_tests.rs
+++ b/crates/areev-run-core/tests/scheduler_tests.rs
@@ -520,6 +520,83 @@ fn cancel_drains_without_new_dispatches() {
         !out2.commands.iter().any(|c| matches!(c, Command::Dispatch { .. })),
         "a canceled run must not dispatch new work"
     );
+    // The terminal checkpoint's clock_close_ms reflects the fresh reading
+    // this batch carried alongside CancelSeen — the shape a driver MUST
+    // produce (doc comment on `step()`: "any call that may open or close a
+    // superstep includes a fresh ClockReading"). This is the positive half
+    // of the contract; `cancel_without_a_fresh_reading_journals_a_stale_close`
+    // below pins what happens when a driver skips it.
+    let close_ms = out2
+        .commands
+        .iter()
+        .find_map(|c| match c {
+            Command::WriteCheckpoint { decision_record, .. } => Some(decision_record.clock_close_ms),
+            _ => None,
+        })
+        .expect("cancellation writes a terminal checkpoint");
+    assert_eq!(close_ms, 2_000, "clock_close_ms must take the batch's fresh reading");
+}
+
+/// The failure mode a real driver can produce by skipping the reading: if
+/// `CancelSeen` rides a batch with NO accompanying `ClockReading`, the
+/// terminal checkpoint's `clock_close_ms` stays at whatever the LAST
+/// reading was — even if that reading predates the moment the cancel was
+/// actually discovered. `step()` has no way to notice this on its own (it
+/// only ever sees what a caller hands it); the guarantee has to come from
+/// every driver honoring the doc comment on `step()`. `areev-run`'s live
+/// driver used to violate exactly this (the kill-switch drill's
+/// `close_ms >= cancel_ms` assertion caught it under real concurrency);
+/// this is the deterministic, non-racy pin of the underlying mechanism.
+#[test]
+fn cancel_without_a_fresh_reading_journals_a_stale_close() {
+    let plan = PlanGraph::build(&wf(&["a", "b", "c"]).edge("a", "b").edge("b", "c")).unwrap();
+    let execs = host_execs(&plan);
+    let behavior = |key: &JournalKey, _in: &Value| ok(json!({key.node.clone(): true}));
+
+    let e = env(&plan, &execs, Budgets::default());
+    let st = SchedulerState::new("run-1", &plan);
+    let out = step(
+        &e,
+        st,
+        &[
+            EventIn::ClockReading { unix_ms: 1_000 },
+            EventIn::Start { input: json!({}) },
+        ],
+    );
+    let dispatched: Vec<JournalKey> = out
+        .commands
+        .iter()
+        .filter_map(|c| match c {
+            Command::Dispatch { key, .. } => Some(key.clone()),
+            _ => None,
+        })
+        .collect();
+
+    // Same scenario as `cancel_drains_without_new_dispatches`, EXCEPT this
+    // batch carries no ClockReading before CancelSeen — the shape the live
+    // driver used to produce.
+    let mut events = vec![EventIn::CancelSeen { principal: "user:ops".into(), reason: "abort".into() }];
+    for key in dispatched {
+        events.push(EventIn::EffectResolved { key: key.clone(), outcome: behavior(&key, &json!({})) });
+    }
+    let out2 = step(&e, out.state, &events);
+    assert_eq!(
+        out2.state.outcome(),
+        Some(&RunOutcome::Canceled { by: "user:ops".into(), reason: "abort".into() })
+    );
+    let close_ms = out2
+        .commands
+        .iter()
+        .find_map(|c| match c {
+            Command::WriteCheckpoint { decision_record, .. } => Some(decision_record.clock_close_ms),
+            _ => None,
+        })
+        .expect("cancellation writes a terminal checkpoint");
+    assert_eq!(
+        close_ms, 1_000,
+        "without a fresh reading, clock_close_ms is stuck at the superstep's OPEN — \
+         exactly the staleness a driver skipping the reading would journal"
+    );
 }
 
 #[test]

--- a/crates/areev-run/CLAUDE.md
+++ b/crates/areev-run/CLAUDE.md
@@ -45,6 +45,32 @@ against the stored chain. Divergence verdicts name the differing fields
 (`diff_fields`). Parked spans replay by feeding the stored close reading
 before `ResponseSettled` — see run-core's wall/elapsed pin for why.
 
+## The clock-reading contract on cancellation
+
+`step()`'s doc comment: "any call that may open or close a superstep
+includes a fresh `ClockReading`." The live `drive()` loop's cancel poll used
+to violate this — it pushed `CancelSeen` alone when `cancel_marker` first
+found the operator's Fact, so a freshly-detected cancel (which closes the
+run's FINAL superstep) journaled `clock_close_ms` from whatever the last
+**completed wave** happened to read, which can predate the cancel Fact's own
+`created_at` when the cancel lands in the gap between one wave finishing and
+the next loop iteration noticing it — inverting the audit trail
+`oversight-report`'s <5-minute kill-switch measurement reads (it already
+silently drops inverted samples rather than trusting them, which is how this
+went unnoticed). The fix: take a fresh reading in the SAME batch as
+`CancelSeen`, mirroring what `verify()`'s own replay already does at both its
+`cancel_peek` call sites (a `ClockReading` immediately preceding
+`CancelSeen`). `cancel_marker` only returns once its store read has observed
+the write `cancel()` performed, so a reading taken right after is monotone
+at or after it. Pinned two ways: `wave6_tests.rs`'s
+`kill_switch_drill_measures_cancel_to_drain_under_the_clause` under real
+concurrency (the shape that caught it), and the deterministic, non-racy pair
+in `areev-run-core/tests/scheduler_tests.rs` —
+`cancel_drains_without_new_dispatches` (now also asserts `clock_close_ms`
+takes the batch's reading) and `cancel_without_a_fresh_reading_journals_a_stale_close`
+(pins the contract's negative: skip the reading, get a stale close — the
+exact shape the old driver code produced).
+
 ## HITL (§6.6)
 
 `respond` validates in order (pausable → known ask by `tool_call_id`, NEVER

--- a/crates/areev-run/src/runner.rs
+++ b/crates/areev-run/src/runner.rs
@@ -936,6 +936,22 @@ impl Runner {
             // The kill switch: polled every iteration (a µs point read).
             if st.cancel.is_none() {
                 if let Some((by, reason)) = self.cancel_marker(&run_id) {
+                    // `step()`'s contract: any call that may CLOSE a
+                    // superstep carries a fresh ClockReading (doc comment on
+                    // `step()`). A freshly-seen cancel closes the run's
+                    // FINAL superstep, but without a reading taken HERE
+                    // `st.clock_ms` stays whatever an earlier, already-
+                    // completed wave last set it to — which can predate the
+                    // cancel Fact's own `created_at`, journaling a
+                    // clock_close_ms that appears to close before the
+                    // operator asked to cancel. `cancel_marker` only
+                    // returns once its read has observed the write `cancel`
+                    // performed, so a reading taken now is monotone at or
+                    // after it. `verify()`'s replay already assumes this
+                    // shape at both its own cancel_peek sites (a
+                    // ClockReading immediately preceding CancelSeen in the
+                    // same batch) — this is the live counterpart.
+                    events.push(EventIn::ClockReading { unix_ms: self.clock.now_ms() });
                     events.push(EventIn::CancelSeen { principal: by, reason });
                 }
             }


### PR DESCRIPTION
Fixes a real correctness bug in the live driver — not an over-tight test.

## Root cause

`step()`'s own doc comment states the contract: *"any call that may open or close a superstep includes a fresh `ClockReading`."* A freshly-detected cancel closes the run's **final** superstep via `finish()`, but the `drive()` loop's cancel poll pushed only `CancelSeen` — no accompanying reading — so `clock_close_ms` stayed at whatever the **last completed wave** happened to read. When the operator's cancel lands in the gap between one wave finishing and the next loop iteration noticing it, that stale reading can predate the cancel Fact's own `created_at`, inverting the audit trail `areev run oversight-report`'s <5-minute kill-switch measurement reads. `oversight-report` already silently drops inverted samples rather than trusting them, which is how this went unnoticed in production and only surfaced as an intermittent CI failure under real concurrency.

Confirmed present on the **v1.2.0 release commit itself** and at least two commits before it — unrelated to v1.2.1, been there a while.

The tell that this was the driver's bug, not the test's: `verify()`'s own replay already assumes and produces this exact shape — both its `cancel_peek` call sites push a `ClockReading` immediately before `CancelSeen` in the same batch. The live driver was the one path violating its own documented contract.

## Fix

Take a fresh reading (`self.clock.now_ms()`) in the same event batch as `CancelSeen`, at the point `cancel_marker` first finds the operator's Fact. `cancel_marker` only returns once its store read has observed the write `cancel()` performed, so a reading taken right after is monotone at or after it — matching `verify()`'s replay shape exactly.

`crates/areev-run-core` (the sans-IO scheduler core) is untouched by construction — the fix lives entirely in `crates/areev-run`, the impure driver.

## Tests — pinned two ways

- **The real drill**, under actual concurrency: `wave6_tests.rs`'s `kill_switch_drill_measures_cancel_to_drain_under_the_clause`. 55/55 across two stress runs post-fix; intermittently failing pre-fix.
- **A deterministic pair**, no clock/threads/sleep (0.00s), in `areev-run-core/tests/scheduler_tests.rs`:
  - `cancel_drains_without_new_dispatches` now also asserts `clock_close_ms` takes the batch's fresh reading (the contract's positive half).
  - `cancel_without_a_fresh_reading_journals_a_stale_close` — new — pins the negative: feed `CancelSeen` alone and the terminal checkpoint stays stuck at the superstep's open, exactly what the old driver code produced. This is the one that actually catches a regression; the wall-clock drill needs a slow/contended runner to fire at all.

## Gate

`cargo test --workspace` 108/108 binaries green · clippy `-D warnings` clean · `areev-run-core` purity checks (no clock in its dep tree, `SystemTime::now`/`Instant::now` disallowed) unaffected.

Docs: `areev-run/CLAUDE.md` — new section documenting the contract and why it was violated.