### PR TITLE
anon: propagate known identities into scan_text/anonymize_text

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -849,6 +849,14 @@ are exempt with the reason stated in code: `subject_report` (the DSAR must
 disclose what is stored), `run_grains` (the runtime's machine replay), and
 the authz engine's grant recall (a pseudonymized principal would fail every
 check). The vocabulary is *pseudonymize* — no anonymity claim, anywhere.
+The free-text APIs (`scan_text`/`anonymize_text`) sit one layer up, on the
+facade, and stay pure-text-in/JSON-out — no store *writes* — but now read
+the store's known-identity table for the facade's default namespace, the
+same propagation table the grain-egress boundary builds: a subject already
+interned by an intake step is detectable in prose passed to these APIs too,
+not only in grain reads (issue #32). `AnonPolicy.known` is the
+caller-supplied complement — identities a host holds but never interned as
+a grain subject (a CRM row, an email header), each with its own category.
 
 ### Portability and provenance over lock-in
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ the pre-rename release history lives in that repository's `CHANGELOG.md`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Known-identity propagation now reaches `scan_text`/`anonymize_text`**
+  (#32): these free-text APIs read the store's known-identity table for the
+  facade's default namespace — the same propagation table grain-egress
+  reads already build — so a subject interned by an intake step (e.g. a
+  `subject` written under the namespace) is now detected/pseudonymized in
+  prose passed to these APIs too, not only in `recall`/CAL results.
+  `AnonPolicy` grows a `known: [{value, category}]` field so a caller can
+  also inject identities it holds but never interned as a grain subject
+  (an email's From header, a CRM row, a project codename), each with its
+  own detection category. Both APIs' signatures are unchanged; the
+  bindings pick this up with no code changes.
+
 ## [1.2.2] — 2026-08-18
 
 ### Added

--- a/crates/areev-cal/src/areev_facade.rs
+++ b/crates/areev-cal/src/areev_facade.rs
@@ -461,12 +461,24 @@ impl AreevFacade {
 
     // ---- text anonymization (docs/anonymization-proposal.md, P0) ----------
     //
-    // The explicit front door: pure text in, JSON out, no store access. From
-    // P1 on these same signatures grow policy-row lookup (`anon:<ns>`) and
-    // the session mapping table; the P0 caller supplies the policy explicitly
-    // and holds the mapping (D5 custody: an in-process caller already holds
-    // the raw file, so no gate applies here — the vaulted `reveal` path is
-    // the gated one).
+    // Text in, JSON out — no store WRITES, but reads the store's
+    // known-identity table for the facade's default namespace (issue #32):
+    // a subject already interned by an intake step (grain egress) is
+    // detectable in free text too, the same propagation table, one
+    // matcher. `policy_json` is still supplied explicitly by the caller
+    // (P0's contract; the declared `anon:<ns>` policy row is not
+    // auto-loaded here) and may carry its own `known` entries for
+    // identities the caller holds but never interned as a grain subject.
+
+    /// The facade's default namespace's accumulated known-identity list —
+    /// same table `egress_grains` builds for grain reads (issue #32). Empty
+    /// when the facade has no default namespace (bare `AreevFacade::new`).
+    fn known_identities(&self) -> Vec<String> {
+        match &self.namespace {
+            Some(ns) => self.with_store(|m| m.anon_known_identities(ns)),
+            None => Vec::new(),
+        }
+    }
 
     /// Run the Tier-0 detector chain over `text`. Returns JSON
     /// `{"text": <nfc text>, "detections": [{start, end, category,
@@ -477,7 +489,7 @@ impl AreevFacade {
             Some(j) => areev_core::anon::AnonPolicy::from_json(j)?,
             None => areev_core::anon::AnonPolicy::default(),
         };
-        let out = areev_core::anon::scan(text, &policy, &[])?;
+        let out = areev_core::anon::scan(text, &policy, &self.known_identities())?;
         serde_json::to_string(&out).map_err(|e| AreevError::Internal(e.to_string()))
     }
 
@@ -502,7 +514,8 @@ impl AreevFacade {
             })?),
             None => None,
         };
-        let out = areev_core::anon::anonymize(text, &policy, &[], key.as_deref())?;
+        let out =
+            areev_core::anon::anonymize(text, &policy, &self.known_identities(), key.as_deref())?;
         serde_json::to_string(&out).map_err(|e| AreevError::Internal(e.to_string()))
     }
 

--- a/crates/areev-cal/tests/anon_facade_tests.rs
+++ b/crates/areev-cal/tests/anon_facade_tests.rs
@@ -71,6 +71,66 @@ fn policy_errors_are_hard_val_errors() {
 }
 
 #[test]
+fn known_identities_propagate_from_the_store_into_free_text() {
+    // GitHub issue #32: a subject interned as a grain (the same way
+    // egress-grain reads build their propagation table) must now also be
+    // detectable/pseudonymizable through the free-text APIs, not only
+    // through recall/CAL — same matcher, same category assignment.
+    use areev_cal::{CalExecutor, CalExecutorConfig};
+
+    let (facade, _d) = setup();
+    facade
+        .with_store(|m| m.set_anon_policy("caller", r#"{"mode": "egress"}"#))
+        .unwrap();
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+    ex.execute(
+        r#"ADD fact SET subject = "Kenneth Shea" SET relation = "role" SET object = "sell-side banker" SET namespace = "caller" REASON "test""#,
+        &facade,
+    )
+    .unwrap();
+
+    let scanned = facade
+        .scan_text("Kenneth Shea sent the Project Falcon NDA.", None)
+        .unwrap();
+    let scanned: serde_json::Value = serde_json::from_str(&scanned).unwrap();
+    let cats: Vec<&str> = scanned["detections"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["category"].as_str().unwrap())
+        .collect();
+    assert!(cats.contains(&"person"), "scan missed the propagated subject: {cats:?}");
+
+    let out = facade
+        .anonymize_text("Kenneth Shea sent the Project Falcon NDA.", None, None)
+        .unwrap();
+    let out: serde_json::Value = serde_json::from_str(&out).unwrap();
+    let anon_text = out["text"].as_str().unwrap();
+    assert!(!anon_text.contains("Kenneth Shea"), "raw identity leaked: {anon_text}");
+    assert!(anon_text.contains("[PERSON_1]"), "expected pseudonym: {anon_text}");
+    // Project Falcon was never interned as a subject and the policy carried
+    // no `known` entry for it — it must be left alone.
+    assert!(anon_text.contains("Project Falcon"));
+}
+
+#[test]
+fn policy_known_lets_callers_inject_identities_the_store_never_interned() {
+    // Issue #32's suggested option 2: identities from outside the store
+    // (an email header, a CRM row) without writing them as grains first.
+    let (facade, _d) = setup();
+    let policy = r#"{"known": [{"value": "Project Falcon", "category": "custom"}]}"#;
+    let out = facade
+        .anonymize_text("Kenneth Shea sent the Project Falcon NDA.", Some(policy), None)
+        .unwrap();
+    let out: serde_json::Value = serde_json::from_str(&out).unwrap();
+    let anon_text = out["text"].as_str().unwrap();
+    assert!(!anon_text.contains("Project Falcon"), "{anon_text}");
+    assert!(anon_text.contains("[CUSTOM_1]"), "{anon_text}");
+    // Kenneth Shea is neither interned nor listed in `known` — untouched.
+    assert!(anon_text.contains("Kenneth Shea"));
+}
+
+#[test]
 fn cal_payload_carries_the_egress_flag_and_transformed_fields() {
     use areev_cal::{CalExecutor, CalExecutorConfig};
 

--- a/crates/areev-core/src/anon/detect.rs
+++ b/crates/areev-core/src/anon/detect.rs
@@ -404,6 +404,31 @@ fn identity_match_terms(identities: &[String]) -> Vec<String> {
     terms
 }
 
+/// `AnonPolicy.known` — caller-supplied identities (issue #32), grouped by
+/// each entry's own category rather than tier0's fixed `"person"`. Same
+/// boundary-checked verbatim matching and 3-char floor as
+/// [`identity_match_terms`], just without the colon-tail heuristic (that
+/// one is specific to store subject id shapes like `caller:john`; a bare
+/// caller-supplied value has no such convention to lean on).
+pub(super) fn run_known(
+    text: &str,
+    known: &[super::KnownIdentity],
+) -> Result<Vec<Detection>> {
+    let mut by_category: std::collections::BTreeMap<&str, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for k in known {
+        let value = k.value.trim();
+        if value.len() >= 3 {
+            by_category.entry(k.category.as_str()).or_default().push(value.to_string());
+        }
+    }
+    let mut out = Vec::new();
+    for (category, terms) in by_category {
+        detect_terms(text, &terms, category, "tier0.policy_known", &mut out)?;
+    }
+    Ok(out)
+}
+
 /// Case-insensitive, boundary-checked term matching for the user dictionary
 /// and known identities. Terms are matched verbatim (multi-word allowed).
 fn detect_terms(

--- a/crates/areev-core/src/anon/mod.rs
+++ b/crates/areev-core/src/anon/mod.rs
@@ -213,6 +213,30 @@ pub struct AnonPolicy {
     pub vault_ttl_days: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub because: Option<String>,
+    /// Caller-supplied identities to detect verbatim in free text (issue
+    /// #32's escape hatch): a host that hasn't interned the identity as a
+    /// grain subject first — an email's From header, a CRM row, a project
+    /// codename — still gets it detected and pseudonymized, without
+    /// writing it to the store just to make it detectable. Distinct from
+    /// the automatic propagation `scan_text`/`anonymize_text` already pull
+    /// from the store's own interned subjects for the call's namespace
+    /// (same table the grain-egress path builds).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub known: Vec<KnownIdentity>,
+}
+
+/// One entry of [`AnonPolicy::known`]: a bare value and the category it
+/// should be detected/pseudonymized as — not always `person` (a project
+/// codename is `custom`, say).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KnownIdentity {
+    pub value: String,
+    #[serde(default = "default_known_category")]
+    pub category: String,
+}
+
+fn default_known_category() -> String {
+    "person".to_string()
 }
 
 fn default_detectors() -> Vec<String> {
@@ -233,6 +257,7 @@ impl Default for AnonPolicy {
             vault: false,
             vault_ttl_days: None,
             because: None,
+            known: Vec::new(),
         }
     }
 }
@@ -341,6 +366,18 @@ impl AnonPolicy {
                 ));
             }
         }
+        for k in &self.known {
+            if k.value.trim().is_empty() {
+                return Err(AreevError::Validation(
+                    "invalid anonymization policy: empty known[].value entry".into(),
+                ));
+            }
+            if k.category.trim().is_empty() {
+                return Err(AreevError::Validation(
+                    "invalid anonymization policy: empty known[].category entry".into(),
+                ));
+            }
+        }
         Ok(())
     }
 
@@ -420,6 +457,9 @@ pub fn scan_with(
     } else {
         Vec::new()
     };
+    if !policy.known.is_empty() {
+        detections.extend(detect::run_known(&text, &policy.known)?);
+    }
     for kind in policy.detectors.iter().filter(|d| *d != "tier0") {
         let backend = backends
             .iter()

--- a/crates/areev-core/tests/anon_tests.rs
+++ b/crates/areev-core/tests/anon_tests.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeMap;
 
-use areev_core::anon::{anonymize, mapping_from_json, rehydrate, scan, AnonPolicy};
+use areev_core::anon::{anonymize, mapping_from_json, rehydrate, scan, AnonPolicy, KnownIdentity};
 use proptest::prelude::*;
 
 fn spans(text: &str) -> Vec<(String, String)> {
@@ -115,6 +115,30 @@ fn golden_dictionary_and_known_identities() {
     assert!(found.contains(&"john"), "tail propagation missed: {found:?}");
     assert!(found.contains(&"caller:john"), "full identity missed: {found:?}");
     assert!(!found.contains(&"johnson"), "boundary violated: {found:?}");
+}
+
+#[test]
+fn policy_known_identities_match_each_with_its_own_category() {
+    // GitHub issue #32's escape hatch: a caller-supplied `known` entry
+    // detects with the category IT names, not tier0's fixed "person" — a
+    // project codename is `custom`, not a person.
+    let policy = AnonPolicy {
+        known: vec![
+            KnownIdentity { value: "Kenneth Shea".into(), category: "person".into() },
+            KnownIdentity { value: "Project Falcon".into(), category: "custom".into() },
+            KnownIdentity { value: "ab".into(), category: "custom".into() }, // too short, dropped
+        ],
+        ..Default::default()
+    };
+    let out = scan("Kenneth Shea sent the Project Falcon NDA.", &policy, &[]).unwrap();
+    let found: BTreeMap<String, String> = out
+        .detections
+        .iter()
+        .map(|d| (out.text[d.start..d.end].to_string(), d.category.clone()))
+        .collect();
+    assert_eq!(found.get("Kenneth Shea"), Some(&"person".to_string()));
+    assert_eq!(found.get("Project Falcon"), Some(&"custom".to_string()));
+    assert_eq!(found.len(), 2, "the sub-3-char entry must not match: {found:?}");
 }
 
 #[test]

--- a/crates/areev-store/src/anon_gate.rs
+++ b/crates/areev-store/src/anon_gate.rs
@@ -366,6 +366,14 @@ impl AnonGate {
         }
     }
 
+    /// The ns's accumulated identity list — the read side of the same
+    /// propagation table `egress_grains` builds, exposed so callers that
+    /// aren't reading grains (issue #32's free-text APIs) can consult it
+    /// too. Empty for an ns with no declared policy and no floor.
+    pub(crate) fn known_for(&self, ns: &str) -> Vec<String> {
+        self.known.get(ns).cloned().unwrap_or_default()
+    }
+
     pub(crate) fn install_backend(&mut self, backend: Box<dyn DetectorBackend>) {
         self.backends.insert(backend.kind().to_string(), backend);
     }

--- a/crates/areev-store/src/lib.rs
+++ b/crates/areev-store/src/lib.rs
@@ -2307,6 +2307,16 @@ impl Areev {
         Ok(out)
     }
 
+    /// The ns's accumulated known-identity list (issue #32) — the same
+    /// propagation table `egress_grains` consults to catch a bare subject
+    /// mention in grain prose, exposed so free-text callers that never go
+    /// through a grain read (`scan_text`/`anonymize_text`) can pass it to
+    /// `areev_core::anon::scan`/`anonymize` as `known_identities` too.
+    /// Empty for an ns with no declared policy and no floor.
+    pub fn anon_known_identities(&self, ns: &str) -> Vec<String> {
+        self.anon.known_for(ns)
+    }
+
     fn reload_anon_policies(&mut self) -> Result<()> {
         let rows = self.meta_scan(anon_gate::ANON_PREFIX)?;
         self.anon.reload(&rows);

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -846,6 +846,29 @@ final = json.loads(m.rehydrate_text(reply, json.dumps(mapping)))["text"]
 CAL payloads carry an `anonymized` report with mapping **ids** only — the
 mapping itself never rides a payload; the host process rehydrates.
 
+The free-text APIs (`scan_text`/`anonymize_text`) propagate the same
+interned-subject table — a name written as a `subject` under the handle's
+namespace is caught in prose you scan/anonymize directly, not only in
+grain reads:
+
+```python
+m = areev.Areev("support.db", ns="caller")
+m.add_fact("Kenneth Shea", "role", "sell-side banker", ns="caller")
+m.set_anon_policy("caller", json.dumps({"mode": "egress"}))
+
+out = json.loads(m.anonymize_text("Kenneth Shea sent the Project Falcon NDA.", None, None))
+out["text"]   # "[PERSON_1] sent the Project Falcon NDA."
+```
+
+For identities you hold but never interned as a grain subject — an email's
+From header, a CRM row, a project codename — pass them straight in the
+policy's `known` list, each with its own category:
+
+```python
+policy = json.dumps({"known": [{"value": "Project Falcon", "category": "custom"}]})
+out = json.loads(m.anonymize_text("...Project Falcon...", policy, None))
+```
+
 Cross-process reconstruction needs the sealed vault (encrypted memory):
 
 ```bash

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -73,6 +73,14 @@ top of that.
   never identities. Pseudonym mappings otherwise stay in process custody:
   bounded in memory, returned only to in-process callers, and carried on
   MCP/server payloads as mapping **ids** only.
+- **The free-text APIs read, never write, the trust boundary.**
+  `scan_text`/`anonymize_text` stay pure-text-in/JSON-out (no grain writes),
+  but they now read the store's known-identity table for the facade's
+  default namespace — the same propagation table grain-egress reads
+  already build — so a subject interned by an intake step is caught in
+  prose passed to these APIs too. `AnonPolicy.known` lets a caller inject
+  identities it holds but never interned as a grain subject, each with an
+  explicit category; those never touch the store either.
 
 ### Known limitations at rest
 


### PR DESCRIPTION
Closes #32.

`scan_text`/`anonymize_text` always passed `known_identities=[]` to the
core anon functions, so a subject already interned by the store (the
same propagation table grain-egress reads consult) was never detected
in free text — only the structured egress path (recall/CAL) caught it.

## Platform fix (option 1 in the issue)

`AreevFacade::scan_text`/`anonymize_text` now pull the facade's default
namespace's known-identity list via a new `Areev::anon_known_identities`
store accessor (`AnonGate::known_for`) — the read side of the table
`egress_grains` already builds. **No signature change**: both methods
keep their existing `(text, policy_json[, key_hex])` shape, so the
Python and Node bindings pick this up with zero code changes.

## Client escape hatch (option 2 in the issue)

`AnonPolicy` grows `known: [{value, category}]` — a caller-supplied
list for identities that were never interned as a grain subject (an
email header, a CRM row, a project codename), each detected under its
own category rather than tier0's fixed `"person"`.

## Tests

- `areev-core`: `policy_known_identities_match_each_with_its_own_category`
- `areev-cal`: `known_identities_propagate_from_the_store_into_free_text`,
  `policy_known_lets_callers_inject_identities_the_store_never_interned`
  — reproduce the issue's exact `Kenneth Shea` / `Project Falcon` scenario
  end to end.

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` both green.

## Docs

ARCHITECTURE.md §10, docs/security-model.md, docs/cookbook.md recipe 16, CHANGELOG.md.