### PR TITLE
Release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,77 @@ the pre-rename release history lives in that repository's `CHANGELOG.md`.
 
 ## [Unreleased]
 
+## [1.2.2] — 2026-08-18
+
+### Added
+
+- **A Workflows tab in the console** (#37): lists Workflow grains as cards
+  and opens one into an editable node/edge graph — a deterministic
+  left-to-right layered layout on canvas, add/rename/delete a step, rebind
+  it to any Tool definition, drag a step's connector dot to wire it to
+  another step, set/clear an edge's `WHEN` condition. Saving always writes
+  a new `ADD workflow` grain, since plans are content-addressed and
+  immutable and "editing" one means authoring a new version; a plan with a
+  bounded-cycle edge or a per-node retry count opens **view-only**, because
+  `ADD`/`SUPERSEDE workflow` has no surface syntax yet to author either
+  (`* N` populates `retries`, not `max_cycles`). No new server routes —
+  built entirely on the existing `/api/browse` and `/api/cal` surface.
+  `crates/areev-store/examples/seed_workflow_demo.rs` seeds three demo
+  plans into the "Northwind Support" corpus.
+- **An Analytics tab in the console**: a grain-type census across all 12
+  types, a namespace breakdown, a 14-day growth trend, and recall-leg
+  status — generalizes the Query page's "WHAT'S IN THIS MEMORY" on-ramp
+  (now removed from Query in favor of it) to cover every grain type
+  instead of 4, and every namespace instead of just the bound one.
+
+### Fixed
+
+- **Workflow edge arrowheads were never visible, and edge selection didn't
+  line up with what was drawn.** The graph stroked each edge along a
+  border-adjusted bezier curve but evaluated the arrowhead position and
+  click hit-testing on a different curve through the raw node centers, so
+  the arrowhead landed inside the destination node (painted over by its
+  opaque fill) and a click near an edge sampled a curve offset from the
+  one on screen. Both now read off the exact curve that gets stroked.
+- **A node bound to another plan ("subgraph") showed as "unbound" in the
+  editor's "Runs as" picker**, contradicting the "Subgraph" badge shown
+  directly above it — the option list was built from Tool definitions
+  only, with no entry for a Workflow-grain target.
+- **A crafted `BIND` binding could inject arbitrary CAL into a plan's save
+  statement.** Every other value the Workflows editor writes into
+  `ADD workflow` (node names, `WHEN`, the trigger, the reason) is quoted;
+  the bound hash was spliced in bare. A plan opened in the console can
+  have been authored outside it (the Rust/Python/Node API, or a synced
+  bundle), so a binding value crafted to look like a hash followed by more
+  CAL could append clauses — rebinding other steps or overriding the
+  reason — the moment someone reopened and resaved that plan through the
+  UI. The hash is now validated against the content-address format before
+  it reaches the statement.
+- **Drawing a cycle in the workflow editor saved silently and only failed
+  later, at run time.** Every edge the console can author is
+  unconditionally unbounded (`ADD workflow` has no syntax to re-emit a
+  bound on save), so any cycle drawn through the editor was guaranteed to
+  fail at run-load with `RUN-E002`. Connecting an edge that would close
+  one is now refused up front.
+- The sidebar's Workflows nav item didn't reset an open draft or selection
+  the way navigating to a bare `#workflows` hash already did, so clicking
+  it while mid-edit just re-rendered the same editor instead of returning
+  to the plan list.
+- Query's "start from a question" examples wrote hardcoded placeholder
+  subjects (`"john"`, `"acme-corp"`) that almost never match a real
+  memory's own data, so the first thing a new user tried reliably came
+  back empty. They now pull an actual subject and value from the file's
+  own Facts, falling back to filter-free forms only when the file has none
+  yet.
+- Console-wide: one shared namespace-picker component ("Namespace  value
+  ⌄") replaced three different layouts across Activity, Workflows, and
+  Analytics, each with its own alignment quirks; every native `<select>`
+  in the console (the "Runs as" picker above, the anonymization policy
+  picker) now matches the rest of the UI instead of the browser's default
+  box; the "Areev" brand mark is clickable (home) and aligned with the nav
+  icons below it; the breadcrumb home icon's optical alignment against its
+  trail text.
+
 ## [1.2.1] — 2026-08-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "areev"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-context",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "areev-bench"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-context",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "areev-cal"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-core",
  "areev-store",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "areev-conformance"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "areev-context"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "areev-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "hex",
  "insta",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "areev-llm"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-core",
  "areev-loop",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop-adapter"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "areev-mcp"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "areev-py"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-core",
  "serde",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "areev-server"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "areev-store"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "areev-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/areev-core", "crates/areev-store", "crates/areev-cal", "crates/areev-cli", "crates/areev-mcp", "crates/areev-context", "crates/areev-server", "crates/areev-py", "crates/areev-bench", "crates/areev-loop", "crates/areev-loop-adapter", "crates/areev-llm", "crates/areev-conformance", "crates/areev-run-core", "crates/areev-run"]
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["MindGryd Software Private Limited"]

--- a/crates/areev-bench/Cargo.toml
+++ b/crates/areev-bench/Cargo.toml
@@ -11,14 +11,14 @@ homepage.workspace = true
 publish = false
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
 # `cargo run -p areev-bench --features postgres --bin pg_bench` — the
 # server-tier latency harness (needs DATABASE_URL).
 
-areev-store = { path = "../areev-store", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
-areev-context = { path = "../areev-context", version = "1.2.1" }
-areev-server = { path = "../areev-server", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
+areev-context = { path = "../areev-context", version = "1.2.2" }
+areev-server = { path = "../areev-server", version = "1.2.2" }
 areev-loop = { path = "../areev-loop" }
 areev-llm = { path = "../areev-llm" }
 serde_json = "1"

--- a/crates/areev-cal/Cargo.toml
+++ b/crates/areev-cal/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["query-language", "parser", "memory", "cal", "ai-agents"]
 categories = ["parser-implementations", "database-implementations"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-store = { path = "../areev-store", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 logos = "0.14"

--- a/crates/areev-cli/Cargo.toml
+++ b/crates/areev-cli/Cargo.toml
@@ -25,9 +25,9 @@ postgres = ["areev-store/postgres"]
 tls = ["areev-server/tls"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-store = { path = "../areev-store", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
 serde_json = "1"
 sha2 = "0.10"
 hex = "0.4"
@@ -36,14 +36,14 @@ zeroize = "1"
 # ISO-8601 transcript timestamps so capture-stop can pin created_at.
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 
-areev-mcp = { path = "../areev-mcp", version = "1.2.1" }
-areev-context = { path = "../areev-context", version = "1.2.1" }
-areev-server = { path = "../areev-server", version = "1.2.1" }
-areev-loop = { path = "../areev-loop", version = "1.2.1" }
-areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.1" }
-areev-llm = { path = "../areev-llm", version = "1.2.1" }
-areev-run = { path = "../areev-run", version = "1.2.1" }
-areev-run-core = { path = "../areev-run-core", version = "1.2.1" }
+areev-mcp = { path = "../areev-mcp", version = "1.2.2" }
+areev-context = { path = "../areev-context", version = "1.2.2" }
+areev-server = { path = "../areev-server", version = "1.2.2" }
+areev-loop = { path = "../areev-loop", version = "1.2.2" }
+areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.2" }
+areev-llm = { path = "../areev-llm", version = "1.2.2" }
+areev-run = { path = "../areev-run", version = "1.2.2" }
+areev-run-core = { path = "../areev-run-core", version = "1.2.2" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/areev-context/Cargo.toml
+++ b/crates/areev-context/Cargo.toml
@@ -20,8 +20,8 @@ llm-rerank = []
 rerank = []
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }

--- a/crates/areev-js/Cargo.lock
+++ b/crates/areev-js/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "areev-cal"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-core",
  "areev-store",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "areev-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "hex",
  "regex",
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "areev-js"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "areev-llm"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-core",
  "areev-loop",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "areev-loop-adapter"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-cal",
  "areev-core",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "areev-run-core"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "areev-core",
  "serde",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "areev-store"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "areev-core",

--- a/crates/areev-js/Cargo.toml
+++ b/crates/areev-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "areev-js"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["MindGryd Software Private Limited"]
@@ -21,12 +21,12 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
 # The postgres backend ships ON in the binding: it is a server-side surface,
 # and `new Areev("postgres://…?schema=<name>")` must work from a stock
 # `npm install @areev/areev`. The dependency-light default stays with the CLI/store.
-areev-store = { path = "../areev-store", version = "1.2.1", features = ["postgres"] }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-store = { path = "../areev-store", version = "1.2.2", features = ["postgres"] }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
 areev-loop = { path = "../areev-loop" }
 areev-loop-adapter = { path = "../areev-loop-adapter" }
 areev-llm = { path = "../areev-llm" }

--- a/crates/areev-js/index.js
+++ b/crates/areev-js/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('areev-android-arm64')
         const bindingPackageVersion = require('areev-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('areev-android-arm-eabi')
         const bindingPackageVersion = require('areev-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-x64-gnu')
         const bindingPackageVersion = require('areev-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-x64-msvc')
         const bindingPackageVersion = require('areev-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-ia32-msvc')
         const bindingPackageVersion = require('areev-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('areev-win32-arm64-msvc')
         const bindingPackageVersion = require('areev-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('areev-darwin-universal')
       const bindingPackageVersion = require('areev-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('areev-darwin-x64')
         const bindingPackageVersion = require('areev-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('areev-darwin-arm64')
         const bindingPackageVersion = require('areev-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('areev-freebsd-x64')
         const bindingPackageVersion = require('areev-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('areev-freebsd-arm64')
         const bindingPackageVersion = require('areev-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-x64-musl')
           const bindingPackageVersion = require('areev-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-x64-gnu')
           const bindingPackageVersion = require('areev-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm64-musl')
           const bindingPackageVersion = require('areev-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm64-gnu')
           const bindingPackageVersion = require('areev-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm-musleabihf')
           const bindingPackageVersion = require('areev-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-arm-gnueabihf')
           const bindingPackageVersion = require('areev-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-loong64-musl')
           const bindingPackageVersion = require('areev-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-loong64-gnu')
           const bindingPackageVersion = require('areev-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-riscv64-musl')
           const bindingPackageVersion = require('areev-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('areev-linux-riscv64-gnu')
           const bindingPackageVersion = require('areev-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('areev-linux-ppc64-gnu')
         const bindingPackageVersion = require('areev-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('areev-linux-s390x-gnu')
         const bindingPackageVersion = require('areev-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('areev-openharmony-arm64')
         const bindingPackageVersion = require('areev-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('areev-openharmony-x64')
         const bindingPackageVersion = require('areev-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('areev-openharmony-arm')
         const bindingPackageVersion = require('areev-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.2.1' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('areev-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '1.2.1') {
-            throw new Error(`WASI binding package version mismatch, expected 1.2.1 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.2.2') {
+            throw new Error(`WASI binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('areev-wasm32-wasi')

--- a/crates/areev-js/package.json
+++ b/crates/areev-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "areev",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Node.js bindings for Areev, the embedded memory engine for AI agents.",
   "license": "MIT OR Apache-2.0",
   "author": "MindGryd Software Private Limited",

--- a/crates/areev-llm/Cargo.toml
+++ b/crates/areev-llm/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["ai-agents", "llm", "loop", "self-improvement", "areev"]
 categories = ["api-bindings"]
 
 [dependencies]
-areev-loop = { path = "../areev-loop", version = "1.2.1" }
+areev-loop = { path = "../areev-loop", version = "1.2.2" }
 # Wave 0 (governed-agents §6.11): the ToolCallLlm seam renders Tool
 # Definition grains to each provider's native tools format via core's
 # tool_schema module — workspace-internal, no new external surface.
-areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # A small BLOCKING HTTP client — matches the sync-over-private-runtime / std

--- a/crates/areev-loop-adapter/Cargo.toml
+++ b/crates/areev-loop-adapter/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["ai-agents", "memory", "loop", "self-improvement", "areev"]
 categories = ["algorithms"]
 
 [dependencies]
-areev-loop = { path = "../areev-loop", version = "1.2.1" }
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-store = { path = "../areev-store", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-loop = { path = "../areev-loop", version = "1.2.2" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/areev-mcp/Cargo.toml
+++ b/crates/areev-mcp/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["mcp", "memory", "ai-agents", "llm", "protocol"]
 categories = ["api-bindings"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-store = { path = "../areev-store", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
-areev-loop = { path = "../areev-loop", version = "1.2.1" }
-areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.1" }
-areev-run = { path = "../areev-run", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
+areev-loop = { path = "../areev-loop", version = "1.2.2" }
+areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.2" }
+areev-run = { path = "../areev-run", version = "1.2.2" }
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/areev-py/Cargo.toml
+++ b/crates/areev-py/Cargo.toml
@@ -26,9 +26,9 @@ name = "areev"
 crate-type = ["cdylib"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-store = { path = "../areev-store", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
 areev-loop = { path = "../areev-loop" }
 areev-loop-adapter = { path = "../areev-loop-adapter" }
 areev-llm = { path = "../areev-llm" }

--- a/crates/areev-py/pyproject.toml
+++ b/crates/areev-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "areev"
-version = "1.2.1"
+version = "1.2.2"
 description = "Python bindings for Areev, the embedded memory engine for AI agents."
 requires-python = ">=3.9"
 license = { text = "MIT OR Apache-2.0" }

--- a/crates/areev-run-core/Cargo.toml
+++ b/crates/areev-run-core/Cargo.toml
@@ -26,7 +26,7 @@ keywords = ["ai-agents", "workflow", "deterministic", "runtime", "areev"]
 categories = ["algorithms"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/areev-run/Cargo.toml
+++ b/crates/areev-run/Cargo.toml
@@ -17,12 +17,12 @@ keywords = ["ai-agents", "workflow", "runtime", "deterministic", "areev"]
 categories = ["development-tools"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-store = { path = "../areev-store", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
-areev-run-core = { path = "../areev-run-core", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
+areev-run-core = { path = "../areev-run-core", version = "1.2.2" }
 # The ToolCallLlm seam for abstract nodes (§6.2/§6.11).
-areev-llm = { path = "../areev-llm", version = "1.2.1" }
+areev-llm = { path = "../areev-llm", version = "1.2.2" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/areev-server/Cargo.toml
+++ b/crates/areev-server/Cargo.toml
@@ -13,14 +13,14 @@ keywords = ["memory", "server", "sync", "ai-agents", "http"]
 categories = ["web-programming::http-server"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
-areev-store = { path = "../areev-store", version = "1.2.1" }
-areev-cal = { path = "../areev-cal", version = "1.2.1" }
-areev-loop = { path = "../areev-loop", version = "1.2.1" }
-areev-run = { path = "../areev-run", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
+areev-store = { path = "../areev-store", version = "1.2.2" }
+areev-cal = { path = "../areev-cal", version = "1.2.2" }
+areev-loop = { path = "../areev-loop", version = "1.2.2" }
+areev-run = { path = "../areev-run", version = "1.2.2" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 rustls-pki-types = { version = "1.15", features = ["std"], optional = true }
-areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.1" }
+areev-loop-adapter = { path = "../areev-loop-adapter", version = "1.2.2" }
 serde_json = "1"
 
 [dev-dependencies]

--- a/crates/areev-store/Cargo.toml
+++ b/crates/areev-store/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["database-implementations", "caching"]
 postgres = ["dep:tokio-postgres", "tokio/net", "tokio/time"]
 
 [dependencies]
-areev-core = { path = "../areev-core", version = "1.2.1" }
+areev-core = { path = "../areev-core", version = "1.2.2" }
 # Pinned exactly: encryption-at-rest rides turso's experimental AES-256-GCM,
 # so the audited version is fixed until a deliberate, tested bump.
 turso = "=0.7.2"


### PR DESCRIPTION
Version bump + changelog for 1.2.2. Follows PR #37 (Workflows tab, Analytics tab, review-comment fixes). No functional changes beyond the version/changelog/index.js regen described in the release runbook.