### PR TITLE
run: a cycle's back-edge can close on any node, not just the entry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -858,6 +858,23 @@ not only in grain reads (issue #32). `AnonPolicy.known` is the
 caller-supplied complement — identities a host holds but never interned as
 a grain subject (a CRM row, an email header), each with its own category.
 
+### A cycle's back-edge gates a node's own first activation, not the entry's
+
+A bounded cycle's re-entry point can be **any** node, not only the plan's
+entry — `PlanGraph::build` classifies every edge as a DFS back-edge (via
+the entry-rooted Tarjan traversal already computing `scc_of`) or not, and
+`refresh_readiness` excludes an in-edge from a node's *generation-0*
+AND-join exactly when it's a back-edge: such an edge closes a cycle through
+that very node, so it cannot possibly have resolved before the node's own
+first run. Node 0 needed no such rule — it bootstraps unconditionally
+(`apply_event`'s `Start` handler) — but nothing generalized the idea to a
+non-entry cycle head, so a plan like `a -> g -> c -> g` (back-edge to `g`,
+not `a`) validated cleanly and then deadlocked at superstep 1 (issue #33).
+Removing exactly the DFS back-edges of an entry-rooted traversal always
+leaves an acyclic graph — a standard theorem — which is what makes the
+generalization safe for arbitrary cycle shapes, not just the single-node
+self-loop or entry-targeted back-edge the original scheduler handled.
+
 ### Portability and provenance over lock-in
 
 Grains are content-addressed, immutable, and hash-linked; the format reserves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ the pre-rename release history lives in that repository's `CHANGELOG.md`.
   (an email's From header, a CRM row, a project codename), each with its
   own detection category. Both APIs' signatures are unchanged; the
   bindings pick this up with no code changes.
+- **A cycle's back-edge can now close on any node, not only the plan's
+  entry** (#33): a bounded cycle whose re-entry point was a mid-graph node
+  (e.g. `analyze -> notify -> gate -> converse -> gate`, the back-edge
+  targeting `gate`) validated cleanly and then stalled the run at the
+  entry on superstep 1, because the scheduler's AND-join gate required
+  that not-yet-resolvable back-edge before the node could ever go Ready —
+  a rule only the entry node's unconditional bootstrap sidestepped.
+  `PlanGraph` now classifies every edge as a DFS back-edge or not (from
+  the same entry-rooted Tarjan traversal that already computes `scc_of`),
+  and a node's first activation only gates on edges that could possibly
+  have resolved by then. `run oversight-report`'s stall diagnosis also no
+  longer blames the entry node when its own edge fired correctly.
 
 ## [1.2.2] — 2026-08-18
 

--- a/crates/areev-run-core/src/plan.rs
+++ b/crates/areev-run-core/src/plan.rs
@@ -38,6 +38,16 @@ pub struct PlanGraph {
     pub in_edges: Vec<Vec<usize>>,
     /// Per node: SCC id (condensation vertex).
     pub scc_of: Vec<usize>,
+    /// Per edge: true iff it is a DFS back-edge in the entry-rooted
+    /// traversal (its destination is an ancestor on the recursion path
+    /// when the edge is walked) — i.e. it closes a cycle. Removing exactly
+    /// the back-edges always leaves an acyclic graph (a standard DFS
+    /// edge-classification theorem), which is what lets the scheduler
+    /// treat a cycle's re-entry point as ANY node, not only the plan's
+    /// entry: a back-edge into node `i` cannot possibly have resolved
+    /// before `i`'s own first run, so `step.rs::refresh_readiness` excludes
+    /// it from `i`'s generation-0 AND-join (RUN issue #33).
+    pub cycle_edge: Vec<bool>,
     /// Per node: re-attempt budget (`retries[n] = n` re-attempts, so up to
     /// n+1 executions — §6.3's pinned reading of the field).
     pub retries: Vec<u32>,
@@ -146,7 +156,7 @@ impl PlanGraph {
         // cycle (size > 1, or a self-loop), at least one intra-SCC edge must
         // set max_cycles. Tarjan, iterative (plans are small, but a deep
         // chain must not blow the stack).
-        let scc_of = tarjan_scc(n, &out_edges, &edges);
+        let (scc_of, cycle_edge) = tarjan_scc(n, &out_edges, &edges);
         let mut scc_nodes: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
         for (v, &c) in scc_of.iter().enumerate() {
             scc_nodes.entry(c).or_default().push(v);
@@ -182,6 +192,7 @@ impl PlanGraph {
             out_edges,
             in_edges,
             scc_of,
+            cycle_edge,
             retries,
             bindings,
         })
@@ -195,14 +206,28 @@ impl PlanGraph {
     }
 }
 
-/// Iterative Tarjan SCC. Returns the SCC id per vertex (ids are arbitrary
-/// but deterministic for a given graph).
-fn tarjan_scc(n: usize, out_edges: &[Vec<usize>], edges: &[PlanEdge]) -> Vec<usize> {
+/// Iterative Tarjan SCC, plus the entry-rooted DFS back-edge classification
+/// (see `PlanGraph::cycle_edge`'s doc). Returns (SCC id per vertex, back-edge
+/// flag per edge); SCC ids are arbitrary but deterministic for a given
+/// graph.
+///
+/// The back-edge flag rides the same traversal via one extra array,
+/// `in_frame`: true while a vertex is on the *current DFS recursion path*
+/// (pushed when a frame opens, cleared when it closes) — a strictly
+/// narrower set than `on_stack`, which also holds vertices whose frame
+/// already closed but whose SCC hasn't (the cross-edge case, e.g. a
+/// diamond's second incoming arm into an SCC member). An edge whose target
+/// is `in_frame` is a genuine ancestor edge (a back-edge); an edge whose
+/// target is merely `on_stack` but not `in_frame` is a cross/forward edge
+/// and must stay a normal AND-join requirement.
+fn tarjan_scc(n: usize, out_edges: &[Vec<usize>], edges: &[PlanEdge]) -> (Vec<usize>, Vec<bool>) {
     const UNSET: usize = usize::MAX;
     let mut idx = vec![UNSET; n];
     let mut low = vec![0usize; n];
     let mut on_stack = vec![false; n];
+    let mut in_frame = vec![false; n];
     let mut scc_of = vec![UNSET; n];
+    let mut back_edge = vec![false; edges.len()];
     let mut stack: Vec<usize> = Vec::new();
     let mut next_index = 0usize;
     let mut next_scc = 0usize;
@@ -218,6 +243,7 @@ fn tarjan_scc(n: usize, out_edges: &[Vec<usize>], edges: &[PlanEdge]) -> Vec<usi
         next_index += 1;
         stack.push(root);
         on_stack[root] = true;
+        in_frame[root] = true;
 
         while let Some(&mut (v, ref mut ei_pos)) = frames.last_mut() {
             if *ei_pos < out_edges[v].len() {
@@ -230,12 +256,19 @@ fn tarjan_scc(n: usize, out_edges: &[Vec<usize>], edges: &[PlanEdge]) -> Vec<usi
                     next_index += 1;
                     stack.push(w);
                     on_stack[w] = true;
+                    in_frame[w] = true;
                     frames.push((w, 0));
-                } else if on_stack[w] {
-                    low[v] = low[v].min(idx[w]);
+                } else {
+                    if on_stack[w] {
+                        low[v] = low[v].min(idx[w]);
+                    }
+                    if in_frame[w] {
+                        back_edge[ei] = true;
+                    }
                 }
             } else {
                 frames.pop();
+                in_frame[v] = false;
                 if let Some(&mut (parent, _)) = frames.last_mut() {
                     low[parent] = low[parent].min(low[v]);
                 }
@@ -253,7 +286,7 @@ fn tarjan_scc(n: usize, out_edges: &[Vec<usize>], edges: &[PlanEdge]) -> Vec<usi
             }
         }
     }
-    scc_of
+    (scc_of, back_edge)
 }
 
 #[cfg(test)]

--- a/crates/areev-run-core/src/step.rs
+++ b/crates/areev-run-core/src/step.rs
@@ -1299,12 +1299,30 @@ fn deliver(env: &StepEnv<'_>, st: &mut SchedulerState, ei: usize, fired: bool) -
 
 /// Waiting → Ready when no in-edge is Pending and ≥1 Fired; → Dead when all
 /// resolved and none Fired (§6.2: edges must RESOLVE, not fire).
+///
+/// A node's FIRST generation (`node_gen[i] == 0`) only gates on in-edges
+/// that could possibly have resolved by then: a back-edge that closes a
+/// cycle through this very node (`env.plan.cycle_edge`) cannot fire before
+/// the node's own first run, so requiring it here would deadlock any cycle
+/// whose re-entry point isn't the plan's entry node (RUN issue #33) — every
+/// OTHER in-edge into a reachable non-root node is guaranteed non-back (the
+/// DFS tree edge that first discovered it, at minimum), so this never
+/// starves a node of every gating edge. The entry node sidesteps this rule
+/// entirely via an unconditional bootstrap (`apply_event`'s `Start`
+/// handler), since it may have zero in-edges at all. Once a node is
+/// re-entered (generation ≥ 1), `deliver`'s re-entry branch already
+/// resolves every other in-edge from concrete current node state, so the
+/// full AND-join applies again from generation 1 onward.
 fn refresh_readiness(env: &StepEnv<'_>, st: &mut SchedulerState, i: usize) {
     if st.node_state[i] != NodeState::Waiting {
         return;
     }
     let ins = &env.plan.in_edges[i];
-    if !ins.iter().all(|e| st.in_res[i].contains_key(e)) {
+    let gen0 = st.node_gen[i] == 0;
+    let all_gated_resolved = ins
+        .iter()
+        .all(|&e| (gen0 && env.plan.cycle_edge[e]) || st.in_res[i].contains_key(&e));
+    if !all_gated_resolved {
         return;
     }
     let any_fired = ins.iter().any(|e| st.in_res[i].get(e) == Some(&EdgeRes::Fired));
@@ -1345,6 +1363,15 @@ fn stalled_culprit(env: &StepEnv<'_>, st: &SchedulerState) -> String {
             && !env.plan.out_edges[i].is_empty()
             && env.plan.out_edges[i].iter().all(|&ei| st.edge_fired[ei] == 0)
         {
+            return env.plan.nodes[i].clone();
+        }
+    }
+    // No completed node's own out-edges explain it (every completed node
+    // fired something downstream) — name the lowest-index node that never
+    // got a chance to run at all, the actual culprit, rather than blaming
+    // the entry unconditionally when its own edge fired correctly.
+    for i in 0..env.plan.nodes.len() {
+        if st.node_state[i] == NodeState::Waiting {
             return env.plan.nodes[i].clone();
         }
     }

--- a/crates/areev-run-core/tests/scheduler_tests.rs
+++ b/crates/areev-run-core/tests/scheduler_tests.rs
@@ -290,6 +290,105 @@ fn bounded_self_loop_iterates_exactly_max_cycles_plus_one_runs() {
 }
 
 #[test]
+fn cycle_whose_back_edge_targets_a_non_entry_node_parks_instead_of_stalling() {
+    // GitHub issue #33's exact repro shape: a -> g, g -> c (cond +
+    // max_cycles), c -> g — the back-edge closes the cycle on `g`, NOT on
+    // the plan's entry `a`. Before the fix, `refresh_readiness` required
+    // the not-yet-resolvable `c -> g` edge before `g` could ever go Ready,
+    // so the run stalled naming "a" on superstep 1 — even though `a`'s own
+    // edge fired — and `g` was never dispatched at all.
+    let mut w = wf(&["a", "g", "c"])
+        .edge("a", "g")
+        .cond_edge("g", "c", "decision == \"question\"");
+    w.edges[1].max_cycles = Some(6);
+    w.edges.push(areev_core::types::WorkflowEdge {
+        src: "c".into(),
+        dst: "g".into(),
+        cond: None,
+        max_cycles: None,
+    });
+    let plan = PlanGraph::build(&w).unwrap();
+    let mut execs = host_execs(&plan);
+    execs[1] = NodeExecutor::Client { tool_hash: "cafe".into(), tool_name: "g".into() };
+    let behavior = |key: &JournalKey, _in: &Value| ok(json!({key.node.clone(): true}));
+
+    let r = Sim {
+        env: env(&plan, &execs, Budgets::default()),
+        behavior: &behavior,
+        seed: 9,
+        clock: 1_000,
+        respond: BTreeMap::new(),
+    }
+    .run();
+
+    assert!(!r.state.is_terminal(), "must park on g's ask, not finish stalled");
+    assert_eq!(r.state.pending_asks.len(), 1);
+    let ask_id = r.state.pending_asks.keys().next().unwrap().clone();
+    // The ask id is the journal key digest for g's first attempt — proof
+    // the park landed on g, not on a stall diagnosis naming a.
+    let expect_key = JournalKey {
+        run_id: "run-1".into(),
+        task_path: "".into(),
+        node: "g".into(),
+        attempt: 1,
+        effect_seq: 0,
+        kind: EffectKind::Tool,
+    };
+    assert_eq!(ask_id, expect_key.tool_call_id(), "parked on g's ask, not stalled at a");
+}
+
+#[test]
+fn all_host_cycle_whose_back_edge_targets_a_non_entry_node_iterates_correctly() {
+    // Same shape, no Client node (the issue's "not the client node" check)
+    // — driven far enough to prove `g` and `c` both re-enter correctly
+    // across generations, not just that the very first dispatch succeeds.
+    let mut w = wf(&["a", "g", "c"])
+        .edge("a", "g")
+        .cond_edge("g", "c", "decision == \"question\"");
+    w.edges[1].max_cycles = Some(2);
+    w.edges.push(areev_core::types::WorkflowEdge {
+        src: "c".into(),
+        dst: "g".into(),
+        cond: None,
+        max_cycles: None,
+    });
+    let plan = PlanGraph::build(&w).unwrap();
+    let execs = host_execs(&plan);
+    let behavior = |key: &JournalKey, input: &Value| match key.node.as_str() {
+        "g" => {
+            let runs = input.get("g_runs").and_then(|v| v.as_i64()).unwrap_or(0);
+            ok(json!({"decision": "question", "g_runs": runs + 1}))
+        }
+        "c" => {
+            let runs = input.get("c_runs").and_then(|v| v.as_i64()).unwrap_or(0);
+            ok(json!({"c_runs": runs + 1}))
+        }
+        _ => ok(json!({key.node.clone(): true})),
+    };
+
+    let r = Sim {
+        env: env(&plan, &execs, Budgets::default()),
+        behavior: &behavior,
+        seed: 13,
+        clock: 1_000,
+        respond: BTreeMap::new(),
+    }
+    .run();
+
+    // g dispatches once per generation (0, 1, 2 — the third g->c attempt
+    // exhausts max_cycles=2); c runs once per successfully fired loop edge.
+    assert_eq!(r.state.context["g_runs"], json!(3), "g ran across three generations");
+    assert_eq!(r.state.context["c_runs"], json!(2), "c ran once per fired loop edge");
+    let exhausted = r
+        .checkpoints
+        .iter()
+        .flat_map(|c| &c.edges)
+        .filter(|(_, _, o)| *o == EdgeOutcome::CycleExhausted)
+        .count();
+    assert_eq!(exhausted, 1, "the bounded edge reports exhaustion exactly once");
+}
+
+#[test]
 fn retryable_failures_retry_within_budget_then_succeed() {
     let w = wf(&["flaky", "next"]).edge("flaky", "next");
     let mut w = w;

--- a/docs/run.md
+++ b/docs/run.md
@@ -112,7 +112,10 @@ What each piece means:
 - **`max_cycles`** — the loop-authoring primitive. Cycles are legal, but
   every cycle must carry at least one `max_cycles`-bounded edge or the plan
   is refused at load (`RUN-E002` — an unbounded loop is a bug, not a
-  feature).
+  feature). The cycle's re-entry point can be **any** node in the loop —
+  above, the back-edge closes on `fetch`, the entry, but a mid-graph gate
+  (`notify -> gate -> converse -> gate`, the back-edge targeting `gate`,
+  not the entry) works identically.
 - **`reducers`** — per-state-key merge functions, frozen into the manifest:
   `lww` (the default for undeclared keys), `append`, `sum`, `max`, `min`.
   They are law-tested for batching invariance, which is what makes fan-out


### PR DESCRIPTION
Closes #33.

A plan whose bounded cycle's back-edge targeted a **non-entry** node
(`a -> g -> c -> g`, back-edge to `g`) passed plan validation — the
cycle carries a `max_cycles` edge, so no `RUN-E002` — but stalled at
`"a"` on superstep 1, before the cycle was ever reached.

## Root cause

`g`'s other in-edge (the back-edge `c -> g`) could never resolve
before `g`'s own first run, so `refresh_readiness`'s full AND-join
never let `g` go `Ready`; only node 0 sidestepped this via its
unconditional `Start`-event bootstrap.

## Fix

`PlanGraph::build` now classifies every edge as a DFS back-edge or not
(`in_frame` tracking added to the existing entry-rooted Tarjan
traversal, alongside the `on_stack` set it already computes for
`scc_of`) and stores it as a per-edge `cycle_edge: Vec<bool>`.
`refresh_readiness` excludes an in-edge from a node's *generation-0*
AND-join exactly when it's a back-edge — every other in-edge into a
reachable non-root node is guaranteed non-back (the DFS tree edge that
discovered it, at minimum), so this never starves a node of every
gating edge.

Removing exactly the DFS back-edges of an entry-rooted traversal always
leaves an acyclic graph (a standard theorem), which is what makes this
safe for arbitrary cycle shapes, not just a self-loop or an
entry-targeted back-edge — i.e. this is a general scheduler fix, not a
narrow patch for the reported repro shape.

Also fixed: `stalled_culprit`'s diagnosis no longer falls back to
blaming the entry node when its own out-edge fired correctly; it now
names the first node that never got a chance to run.

## Tests

`crates/areev-run-core/tests/scheduler_tests.rs`: a Client-ask variant
matching the issue's exact repro, and an all-host variant driven across
three generations to prove the cycle iterates correctly, not just that
the first dispatch succeeds. **Both fail without the fix** (verified by
temporarily reverting it before writing this PR description).

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` both green.

## Docs

ARCHITECTURE.md §10, docs/run.md, CHANGELOG.md.