### PR TITLE
ci: group the RustCrypto crates into one Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,21 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: deps
+    groups:
+      # The RustCrypto crates version in lockstep around `digest`: sha2 0.11 /
+      # hkdf 0.13 / aes-gcm 0.11 are digest-0.11, and mixing generations does
+      # not compile (see PRs #12, #8, #13). One grouped PR keeps the migration
+      # atomic — and it should wait until turso leaves the digest-0.10 line,
+      # or the tree carries two copies of the AES/GCM stack.
+      rustcrypto:
+        patterns:
+          - "sha2"
+          - "hkdf"
+          - "hmac"
+          - "aes-gcm"
+          - "argon2"
+          - "getrandom"
+          - "digest"
 
   # Node bindings (napi) — standalone package, not in the Cargo workspace.
   - package-ecosystem: npm


### PR DESCRIPTION
The RustCrypto crates (sha2, hkdf, hmac, aes-gcm, argon2, getrandom, digest) version in lockstep around the `digest` generation — piecemeal bumps do not compile, as the current Dependabot PRs demonstrate (verified locally against the codebase):

- #12 (sha2 0.11): 10 compile errors in areev-store — hkdf 0.12/hmac 0.12/aes-gcm 0.10 require digest-0.10 types
- #8 (hkdf 0.13): 5 compile errors — the mirror image
- #13 (aes-gcm 0.11): compiles, but clippy `-D warnings` fails on deprecated `Nonce::from_slice`, and turso_core still pins aes-gcm 0.10.3 so the tree would carry two copies of the AES/GCM stack

This groups them so the digest-0.11 migration arrives as one atomic PR — to be taken deliberately once turso leaves the digest-0.10 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)