### PR TITLE
Fix the 1.2.2 evaluation findings (#42–#50) and the loop's definition-rewrite gap (#28)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write, not read: the /code-review plugin posts its verdict with
+      # `gh pr comment`, which is an issue-comment write.
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,8 +40,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # `--allowedTools` REPLACES the session allowlist — it does not add to
+          # a default set. Restricted to the inline-comment MCP tool alone, the
+          # plugin could not run at all: it fetches the PR with `gh pr diff` /
+          # `gh pr view`, fans out to Haiku/Sonnet sub-agents (Task), and posts
+          # its verdict with `gh pr comment`. Every one of those was denied.
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*)"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,10 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      # write, not read: the /code-review plugin posts its verdict with
-      # `gh pr comment`, which is an issue-comment write.
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
 
     steps:
@@ -40,13 +38,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # `--allowedTools` REPLACES the session allowlist — it does not add to
-          # a default set. Restricted to the inline-comment MCP tool alone, the
-          # plugin could not run at all: it fetches the PR with `gh pr diff` /
-          # `gh pr view`, fans out to Haiku/Sonnet sub-agents (Task), and posts
-          # its verdict with `gh pr comment`. Every one of those was denied.
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*)"'
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,13 +1,13 @@
-# Publish the Node bindings (crates/areev-js) to npm as `areev`.
+# Publish the Node bindings (crates/areev-js) to npm as `@areev/areev`.
 #
 # napi-rs ships a native addon per platform. This builds the `.node` for each
 # target, then publishes one small platform package per target
-# (`areev-<platform>`) plus the thin main package that loads the right one at
+# (`@areev/areev-<platform>`) plus the thin main package that loads the right one at
 # runtime via optionalDependencies (the layout the review flagged as missing).
 #
 # Trigger: on a published GitHub Release (tag `vX.Y.Z`) or manual dispatch.
-# Prerequisite secret: `NPM_TOKEN` (an npm automation token for the `areev`
-# package / the account that owns it).
+# Prerequisite secret: `NPM_TOKEN` (an npm automation token for the `@areev`
+# scope / the account that owns it).
 #
 # NOTE: native cross-platform CI is finicky — watch the first release run and
 # adjust the target matrix / napi flags to your installed @napi-rs/cli (v3) if a
@@ -138,17 +138,22 @@ jobs:
         run: npx napi artifacts
       - name: Publish platform packages + main to npm
         # We do NOT use `napi prepublish` here: it publishes every platform
-        # package in one shot and aborts the whole release if one fails —
-        # useful if any single platform name ever trips npm's spam filter
-        # (403 on publish) and needs to be deferred without taking the whole
-        # release down with it.
+        # package in one shot, and we want the main package to go out LAST so
+        # a half-published release never advertises a platform that is not on
+        # the registry yet.
         #
-        # Instead `prepare-npm.mjs` stamps versions, wires the main package's
-        # optionalDependencies to ALL platforms (incl. any deferred one, so a
-        # later same-version publish resolves for installs), and prints the dirs
-        # to publish now. We publish each, skipping anything already on the
-        # registry so re-runs are idempotent — including a later run that
-        # un-defers a package, which then publishes only the missing one.
+        # `prepare-npm.mjs` asserts that every target in `napi.targets` built,
+        # stamps versions, wires optionalDependencies, and prints the dirs to
+        # publish. Publishes skip anything already on the registry, so re-runs
+        # are idempotent.
+        #
+        # Both the main package and the per-platform packages are SCOPED
+        # (`@areev/areev`, `@areev/areev-win32-x64-msvc`, …). The unscoped
+        # `areev-*` names are rejected by npm's similarity/spam filter; every
+        # release before 1.2.3 worked around that by warning past the Windows
+        # 403 and shipping a manifest that promised a package npm had refused
+        # — which broke `require()` on Windows. Scoping removes the filter from
+        # the release path entirely, so any 403 here is now a real failure.
         run: |
           set -euo pipefail
           publish_if_absent() { # $1 = package name, $2 = version, $3 = dir
@@ -163,38 +168,11 @@ jobs:
           for dir in "${DIRS[@]}"; do
             name=$(node -p "require('./$dir/package.json').name")
             ver=$(node -p "require('./$dir/package.json').version")
-            if ! publish_if_absent "$name" "$ver" "$dir"; then
-              # areev-win32-x64-msvc is blocked by npm's spam filter. The
-              # prior whitelist (2026-07-17) covered the FORMER name
-              # dejadb-win32-x64-msvc only; the areev-* exception is a new
-              # request, user-tracked with npm support (see CLAUDE.md
-              # "Naming"). Windows users build from source meanwhile — the
-              # one blocked platform package must not abort the loop and
-              # leave the MAIN package unpublished (exactly how v1.1.0's
-              # first publish run failed). Any other failure hard-fails.
-              if [ "$name" = "areev-win32-x64-msvc" ]; then
-                echo "::warning::$name@$ver rejected by npm spam filter (pending support exception) — continuing without the Windows prebuild"
-              else
-                exit 1
-              fi
-            fi
+            publish_if_absent "$name" "$ver" "$dir"
           done
           main_name=$(node -p "require('./package.json').name")
           main_ver=$(node -p "require('./package.json').version")
-          if ! publish_if_absent "$main_name" "$main_ver" "."; then
-            # The unscoped main name is still behind npm's similarity filter
-            # ("too similar to existing package argv"; support exception
-            # pending — see CLAUDE.md "Naming"). Ship the scoped package
-            # instead: the shape every release since 1.0.0 actually has on
-            # the registry. The day npm unblocks the unscoped name, the
-            # publish above simply succeeds and this fallback stops firing.
-            # Safe to rename here: prepare-npm.mjs already wired the version
-            # and optionalDependencies, and binary loading keys on
-            # napi.binaryName, not the registry name.
-            echo "::warning::unscoped $main_name@$main_ver rejected by npm similarity filter — publishing @areev/areev instead"
-            node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.name='@areev/areev';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
-            publish_if_absent "@areev/areev" "$main_ver" "."
-          fi
+          publish_if_absent "$main_name" "$main_ver" "."
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -910,6 +910,96 @@ leaves an acyclic graph — a standard theorem — which is what makes the
 generalization safe for arbitrary cycle shapes, not just the single-node
 self-loop or entry-targeted back-edge the original scheduler handled.
 
+### Pinned literal sections in `ASSEMBLE` (`LITERAL` + `PIN`)
+
+**Decision (2026-08-19, issue #42):** `ASSEMBLE` sources may be host-supplied
+literal text (`label: LITERAL "…"`) and may be marked non-degradable
+(`label: PIN …`). This is **new CAL syntax ahead of the OMS spec**, recorded
+here deliberately — the same posture `DEFINE QUERY` already has.
+
+Why it had to be syntax rather than a host wrapper: a production system prompt
+is not "some grains", it is grains **interleaved with fixed text at fixed
+positions**, and some of that text is legally or contractually mandatory. Two
+things were expressible nowhere. First, a literal: to include a fixed
+instruction the host had to write it into memory as a grain, which turns a
+compliance-critical string into a mutable row rather than code. Second,
+non-degradability: `PRIORITY` only *weights* the budget split, and the
+progressive-disclosure allocator walks every source Full→Summary→Omit — so a
+long conversation could silently summarise away the one section that had to
+survive verbatim. Neither is expressible by weighting, because both are about
+a source's **kind**, not its share.
+
+Mechanism: pinned sources are costed in full and reserved off the top; the
+remaining budget is shared by `PRIORITY` as before; the trim loop never
+touches a pin. If the pins alone exceed `BUDGET` the statement fails with
+`CAL-E122` rather than degrading them — for a guarantee of verbatim
+disclosure there is no honest partial answer, and a quiet one is the unsafe
+outcome. Render order is FROM-clause order and is now a documented contract
+with a test, explicitly independent of `PRIORITY`.
+
+Related, same change: **out-of-order `ASSEMBLE` clauses are a parse error.**
+They used to detach silently, so `… FORMAT markdown BUDGET 900` ran at the
+4000-token default — the guard you wrote was not the guard that ran.
+
+### One anonymization root, separate from encryption at rest
+
+**Decision (2026-08-19, issue #46):** the HKDF root for the anonymization
+subkeys (session / memory / vault) is `AreevOptions::anon_key` when the host
+supplies one, else the page-cipher key.
+
+Reversible pseudonymisation — replace identities before an LLM egress,
+rehydrate the reply — was keyed *only* from the page cipher, which the Postgres
+backend refuses outright because it is a page-cipher capability. So the backend
+built for stateless hosts could not use the egress control built for untrusted
+egress, and deterministic value-derived tokens were unavailable on plaintext
+files too. Making the root a first-class, host-supplied capability fixes both
+at once and lets a memory be encrypted at rest under one key and pseudonymised
+under another — which is what separating those two roles is for. The key is
+never persisted; rotating it is a crypto-erasure of the mapping table. Trust
+model in [`docs/security-model.md`](docs/security-model.md).
+
+### Credentials are minted per request, not read once
+
+**Decision (2026-08-19, issue #45):** LLM backends hold a
+`areev_llm::cred::Credential`, not a `String`.
+
+A static key read once from an environment variable excludes every
+cloud-native auth model — Vertex AI under Application Default Credentials,
+Azure managed identity, AWS SigV4 — which exist precisely so that no key sits
+on disk. Those are not a larger version of "read a key from the environment";
+many organizations forbid creating such keys at all. The seam is deliberately
+narrow (mint the auth value, refresh it) so the endpoint and header stay with
+the backend. The Vertex adapter reuses the OpenAI-compatible client against the
+**regional** `aiplatform` host — the region is never defaulted and `global` is
+refused, because under a residency obligation the region is the entire point.
+Providers are individually feature-gated, and a third-party model router
+(OpenRouter) is off by default: it is an extra jurisdiction in the transfer
+path, and a regulated build should be able to state that its artifact cannot
+reach one.
+
+### LIMIT bounds the answer, not the search for it
+
+**Decision (2026-08-19, issue #43):** any post-retrieval pipeline stage that
+ranks, filters or counts widens its scan to `max_limit` and re-applies the
+caller's bound afterwards, warning (`CAL-W015`) when even the widened scan
+fills.
+
+`ORDER BY` sorts what the statement already returned, which is a
+`default_limit` page — so `ORDER BY priority DESC | LIMIT 5` returned the top
+5 *of the newest 50* and was indistinguishable from the top 5 overall.
+`CONTRADICTIONS` had already solved this for itself, with a comment explaining
+why; this generalizes that fix to every stage with the same shape rather than
+leaving it a one-off.
+
+True sort pushdown is possible for exactly one field. `created_at` is a column
+on `grains`, so it is pushed into the scan and is exact at any corpus size.
+Every other sort key callers actually use — `priority`, `status`,
+`confidence`, every type-specific field — lives **inside the immutable,
+content-addressed blob**, where SQL cannot reach it without materializing a
+column per field. That is a consequence of content addressing, not an
+oversight, and the honest response is to widen and then say so rather than to
+imply an exactness the storage model cannot provide.
+
 ### Portability and provenance over lock-in
 
 Grains are content-addressed, immutable, and hash-linked; the format reserves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,20 @@ before it was fixed.
   names, which the filter does not reject — Windows works rather than being
   dropped. `prepare-npm.mjs` now hard-fails a release when a declared target
   produced no artifact. Three stale proposal headers corrected.
+- **The CLI aborted with no message on Windows.** Windows gives a process's
+  main thread 1 MiB where Linux and macOS give 8, and the deepest paths —
+  `areev loop apply` threading the argument dispatcher through the engine, the
+  substrate adapter, the CAL facade and the store — sat just over it, so the
+  command died with `STATUS_STACK_OVERFLOW` and no output. `main` now runs the
+  CLI on a thread whose stack size it chooses, making headroom identical on
+  every platform instead of depending on a number the platform picks.
+- **`WITH recency_weight(0)` returned more grains than the statement asked
+  for.** The re-ranking widens its candidate scan and truncates back to the
+  caller's bound afterwards; the widening tested "is the option present" and
+  the truncation "is the weight above zero", so a weight of exactly zero — the
+  same answer as no option at all — widened and never came back, and
+  `RECENT 3` answered with twelve. Both now read one predicate; zero, negative
+  and NaN weights all take the unwidened path.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,102 @@ the pre-rename release history lives in that repository's `CHANGELOG.md`.
 
 ## [Unreleased]
 
+### Fixed
+
+Nine findings from an external evaluation of 1.2.2 as the context assembler
+and memory for a regulated healthcare voice + chat agent (#42–#50), plus the
+loop's definition-rewrite gap (#28). Every one was reproduced against the code
+before it was fixed.
+
+- **`ORDER BY` ranked a truncated window, and vanished on `ASSEMBLE`** (#43).
+  A pipeline stage runs over what the statement already returned — a
+  `default_limit` page — so `ORDER BY priority DESC | LIMIT 5` returned the
+  top 5 *of the newest 50* and looked exactly like a correct answer.
+  `CONTRADICTIONS` already widened its scan for this reason; that fix is now
+  generalized to every stage with the same shape (`ORDER BY`, type-specific
+  `WHERE` post-filters, `COUNT`), with the caller's bound re-applied
+  afterwards and **`CAL-W015`** when even the widened scan fills. `ORDER BY
+  created_at` is pushed into the scan and is exact at any size — it is the one
+  sort key the `grains` table carries as a column; the rest live inside the
+  content-addressed blob. `ORDER BY` on a multi-source `ASSEMBLE` now emits
+  **`CAL-W016`** instead of being silently discarded. `WITH recency_weight(w)`
+  is **implemented** — it was parsed, stored, and read by nothing since 1.0,
+  while ten built-in saved queries passed it.
+- **`session_id` was a post-filter over a 50-row page** (#49). It is now pushed
+  into `idx_thread(ns, session, seq)`, so `RECALL events WHERE session_id = …`
+  is bounded by turns of *that conversation* rather than rows of the namespace
+  — on a busy namespace the tail of a conversation could be entirely outside
+  the window and the query answered "nothing". No new CAL syntax: the existing
+  `WHERE session_id` spelling now pushes down. `thread_tail` is exposed on the
+  Node and Python bindings.
+- **A Postgres handle never recovered from a database outage** (#48). One
+  `tokio_postgres` client with no reconnect meant a routine managed-database
+  restart (`57P01`) permanently poisoned a long-lived handle. The session is
+  now replaced in place, clearing the prepared-statement and BM25-stats caches
+  that belonged to it; **reads replay, writes do not** (a write may have
+  committed before the connection died), and nothing replays inside a
+  transaction. `docs/deployment-profile.md` gains the connection contract —
+  connections per handle, open cost, pooling guidance — and its stale
+  "advisory-locked single writer" claim is corrected to multi-writer.
+- **Windows `require()` failed on a package npm had refused** (#50). The
+  Windows leg built fine; npm's spam filter rejected the *name*
+  `areev-win32-x64-msvc`, and the release shipped a manifest promising it
+  anyway. Scoping the package makes napi derive `@areev/areev-<platform>`
+  names, which the filter does not reject — Windows works rather than being
+  dropped. `prepare-npm.mjs` now hard-fails a release when a declared target
+  produced no artifact. Three stale proposal headers corrected.
+
 ### Added
+
+- **`ASSEMBLE` literal sections and pinning** (#42). `label: LITERAL "…"`
+  renders host-supplied text at its authored position; `label: PIN …` marks a
+  source non-degradable — costed off the top and never trimmed, with
+  **`CAL-E122`** when the pins alone exceed `BUDGET`. A compliance-mandated
+  instruction can now live in the statement instead of as a mutable grain, and
+  cannot be summarised away by a long conversation. Render order is documented
+  as FROM-clause order, explicitly independent of `PRIORITY`, with a test.
+  **Out-of-order `ASSEMBLE` clauses are now a parse error** rather than
+  silently detaching. New CAL syntax ahead of the OMS spec — recorded as a
+  named decision in `ARCHITECTURE.md` §10.
+- **A host-supplied anonymization key** (#46). `AreevOptions::anon_key` is the
+  HKDF root for the session/memory/vault subkeys when given, else the page key
+  as before. The mapping vault and deterministic value-derived tokens now work
+  on **Postgres** — which refuses `encryption_key` because it is a page-cipher
+  capability — and on plaintext files. Never persisted; rotating it is a
+  crypto-erasure of the mapping table. Conformance case on both backends.
+- **Healthcare / national-ID detectors and CI-testable fixtures** (#47).
+  Singapore NRIC/FIN (weighted mod-11 with era offsets) and UAE Emirates ID
+  (`784` prefix + Luhn) are checksum-gated; MRNs are cue-gated on a nearby
+  `MRN`/`medical record number` rather than matching bare digit runs.
+  `co_occurrence` rules express "redact A when B is within N characters" — a
+  name beside a condition is health data, which no per-category action can
+  say — and `term_sets` name the categories they compare. `areev anonymize
+  test --fixtures F` asserts must-redact / must-not-redact and exits non-zero
+  on any miss or false positive.
+- **Pluggable LLM credentials and feature-gated providers** (#45).
+  `areev_llm::cred::Credential` mints the auth value per request instead of
+  reading a `String` once, so Application Default Credentials work: a
+  `vertex:<model>` provider reaches the **regional** `aiplatform` endpoint under
+  workload identity with no key on disk (the region is never defaulted and
+  `global` is refused). Service-account key JSON is refused by name — signing
+  its JWT needs an RSA dependency this tree does not carry. Providers are
+  individually feature-gated; **OpenRouter is off by default**, so a regulated
+  build can state that its artifact cannot reach a third-party router.
+- **A parsed-statement cache, and `calPrepare`** (#44). The executor caches
+  parsed statements by exact text, so a real-time turn stops re-lexing and
+  re-parsing on every turn — and it serves every surface, not just one. The
+  bindings built a fresh executor per `cal()` call and so could never hit a
+  cache; one executor now lives on the handle. `calPrepare`/`cal_prepare`
+  validates and warms a statement at startup. `RESULTS.md` §1b adds measured
+  binding-level p50/p95/p99 for `RECALL`, a three-source `ASSEMBLE`, and
+  `thread_tail`, on both backends.
+- **Executable, undoable definition rewrites in the loop** (#28). A proposal
+  may rewrite a saved query or template — where a self-improving agent's
+  prompt-assembly actually lives. `OmsSubstrate::definition_inverse` records
+  the statement that restores the previous definition (or a `DROP`), so
+  `ROLLBACK` really undoes it; a substrate that cannot produce one refuses the
+  apply rather than applying something rollback could not reverse. Definition
+  targets are excluded from auto-apply by name, like `code` and `evalset`.
 
 - **Triggers** (#36): a standing rule that starts a workflow, declared as a
   `Trigger` grain (type `0x0D`) and evaluated by `areev trigger run` — a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ with CAL, and rendered into model-ready context in-process (no server in the
 recall path).
 
 **Status**: published — the library crates + the `areev` binary on crates.io,
-`areev` on PyPI, and **`@areev/areev`** on npm (the unscoped `areev` npm name
-and `areev-win32-x64-msvc` are pending an npm similarity/spam-filter
-exception; when granted, publish unscoped and deprecate the scoped one).
+`areev` on PyPI, and **`@areev/areev`** on npm — main package *and* every
+per-platform addon (`@areev/areev-win32-x64-msvc`, …) are scoped, because npm's
+similarity/spam filter rejects the unscoped `areev-*` names and a rejected
+platform package left the manifest promising a Windows addon that did not
+exist. An unscoped-`areev` exception is still user-tracked with npm support but
+is no longer on the release path.
 `areev-py`, `areev-bench`, and `areev-conformance` stay `publish = false`;
 `areev-js` ships to npm, not crates.io.
 The version lives in `[workspace.package]` in the root `Cargo.toml` (all crates
@@ -241,8 +244,9 @@ outputs), `name-reservation/` (registry placeholder stubs), `target/`.
 ## Naming
 
 Brand "Areev", CLI binary `areev` (package/crate `areev`), hub daemon
-"areevd", Python module `areev`, npm package `@areev/areev` (unscoped
-`areev` pending npm approval). Formerly published as DejaDB
+"areevd", Python module `areev`, npm packages `@areev/areev` +
+`@areev/areev-<platform>` (all scoped; unscoped `areev` pending npm approval,
+not required by the release). Formerly published as DejaDB
 (github.com/AreevAI/dejadb, frozen at 1.2.0 and archived). The OMS spec
 itself is external (CC0); OMS conformance is the compatibility mechanism
 with other implementations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,8 @@ dependencies = [
  "areev-store",
  "serde_json",
  "tempfile",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "areev-loop",
  "serde",
  "serde_json",
+ "tempfile",
  "ureq",
 ]
 

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -179,9 +179,12 @@ and are the source of truth. Ranges:
 | `CAL-E117`–`E119` | Template limits and inheritance (OMS CAL §10.7–§10.8) |
 | `CAL-E120` | Invalid JSON+CAL |
 | `CAL-E121` | Not authorized — the session's grants don't cover this statement (carries the `AUT-Ennn` detail) |
+| `CAL-E122` | `PIN`ned `ASSEMBLE` sources do not fit the `BUDGET` — a pin is never summarised or dropped, so the statement fails instead of degrading it |
 | `CAL-W001`–`W012` | Warnings (unknown relation, deprecated operator, `{{#each}}` cap, bounded `CONTRADICTIONS` scan, …) |
 | `CAL-W013` | `WITH auto_relate` accepted but not implemented — no relations are inferred |
 | `CAL-W014` | A `WITH` option parsed and ran but cannot change the result on this statement (e.g. `score_breakdown` on `RECALL`) |
+| `CAL-W015` | A post-retrieval stage (`ORDER BY`, a type-specific `WHERE` filter, `COUNT`) widened its scan to `max_limit` and still filled it — the answer is the top-k of a window, not of the memory |
+| `CAL-W016` | A pipeline stage was attached to a payload it cannot act on (e.g. `ORDER BY` on a multi-source `ASSEMBLE`) and was skipped |
 
 `CAL-E116` is the "needs an external LLM, not implemented" error for
 `WITH hyde` / `WITH llm_rerank` — Areev takes no LLM dependency by policy.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Areev ships on all three registries — install the surface you need:
 ```bash
 cargo install areev          # the `areev` CLI
 pip install areev            # Python bindings
-npm install @areev/areev     # Node bindings (unscoped `areev` pending npm approval)
+npm install @areev/areev     # Node bindings
 ```
 
 No Rust toolchain? Every release also carries prebuilt `areev` binaries for
@@ -488,7 +488,7 @@ transaction; to load another system's export, prefer `migrate()`.
 ### Node
 
 ```js
-const { Areev } = require('areev')
+const { Areev } = require('@areev/areev')
 
 const mem = new Areev('john.db', 'caller')                  // 3rd arg: passphrase for AES-256 at rest
 await mem.addFact('john', 'prefers', 'tea', 0.95)
@@ -721,7 +721,7 @@ stated honestly.
 | `areev-server` | Local web console (memories / graph / query / Areev Loop queue / Runs approval queue / sessions) + areevd hub mode; per-principal auth, optional TLS (`tls` feature) and SSO trusted-header |
 | `areev` | The `areev` binary |
 | `areev-py` | Python bindings (`import areev`) |
-| `areev-js` | Node bindings (napi-rs native addon, `require('areev')`) |
+| `areev-js` | Node bindings (napi-rs native addon, `require('@areev/areev')`) |
 | `adapters/` | pip packages `areev-langgraph` (checkpointer, store, trace mirror) and `areev-crewai` (memory backend, audit listener) |
 
 Built on [Turso Database](https://github.com/tursodatabase/turso) (MIT) — see

--- a/crates/areev-bench/RESULTS.md
+++ b/crates/areev-bench/RESULTS.md
@@ -33,6 +33,44 @@ costs ~5x the in-process path — transport, not storage, is the latency
 budget, which is the whole architectural argument. (c) MCP stdio at ~129µs
 p50 is the Claude Code / agent-host number.
 
+### 1b. Binding-level latency — what a real-time turn actually pays
+
+*Run: 2026-08-19 · Apple M4 Max · `@areev/areev` release addon, driven from
+Node 22 · 2,200 grains (2,000 Events across 50 sessions + 200 Facts) · 300
+iterations after 30 warmup · statements pre-warmed with `calPrepare`.*
+
+§1 measures the Rust store. A real-time voice or chat turn does not call the
+Rust store — it calls a **binding**, with a statement **string**, and pays
+lexing, parsing and planning unless something reuses the plan. These rows
+close that gap: same process, same machine, measured from JavaScript.
+
+| statement (from Node) | backend | p50 ms | p95 ms | p99 ms |
+|---|---|---|---|---|
+| `RECALL events RECENT 20` | embedded (Turso file) | 0.17 | 0.48 | 0.86 |
+| `ASSEMBLE` (3 sources, BUDGET 900, FORMAT markdown) | embedded (Turso file) | 0.20 | 0.65 | 0.93 |
+| `thread_tail` 20 events | embedded (Turso file) | 0.08 | 0.28 | 0.58 |
+| `RECALL events RECENT 20` | Postgres 16, loopback Docker | 1.06 | 1.82 | 3.39 |
+| `ASSEMBLE` (3 sources, BUDGET 900, FORMAT markdown) | Postgres 16, loopback Docker | 4.29 | 13.72 | 32.55 |
+| `thread_tail` 20 events | Postgres 16, loopback Docker | 1.68 | 3.35 | 6.36 |
+
+**Can the Postgres backend meet a ~100 ms real-time memory budget?**
+On loopback, comfortably — the worst row here is a 32.6 ms p99 for a
+three-source assembly, a third of the budget. Off loopback it depends on one
+number: **round trips × added RTT**. A three-source `ASSEMBLE` is tens of
+statements (see the round-trip table in
+[`docs/postgres-backend-proposal.md`](../../docs/postgres-backend-proposal.md)),
+so a same-region managed Postgres at ~1 ms RTT adds tens of milliseconds and
+the budget gets tight at p99; a cross-region hop does not fit at all.
+
+*Not measured here:* managed Cloud SQL. These are loopback-Docker figures on
+one machine and are labelled as such — extrapolate with the round-trip count,
+do not quote them as managed-database numbers.
+
+The embedded rows are the ones to design a voice turn around: `thread_tail` at
+0.08 ms p50 is the read every conversational turn makes, and it is
+**index-backed** (`idx_thread(ns, session, seq)`) rather than a namespace scan
+filtered afterwards.
+
 ## 2. Trust suite — durability + integrity artifacts
 
 `cargo run --release -p areev-bench --bin trust_suite` (exit 0 = all pass;

--- a/crates/areev-cal/src/areev_facade.rs
+++ b/crates/areev-cal/src/areev_facade.rs
@@ -1575,13 +1575,13 @@ impl CalStoreFacade for AreevFacade {
             // anchor, so without a type this must still fall through to the
             // "RECALL needs a subject filter, a free-text query, or a specific
             // grain type" refusal below rather than scanning the namespace.
-            (unanchored && params.grain_type.is_some() && k.field == "created_at").then(|| {
+            (unanchored && params.grain_type.is_some() && k.field == "created_at").then_some(
                 if k.descending {
                     areev_store::RecentOrder::CreatedAtDesc
                 } else {
                     areev_store::RecentOrder::CreatedAtAsc
-                }
-            })
+                },
+            )
         }) {
             let n = k.min(1000);
             if scoped {

--- a/crates/areev-cal/src/areev_facade.rs
+++ b/crates/areev-cal/src/areev_facade.rs
@@ -1811,6 +1811,15 @@ impl CalStoreFacade for AreevFacade {
         // would silently WIDEN a result set — the worst failure shape here —
         // so membership is re-asserted per grain when the scope is a set.
         let ns_filter: HashSet<&str> = ns_list.iter().map(String::as_str).collect();
+        // ONE predicate for "recency re-ranking is active", read by both the
+        // widened `take` below and the re-rank block after it. They used to
+        // test it differently — `is_some()` for the widening, `> 0.0` for the
+        // re-rank — so `WITH recency_weight(0)` widened the scan and then
+        // never truncated it back, and a `RECENT 3` answered with
+        // `3 * RECALL_OVERFETCH` grains. A weight of zero means "no recency
+        // component", which is the SAME answer as no option at all; so does a
+        // negative or NaN weight, and all three now take the unwidened path.
+        let recency_weight = params.recency_weight.filter(|w| *w > 0.0);
         let mut hits: Vec<SearchHit> = raw
             .into_iter()
             .filter(|g| {
@@ -1859,11 +1868,7 @@ impl CalStoreFacade for AreevFacade {
             // the same truncated-window mistake ORDER BY made. Without the
             // option the take stays exactly where it was, so the hot path is
             // unchanged.
-            .take(if params.recency_weight.is_some() {
-                usize::MAX
-            } else {
-                k
-            })
+            .take(if recency_weight.is_some() { usize::MAX } else { k })
             .map(Self::hit)
             .collect();
 
@@ -1886,7 +1891,7 @@ impl CalStoreFacade for AreevFacade {
         // State facts are exempt, as documented: "lives in Berlin" does not
         // become less true with age, so decaying it would push a current fact
         // below a stale event.
-        if let Some(w) = params.recency_weight.filter(|w| *w > 0.0) {
+        if let Some(w) = recency_weight {
             let w = w.clamp(0.0, 1.0);
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)

--- a/crates/areev-cal/src/areev_facade.rs
+++ b/crates/areev-cal/src/areev_facade.rs
@@ -1539,7 +1539,57 @@ impl CalStoreFacade for AreevFacade {
         // `WITH superseded` — the caller is asking about the past, so every leg
         // widens from the heads to the whole supersession chain.
         let include_superseded = params.exclude_superseded == Some(false);
-        let raw = if unanchored {
+        // `WHERE session_id = "…"` with nothing else to anchor on: read the
+        // thread index instead of a page of the namespace. Without this, the
+        // `unanchored` arm below scans `recent`/`recent_live` newest-first
+        // across the WHOLE namespace and the session filter is applied
+        // afterwards, so on a busy namespace the tail of one conversation can
+        // sit entirely outside the scanned page and the query answers
+        // "nothing" — the single most common read a chat/voice agent makes,
+        // silently wrong. `idx_thread(ns, session, seq)` bounds the scan by the
+        // session, so k here means k turns of THIS conversation.
+        //
+        // A session IS an anchor, so this branch also lifts the "RECALL needs a
+        // subject filter, a free-text query, or a specific grain type" refusal
+        // for the typed-less form: `RECALL WHERE session_id = "…"` is bounded.
+        //
+        // Only on the unanchored path: with a subject or a free-text query the
+        // hybrid leg is already bounded by that anchor (a far tighter bound
+        // than a namespace page), and the post-filter finishes the job. Kept as
+        // its own branch rather than nested inside the unanchored arm so the
+        // recent-by-type match below stays exactly as it was.
+        let raw = if let Some(session) = params.session_id.as_deref().filter(|_| unanchored) {
+            let n = k.saturating_mul(Self::RECALL_OVERFETCH);
+            if scoped {
+                m.recent_in_session_scoped(&ns_list, session, params.grain_type, n, !include_superseded)?
+            } else {
+                m.recent_in_session(ns, session, params.grain_type, n, !include_superseded)?
+            }
+        } else if let Some(order) = params.order_by.as_ref().and_then(|k| {
+            // `created_at` is the one sort key the `grains` table carries as a
+            // column, so it is the one ORDER BY that can be served from the
+            // scan instead of re-sorting a page afterwards. The executor only
+            // sets `order_by` for it; anything else it ranks itself over a
+            // widened scan (see `RecallParams::order_by`).
+            // `params.grain_type.is_some()` matters: ORDER BY is not an
+            // anchor, so without a type this must still fall through to the
+            // "RECALL needs a subject filter, a free-text query, or a specific
+            // grain type" refusal below rather than scanning the namespace.
+            (unanchored && params.grain_type.is_some() && k.field == "created_at").then(|| {
+                if k.descending {
+                    areev_store::RecentOrder::CreatedAtDesc
+                } else {
+                    areev_store::RecentOrder::CreatedAtAsc
+                }
+            })
+        }) {
+            let n = k.min(1000);
+            if scoped {
+                m.recent_ordered_scoped(&ns_list, params.grain_type, n, !include_superseded, order)?
+            } else {
+                m.recent_ordered(ns, params.grain_type, n, !include_superseded, order)?
+            }
+        } else if unanchored {
             match params.grain_type {
                 // Heads only, unless `WITH superseded` asked otherwise. The
                 // anchored leg already serves heads; this one read the grains
@@ -1804,9 +1854,62 @@ impl CalStoreFacade for AreevFacade {
                 Some(c) => g.get_f64("confidence").unwrap_or(0.0) >= c,
                 None => true,
             })
-            .take(k)
+            // `WITH recency_weight(w)` re-ranks the CANDIDATES, so it has to
+            // see them before this bound — ranking a set already cut to k is
+            // the same truncated-window mistake ORDER BY made. Without the
+            // option the take stays exactly where it was, so the hot path is
+            // unchanged.
+            .take(if params.recency_weight.is_some() {
+                usize::MAX
+            } else {
+                k
+            })
             .map(Self::hit)
             .collect();
+
+        // ── `WITH recency_weight(w)` ─────────────────────────────────────
+        //
+        // Parsed since 1.0, stored on RecallParams, and read by NOTHING — ten
+        // of the built-in saved queries in `queries.rs` pass it, so ten shipped
+        // queries were quietly not doing what they said. Implemented to the
+        // formula the field has always documented:
+        //
+        //     final = (1 - w) * relevance + w * freshness
+        //     freshness = 1 / (1 + age_hours)
+        //
+        // `relevance` comes from FUSION ORDER, not `hit.score`: every hit
+        // leaves `Self::hit` with score 1.0, so the ranking a recall carries is
+        // positional (RRF/structural order), not numeric. Rank i of n therefore
+        // scores `1 - i/n` — order-preserving, and identical to the current
+        // order when w = 0.
+        //
+        // State facts are exempt, as documented: "lives in Berlin" does not
+        // become less true with age, so decaying it would push a current fact
+        // below a stale event.
+        if let Some(w) = params.recency_weight.filter(|w| *w > 0.0) {
+            let w = w.clamp(0.0, 1.0);
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as i64)
+                .unwrap_or(0);
+            let n = hits.len().max(1) as f64;
+            for (i, h) in hits.iter_mut().enumerate() {
+                let relevance = 1.0 - (i as f64) / n;
+                let is_state = h.grain.get_str("temporal_type") == Some("state");
+                h.score = if is_state {
+                    relevance
+                } else {
+                    let age_hours =
+                        ((now - h.grain.get_i64("created_at").unwrap_or(now)).max(0) as f64)
+                            / 3_600_000.0;
+                    let freshness = 1.0 / (1.0 + age_hours);
+                    (1.0 - w) * relevance + w * freshness
+                };
+            }
+            // Stable, so equal scores keep fusion order.
+            hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+            hits.truncate(k);
+        }
 
         // Label the history. A widened recall returns stale versions next to the
         // heads that replaced them, and nothing in an immutable blob says which

--- a/crates/areev-cal/src/assemble.rs
+++ b/crates/areev-cal/src/assemble.rs
@@ -232,7 +232,47 @@ impl<'a> AssembleEngine<'a> {
             .unwrap_or(DEFAULT_BUDGET_TOKENS);
 
         let labels: Vec<&str> = source_results.iter().map(|(l, _)| l.as_str()).collect();
-        let allocations = allocate_budget(&labels, budget_tokens, &stmt.priority);
+
+        // ── PIN: satisfy the non-degradable sources first ────────────────
+        //
+        // PRIORITY only *weights* the split, so it can never express "this
+        // section must survive verbatim" — a long conversation would summarise
+        // away the one instruction that is contractually mandatory. A pinned
+        // source is costed in full and taken off the top; PRIORITY then shares
+        // whatever is left among the rest. If the pins alone do not fit, the
+        // statement fails (CAL-E122) rather than silently degrading them —
+        // the whole point is that a quiet partial answer is the unsafe one.
+        let pinned_labels: HashSet<&str> = sources
+            .iter()
+            .filter(|s| s.pinned)
+            .map(|s| s.label.as_str())
+            .collect();
+        let pinned_cost: u32 = source_results
+            .iter()
+            .filter(|(l, _)| pinned_labels.contains(l.as_str()))
+            .map(|(_, g)| g.iter().map(estimate_grain_tokens).sum::<u32>())
+            .sum();
+        if pinned_cost > budget_tokens {
+            let mut names: Vec<String> = source_results
+                .iter()
+                .filter(|(l, _)| pinned_labels.contains(l.as_str()))
+                .map(|(l, _)| l.clone())
+                .collect();
+            names.sort();
+            return Err(CalError::AssemblePinnedBudgetExceeded {
+                labels: names,
+                required: pinned_cost,
+                budget: budget_tokens,
+                span: stmt.span,
+            });
+        }
+        let free_budget = budget_tokens - pinned_cost;
+        let free_labels: Vec<&str> = labels
+            .iter()
+            .copied()
+            .filter(|l| !pinned_labels.contains(l))
+            .collect();
+        let allocations = allocate_budget(&free_labels, free_budget, &stmt.priority);
         // Snapshot per-source allocations in source order so the trim loop can
         // take ownership of the grains: `allocations` borrows `labels`, which
         // borrows `source_results`.
@@ -254,14 +294,28 @@ impl<'a> AssembleEngine<'a> {
         let mut dropped = 0usize; // grains the budget forced us to omit
 
         for (i, (label, mut grains)) in source_results.into_iter().enumerate() {
-            let allocated = per_source
-                .get(i)
-                .copied()
-                .flatten()
-                .unwrap_or(remaining_budget / source_count.max(1) as u32);
+            // A pinned source was already costed in full and reserved off the
+            // top, so it is handed exactly what it needs and `budget_prefix`
+            // keeps all of it. `remaining_budget` still has the reservation in
+            // it at this point, so this cannot underflow.
+            let is_pinned = pinned_labels.contains(label.as_str());
+            let allocated = if is_pinned {
+                grains.iter().map(estimate_grain_tokens).sum::<u32>()
+            } else {
+                per_source
+                    .get(i)
+                    .copied()
+                    .flatten()
+                    .unwrap_or(remaining_budget / source_count.max(1) as u32)
+            };
 
-            // Use the smaller of allocated or remaining budget.
-            let effective_allocation = allocated.min(remaining_budget);
+            // Use the smaller of allocated or remaining budget — except for a
+            // pin, which is never reduced.
+            let effective_allocation = if is_pinned {
+                allocated
+            } else {
+                allocated.min(remaining_budget)
+            };
 
             // Split rather than copy: the kept grains and the omitted tail are
             // both already in `grains`, and cloning either would hold a second
@@ -317,6 +371,29 @@ impl<'a> AssembleEngine<'a> {
         query: &CalQuery,
         warnings: &mut Vec<String>,
     ) -> Result<Vec<CalGrainResult>, CalError> {
+        // A LITERAL source is host text, not a query — nothing to execute, no
+        // store access, no timeout. It becomes ONE synthetic result so it
+        // flows through dedup, budgeting and rendering exactly like any other
+        // section, and therefore lands at its authored position (sources
+        // render in FROM-clause order).
+        //
+        // The empty hash is load-bearing: this text was never stored, has no
+        // content address, and must never be mistaken for a grain — dedup
+        // keys on the hash and skips it explicitly.
+        if let Some(text) = &source.literal {
+            return Ok(vec![CalGrainResult {
+                hash: String::new(),
+                grain_type: "literal".to_string(),
+                score: 1.0,
+                fields: serde_json::json!({ "content": text }),
+                score_breakdown: None,
+                explanation: None,
+                relative_time: None,
+                is_deterministic: true,
+                contested_by: None,
+            }]);
+        }
+
         // Use per-source WITH options if present, otherwise fall back to parent query's.
         let with_options = if source.with_options.is_empty() {
             query.with_options.clone()
@@ -483,7 +560,10 @@ impl<'a> AssembleEngine<'a> {
             .map(|(label, grains)| {
                 let deduped: Vec<_> = grains
                     .into_iter()
-                    .filter(|g| seen.insert(g.hash.clone()))
+                    // A LITERAL section has no content address, so every
+                    // literal carries the empty hash — deduping on it would
+                    // drop every literal after the first.
+                    .filter(|g| g.hash.is_empty() || seen.insert(g.hash.clone()))
                     .collect();
                 (label, deduped)
             })

--- a/crates/areev-cal/src/ast.rs
+++ b/crates/areev-cal/src/ast.rs
@@ -390,8 +390,29 @@ pub struct AssembleStmt {
 pub struct NamedSource {
     /// The label for this source (e.g. `"recent"`, `"context"`).
     pub label: String,
-    /// The sub-query producing this source's grains.
+    /// The sub-query producing this source's grains. Ignored when
+    /// [`literal`](Self::literal) is set (which parks a placeholder here so
+    /// the serialized AST shape stays unchanged for every existing consumer).
     pub query: Box<CalStatement>,
+    /// `LITERAL "…"` — host-supplied text rendered at this source's authored
+    /// position instead of grains from a query.
+    ///
+    /// A production system prompt is grains INTERLEAVED with fixed text, and
+    /// some of that text is contractually mandatory. Without this the host has
+    /// to write the instruction into the memory as a grain first, which turns
+    /// a compliance-critical string into a mutable row; with it the string
+    /// lives in the statement, i.e. in code.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub literal: Option<String>,
+    /// `PIN` — this source is non-degradable.
+    ///
+    /// The budget allocator satisfies pinned sources FIRST, at their full
+    /// cost, and the trim loop never truncates them; if the budget cannot hold
+    /// them the statement fails with `CAL-E122` rather than quietly
+    /// summarising the one section that had to survive verbatim. Orthogonal to
+    /// `PRIORITY`, which only weights how the REMAINING budget is shared.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub pinned: bool,
     /// Per-source WITH options (e.g. `WITH exhaustive`). When non-empty,
     /// these override the parent query's with_options for this source.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/areev-cal/src/errors.rs
+++ b/crates/areev-cal/src/errors.rs
@@ -300,6 +300,24 @@ pub enum CalError {
     #[error("CAL-E034: Duplicate ASSEMBLE source label \"{label}\"")]
     AssembleDuplicateLabel { label: String, span: Option<Span> },
 
+    /// CAL-E122 — The `PIN`ned sources alone do not fit the `BUDGET`.
+    ///
+    /// A pin is a promise of full, verbatim disclosure, so there is no
+    /// degraded answer to fall back to: summarising the section would break
+    /// the guarantee the pin exists to make, and dropping it silently is
+    /// worse. Failing loudly is the only honest outcome — the budget or the
+    /// pinned text has to change.
+    #[error(
+        "CAL-E122: pinned ASSEMBLE source(s) [{}] need {required} tokens but BUDGET is {budget} — a PIN is never summarised or dropped, so raise the budget or shorten the pinned text",
+        labels.join(", ")
+    )]
+    AssemblePinnedBudgetExceeded {
+        labels: Vec<String>,
+        required: u32,
+        budget: u32,
+        span: Option<Span>,
+    },
+
     /// CAL-E035 — PRIORITY references a label not in the FROM clause.
     #[error("CAL-E035: PRIORITY references unknown source label \"{label}\"")]
     AssemblePriorityMismatch { label: String, span: Option<Span> },
@@ -658,6 +676,7 @@ impl CalError {
             Self::AssembleTooManySources { .. } => "CAL-E032",
             Self::AssembleBudgetExceeded { .. } => "CAL-E033",
             Self::AssembleDuplicateLabel { .. } => "CAL-E034",
+            Self::AssemblePinnedBudgetExceeded { .. } => "CAL-E122",
             Self::AssemblePriorityMismatch { .. } => "CAL-E035",
             Self::TooManyLetBindings { .. } => "CAL-E036",
             Self::LetCircularReference { .. } => "CAL-E037",
@@ -737,6 +756,7 @@ impl CalError {
             | Self::InvalidQuery { span, .. }
             | Self::CryptoError { span, .. }
             | Self::FieldNotOnGrainType { span, .. }
+            | Self::AssemblePinnedBudgetExceeded { span, .. }
             | Self::AssembleTooManySources { span, .. }
             | Self::AssembleBudgetExceeded { span, .. }
             | Self::AssembleDuplicateLabel { span, .. }
@@ -1097,6 +1117,17 @@ impl CalError {
                 span: s,
             },
             Self::DuplicateFormatKey { key, .. } => Self::DuplicateFormatKey { key, span: s },
+            Self::AssemblePinnedBudgetExceeded {
+                labels,
+                required,
+                budget,
+                ..
+            } => Self::AssemblePinnedBudgetExceeded {
+                labels,
+                required,
+                budget,
+                span: s,
+            },
             Self::MissingAccumulateOps { .. } => Self::MissingAccumulateOps { span: s },
             Self::AccumulateNonNumericField { field, current, .. } => {
                 Self::AccumulateNonNumericField {
@@ -1398,6 +1429,39 @@ pub enum CalWarning {
         statement: &'static str,
         why: &'static str,
     },
+
+    /// CAL-W015 — A post-retrieval stage (ORDER BY, a type-specific WHERE
+    /// filter, COUNT) widened its scan to the executor's `max_limit` and
+    /// still filled it, so it ranked/filtered/counted a bounded window rather
+    /// than the whole matching set.
+    ///
+    /// The sibling of `ContradictionScanBounded`, generalized. `ORDER BY`
+    /// sorts the grains a statement already returned; without widening, that
+    /// is a page of `default_limit` rows, so `ORDER BY priority DESC LIMIT 5`
+    /// returned the top 5 *of the newest 50* and looked exactly like the top
+    /// 5 overall. Widening fixes every corpus up to `max_limit`; past that the
+    /// only honest thing left is to say so, because the answer is still a
+    /// well-formed list that happens to be wrong.
+    ScanBounded {
+        /// What forced the wide scan — "ORDER BY priority", "WHERE tool_name", "COUNT".
+        stage: String,
+        scanned: usize,
+    },
+
+    /// CAL-W016 — A pipeline stage was attached to a payload it cannot act on
+    /// (e.g. `ORDER BY` on a multi-source `ASSEMBLE`, which returns an
+    /// assembled section list rather than a flat grain list).
+    ///
+    /// These used to hit a catch-all passthrough arm and vanish with no error
+    /// and no warning, which contradicts `docs/cal-reference.md` §5: silence
+    /// means the option did something. Ordering an assembly is exactly the
+    /// case a host reaches for when rendering authored instruction blocks in
+    /// an intended order — and it was the one case that silently did nothing.
+    PipelineStageInert {
+        stage: String,
+        payload: &'static str,
+        why: &'static str,
+    },
 }
 
 impl CalWarning {
@@ -1417,6 +1481,8 @@ impl CalWarning {
             Self::EachIterationCapped { .. } => "CAL-W011",
             Self::ContradictionScanBounded { .. } => "CAL-W012",
             Self::WithOptionInert { .. } => "CAL-W014",
+            Self::ScanBounded { .. } => "CAL-W015",
+            Self::PipelineStageInert { .. } => "CAL-W016",
         }
     }
 
@@ -1435,7 +1501,9 @@ impl CalWarning {
             | Self::UnrecognizedWhereField { span, .. } => *span,
             Self::EachIterationCapped { .. }
             | Self::ContradictionScanBounded { .. }
-            | Self::WithOptionInert { .. } => None,
+            | Self::WithOptionInert { .. }
+            | Self::ScanBounded { .. }
+            | Self::PipelineStageInert { .. } => None,
         }
     }
 }
@@ -1526,6 +1594,22 @@ impl std::fmt::Display for CalWarning {
                 write!(
                     f,
                     "CAL-W014: WITH {option} has no effect on {statement} — {why}. The result is the same as without it."
+                )
+            }
+            Self::ScanBounded { stage, scanned } => {
+                write!(
+                    f,
+                    "CAL-W015: {stage} ran over the first {scanned} matching grains (the executor's max_limit) and that scan came back full — grains past it were never considered, so this is a bounded answer, not the true one. Narrow the query with WHERE/ABOUT/SINCE, or raise max_limit."
+                )
+            }
+            Self::PipelineStageInert {
+                stage,
+                payload,
+                why,
+            } => {
+                write!(
+                    f,
+                    "CAL-W016: {stage} has no effect on a {payload} result — {why}. The stage was skipped; the result is the same as without it."
                 )
             }
         }

--- a/crates/areev-cal/src/executor.rs
+++ b/crates/areev-cal/src/executor.rs
@@ -728,7 +728,7 @@ impl CalExecutor {
             self.execute_statement(&query.statement, store, &query, &mut exec_warnings)?;
 
         // 4. Apply pipeline stages.
-        let (payload, grouped_by) = self.apply_pipeline(payload, &query.pipeline)?;
+        let (payload, grouped_by) = self.apply_pipeline(payload, &query.pipeline, &mut exec_warnings)?;
 
         // 5. Apply FORMAT clause if present (CAL spec v1.0.1).
         let payload = apply_format_clause(
@@ -810,7 +810,7 @@ impl CalExecutor {
             self.execute_statement(&query.statement, store, &query, &mut exec_warnings)?;
 
         // Apply pipeline stages.
-        let (payload, grouped_by) = self.apply_pipeline(payload, &query.pipeline)?;
+        let (payload, grouped_by) = self.apply_pipeline(payload, &query.pipeline, &mut exec_warnings)?;
 
         // Apply FORMAT clause if present (CAL spec v1.0.1).
         let payload = apply_format_clause(
@@ -2160,6 +2160,69 @@ impl CalExecutor {
             None
         };
 
+        // ── A post-retrieval stage must see the whole matching set ────────
+        //
+        // Same defect as CONTRADICTIONS above, in three more places. ORDER BY,
+        // the type-specific WHERE post-filter, and COUNT all run over the
+        // grains the statement ALREADY returned — a `default_limit` page. So
+        // `ORDER BY priority DESC | LIMIT 5` returned the top 5 *of the newest
+        // 50* and was indistinguishable from the top 5 overall; a
+        // `WHERE tool_name = …` post-filter searched the newest 50 for a match
+        // that might be older; `| COUNT` counted the page. Widening the scan
+        // and re-applying the caller's bound afterwards is the same trade
+        // CONTRADICTIONS already makes: LIMIT bounds the ANSWER, not the
+        // search for it.
+        //
+        // Why widening rather than a sort key pushed into SQL: the sort keys
+        // callers actually use (`priority`, `status`, `confidence`, and every
+        // type-specific field) live INSIDE the content-addressed blob, not in
+        // a `grains` column — the table carries only seq/ns/gtype/created_at/
+        // s/p/o/validity. Ordering on them in SQL would mean materializing a
+        // column per field. `created_at` IS a column, so that one case is
+        // pushed down properly (see `RecallParams::order_by`); everything else
+        // is ranked here, over a scan widened to `max_limit`, and says so via
+        // CAL-W015 when even that scan comes back full.
+        let order_by: Option<(String, bool)> = query.pipeline.iter().find_map(|st| match st {
+            PipelineStage::OrderBy {
+                field, descending, ..
+            } => Some((field.clone(), *descending)),
+            _ => None,
+        });
+        let has_count = query
+            .pipeline
+            .iter()
+            .any(|st| matches!(st, PipelineStage::Count { .. }));
+        let has_post_filter = recall.where_clause.as_ref().is_some_and(|w| {
+            !extract_type_specific_conditions(&w.condition).is_empty()
+                || !extract_type_specific_set_conditions(&w.condition).is_empty()
+        });
+        // CONTRADICTIONS has already widened to the same bound; don't stack.
+        let wide_reason: Option<String> = if recall.contradictions.is_some() {
+            None
+        } else if let Some((ref f, _)) = order_by {
+            Some(format!("ORDER BY {f}"))
+        } else if has_count {
+            Some("COUNT".to_string())
+        } else if has_post_filter {
+            Some("a post-retrieval WHERE filter".to_string())
+        } else {
+            None
+        };
+        // `created_at` is the one sort key the index can serve, so push it
+        // down instead of widening for it.
+        let pushed_down_sort = matches!(order_by, Some((ref f, _)) if f == "created_at");
+        if let (true, Some((ref field, descending))) = (pushed_down_sort, &order_by) {
+            params.order_by = Some(crate::store_types::SortKey {
+                field: field.clone(),
+                descending: *descending,
+            });
+        }
+        let widened_limit = if wide_reason.is_some() && !pushed_down_sort {
+            params.limit.replace(self.config.max_limit as usize)
+        } else {
+            None
+        };
+
         // WITH options.
         self.apply_with_options(&query.with_options, &mut params)?;
 
@@ -2253,6 +2316,59 @@ impl CalExecutor {
                             .iter()
                             .all(|c| grain_matches_set_condition(grain, c))
                 });
+            }
+        }
+
+        // ── Re-apply the caller's bound to the widened scan ──────────────
+        //
+        // The scan above was widened so this ranking/filtering could see the
+        // whole matching set. Rank it here, over that full set, then bound the
+        // ANSWER back to what the caller asked for. The pipeline's own ORDER BY
+        // still runs afterwards and re-sorts the same grains — idempotent, and
+        // it keeps the stage's behaviour unchanged for every path that did not
+        // widen.
+        if let Some(reason) = wide_reason {
+            // Even a max_limit scan can fill up. Saying so is the point: the
+            // result is a well-formed list that happens to be the top-k of a
+            // window rather than of the memory, and nothing else distinguishes
+            // the two.
+            if scan_was_bounded {
+                exec_warnings.push(
+                    super::errors::CalWarning::ScanBounded {
+                        stage: reason,
+                        scanned: self.config.max_limit as usize,
+                    }
+                    .to_string(),
+                );
+            }
+            if let Some((ref field, descending)) = order_by {
+                grains.sort_by(|a, b| {
+                    let cmp = compare_json_values(
+                        json_field(&a.fields, field),
+                        json_field(&b.fields, field),
+                    );
+                    if descending {
+                        cmp.reverse()
+                    } else {
+                        cmp
+                    }
+                });
+            }
+            // A pipeline that bounds or aggregates the result does that job
+            // itself, over the ranked set — truncating first would put the
+            // page back.
+            let pipeline_bounds = query.pipeline.iter().any(|st| {
+                matches!(
+                    st,
+                    PipelineStage::Limit { .. }
+                        | PipelineStage::First { .. }
+                        | PipelineStage::Count { .. }
+                )
+            });
+            if !pipeline_bounds {
+                if let Some(limit) = widened_limit {
+                    grains.truncate(limit);
+                }
             }
         }
 
@@ -2454,6 +2570,15 @@ impl CalExecutor {
                     }
                     ("query", Comparator::Eq) => {
                         params.query = Some(value_to_string(value)?);
+                    }
+                    // Pushed down to the thread index rather than post-filtered.
+                    // `session_id` stays OUT of `COMMON_FIELDS` (it is
+                    // type-specific, and `test_session_id_not_in_common_fields`
+                    // pins that), so the post-retrieval filter still runs over
+                    // it — this arm only narrows the SCAN, from "a page of the
+                    // namespace" to "this conversation".
+                    ("session_id", Comparator::Eq) => {
+                        params.session_id = Some(value_to_string(value)?);
                     }
                     ("time", Comparator::Eq) => {
                         params.temporal_expr = Some(value_to_string(value)?);
@@ -4057,7 +4182,7 @@ impl CalExecutor {
         let (payload, grouped_by) = if entry.pipeline.is_empty() {
             (payload, None)
         } else {
-            self.apply_pipeline(payload, &entry.pipeline)?
+            self.apply_pipeline(payload, &entry.pipeline, exec_warnings)?
         };
 
         // Apply FORMAT clause if present.
@@ -4719,6 +4844,7 @@ impl CalExecutor {
         &self,
         payload: CalResultPayload,
         stages: &[PipelineStage],
+        exec_warnings: &mut Vec<String>,
     ) -> std::result::Result<(CalResultPayload, Option<String>), CalError> {
         let mut current = payload;
         let mut grouped_by: Option<String> = None;
@@ -4946,8 +5072,28 @@ impl CalExecutor {
                     }
                 }
 
-                // Non-Grains payload: passthrough for all stages.
-                (other, _) => other,
+                // A stage attached to a payload it cannot act on.
+                //
+                // This used to be a bare passthrough, so `ORDER BY` on a
+                // multi-source ASSEMBLE — which returns `Assembled`, not
+                // `Grains` — was discarded with no error and no warning. That
+                // contradicts docs/cal-reference.md §5 (silence means the
+                // option did something), and it is precisely the case a host
+                // reaches for: rendering authored instruction blocks in an
+                // intended order. Section order on an ASSEMBLE is FROM-clause
+                // order and is not reorderable by a pipeline stage, so the
+                // honest answer is to say the stage did nothing.
+                (other, stage) => {
+                    exec_warnings.push(
+                        super::errors::CalWarning::PipelineStageInert {
+                            stage: pipeline_stage_name(stage),
+                            payload: payload_kind_name(&other),
+                            why: inert_stage_reason(&other),
+                        }
+                        .to_string(),
+                    );
+                    other
+                }
             };
         }
 
@@ -5256,6 +5402,38 @@ fn required_scope_for_statement(stmt: &CalStatement) -> &'static str {
         | CalStatement::ApplyRec(_)
         | CalStatement::RollbackRec(_)
         | CalStatement::RunLoop(_) => "admin",
+    }
+}
+
+/// The payload kind named in a `CAL-W016` inert-stage warning.
+fn payload_kind_name(payload: &CalResultPayload) -> &'static str {
+    match payload {
+        CalResultPayload::Assembled { .. } => "assembled",
+        CalResultPayload::Count { .. } => "count",
+        CalResultPayload::Formatted { .. } => "formatted",
+        CalResultPayload::Exists { .. } => "exists",
+        CalResultPayload::History { .. } => "history",
+        CalResultPayload::Explain { .. } => "explain",
+        CalResultPayload::Batch { .. } => "batch",
+        _ => "non-grain",
+    }
+}
+
+/// Why a pipeline stage cannot act on this payload — the `CAL-W016` clause
+/// that tells a caller what to do instead.
+fn inert_stage_reason(payload: &CalResultPayload) -> &'static str {
+    match payload {
+        // The case that motivated the warning. Section order on a multi-source
+        // ASSEMBLE is FROM-clause order by contract (docs/cal-reference.md),
+        // deliberately independent of PRIORITY, which weights the budget.
+        CalResultPayload::Assembled { .. } => {
+            "an assembly is a list of named sections, not a flat grain list —              section order is FROM-clause order (PRIORITY weights the budget,              it does not reorder); to order WITHIN a section, put the stage on              that source's sub-query"
+        }
+        CalResultPayload::Count { .. } => "a count is a scalar; stage it before | COUNT",
+        CalResultPayload::Formatted { .. } => {
+            "FORMAT has already rendered the grains to text; stage it before FORMAT"
+        }
+        _ => "this statement does not return a grain list",
     }
 }
 
@@ -10221,6 +10399,8 @@ mod tests {
             context_name: None,
             sources: Some(vec![super::super::ast::NamedSource {
                 label: "facts".into(),
+                literal: None,
+                pinned: false,
                 query: Box::new(CalStatement::Recall(recall_facts)),
                 with_options: vec![],
                 span: None,
@@ -10300,6 +10480,8 @@ mod tests {
             context_name: None,
             sources: Some(vec![super::super::ast::NamedSource {
                 label: "events".into(),
+                literal: None,
+                pinned: false,
                 query: Box::new(CalStatement::Recall(recall_facts)),
                 with_options: vec![],
                 span: None,
@@ -10378,6 +10560,8 @@ mod tests {
             context_name: None,
             sources: Some(vec![super::super::ast::NamedSource {
                 label: "facts".into(),
+                literal: None,
+                pinned: false,
                 query: Box::new(CalStatement::Recall(recall_facts)),
                 with_options: vec![],
                 span: None,

--- a/crates/areev-cal/src/executor.rs
+++ b/crates/areev-cal/src/executor.rs
@@ -5496,7 +5496,10 @@ fn inert_stage_reason(payload: &CalResultPayload) -> &'static str {
         // ASSEMBLE is FROM-clause order by contract (docs/cal-reference.md),
         // deliberately independent of PRIORITY, which weights the budget.
         CalResultPayload::Assembled { .. } => {
-            "an assembly is a list of named sections, not a flat grain list —              section order is FROM-clause order (PRIORITY weights the budget,              it does not reorder); to order WITHIN a section, put the stage on              that source's sub-query"
+            "an assembly is a list of named sections, not a flat grain list — \
+             section order is FROM-clause order (PRIORITY weights the budget, \
+             it does not reorder); to order WITHIN a section, put the stage on \
+             that source's sub-query"
         }
         CalResultPayload::Count { .. } => "a count is a scalar; stage it before | COUNT",
         CalResultPayload::Formatted { .. } => {

--- a/crates/areev-cal/src/executor.rs
+++ b/crates/areev-cal/src/executor.rs
@@ -604,13 +604,38 @@ impl Drop for LetScope {
 // CalExecutor
 // ---------------------------------------------------------------------------
 
+/// Maximum parsed statements held in the plan cache.
+///
+/// A production host runs a small, fixed set of statements (its saved queries
+/// and a handful of literals) many times, so a modest cap gets essentially
+/// every hit; the bound exists to stop a host that interpolates values into
+/// statement text from growing the map without limit.
+const PLAN_CACHE_MAX: usize = 256;
+
 /// CAL query executor.
 ///
-/// Stateless aside from configuration. Create once and call `execute()` for
-/// each query. Thread-safe (`Send + Sync` by construction — no interior
-/// mutability).
+/// Stateless aside from configuration and a parse cache. Create once and call
+/// `execute()` for each query. Thread-safe.
 pub struct CalExecutor {
     config: CalExecutorConfig,
+    /// Parsed statements, keyed by exact statement text.
+    ///
+    /// A real-time turn does not call the Rust store — it calls a binding with
+    /// a statement STRING, and used to pay lexing, parsing and validation on
+    /// every single turn. Parsing is pure and deterministic over the text, so
+    /// the result is cacheable with no semantic change whatsoever: the same
+    /// text yields the same AST.
+    ///
+    /// Deliberately internal rather than a `prepare()` the caller must manage:
+    /// every surface — CLI, MCP, the server, both bindings, and `RUN "name"()`
+    /// — gets the saving without an API change and without a handle-lifetime
+    /// bug class. The bindings additionally expose an explicit handle for
+    /// hosts that want the guarantee rather than the heuristic.
+    ///
+    /// Cleared wholesale at the cap rather than evicted LRU: at this size the
+    /// bookkeeping costs more than the occasional re-parse, and the working
+    /// set is refilled by the next few turns.
+    plan_cache: std::sync::Mutex<HashMap<String, crate::ast::CalQuery>>,
     /// The governance seam (CAL 1.3 §8.16): loop lifecycle statements
     /// execute only when a host attached one — `areev-loop-adapter` provides the
     /// real implementation. Absent → those statements return
@@ -621,7 +646,41 @@ pub struct CalExecutor {
 impl CalExecutor {
     /// Create a new executor with the given configuration.
     pub fn new(config: CalExecutorConfig) -> Self {
-        Self { config, governance: None }
+        Self { config, governance: None, plan_cache: Default::default() }
+    }
+
+    /// Parse `input`, reusing a cached AST for identical text.
+    ///
+    /// Returns a clone: `execute` binds LET values into the query, so the
+    /// cached entry must stay pristine. Cloning an AST is still far cheaper
+    /// than lexing + parsing + validating one.
+    ///
+    /// A poisoned lock degrades to a plain parse rather than failing the
+    /// query — the cache is an optimization, and a caller's statement should
+    /// not fail because some other thread panicked.
+    pub fn parse_cached(
+        &self,
+        input: &str,
+    ) -> std::result::Result<crate::ast::CalQuery, CalError> {
+        if let Ok(cache) = self.plan_cache.lock() {
+            if let Some(q) = cache.get(input) {
+                return Ok(q.clone());
+            }
+        }
+        let query = crate::parser::parse(input)?;
+        if let Ok(mut cache) = self.plan_cache.lock() {
+            if cache.len() >= PLAN_CACHE_MAX {
+                cache.clear();
+            }
+            cache.insert(input.to_string(), query.clone());
+        }
+        Ok(query)
+    }
+
+    /// How many statements the plan cache currently holds. Diagnostics and
+    /// tests; not a stability guarantee.
+    pub fn plan_cache_len(&self) -> usize {
+        self.plan_cache.lock().map(|c| c.len()).unwrap_or(0)
     }
 
     /// Attach the governance host that backs `RUN LOOP`, `APPROVE`,
@@ -691,8 +750,9 @@ impl CalExecutor {
     ) -> std::result::Result<CalExecResult, CalError> {
         let start = std::time::Instant::now();
 
-        // 1. Parse (validates length, bidi, nesting limits, etc.)
-        let query = crate::parser::parse(input)?;
+        // 1. Parse (validates length, bidi, nesting limits, etc.), reusing an
+        // earlier parse of the identical text when there is one.
+        let query = self.parse_cached(input)?;
 
         // 2. Compute query hash (C-4: SHA-256 of normalized / trimmed input).
         let query_hash = compute_query_hash(input);
@@ -1981,7 +2041,16 @@ impl CalExecutor {
         }
 
         // 3. Parse the substituted body.
-        let parsed = super::parser::parse(&body).map_err(|e| CalError::InvalidQueryBody {
+        //
+        // Cached like any other statement — but note WHAT the key is. Params
+        // are substituted into the body TEXT above, before parsing, so the
+        // cache key is the substituted body: `RUN "triage"($subject: "amy")`
+        // reuses a plan only when called with the same arguments again. A
+        // zero-parameter saved query therefore always hits after its first
+        // call; a parameterized one hits per distinct argument set. This is
+        // the honest answer to "does RUN reuse a compiled plan?" and it is
+        // recorded in docs/cal-reference.md.
+        let parsed = self.parse_cached(&body).map_err(|e| CalError::InvalidQueryBody {
             detail: e.to_string(),
             span: run.span,
         })?;

--- a/crates/areev-cal/src/lexer.rs
+++ b/crates/areev-cal/src/lexer.rs
@@ -388,6 +388,18 @@ pub enum Token {
     #[token("PRIORITY", ignore(ascii_case))]
     Priority,
 
+    /// `LITERAL "…"` — an ASSEMBLE source that is host-supplied text rather
+    /// than a query over grains. Lets a compliance-mandated instruction live
+    /// in the statement as code instead of as a mutable row.
+    #[token("LITERAL", ignore(ascii_case))]
+    Literal,
+
+    /// `PIN` — an ASSEMBLE source modifier marking the source non-degradable:
+    /// it is disclosed in full or the statement errors, never summarised or
+    /// dropped to fit the budget.
+    #[token("PIN", ignore(ascii_case))]
+    Pin,
+
     #[token("FORMAT", ignore(ascii_case))]
     Format,
 
@@ -878,6 +890,8 @@ impl Token {
             Token::Cal => "CAL".into(),
             Token::Recall => "RECALL".into(),
             Token::Assemble => "ASSEMBLE".into(),
+            Token::Literal => "LITERAL".into(),
+            Token::Pin => "PIN".into(),
             Token::Where => "WHERE".into(),
             Token::And => "AND".into(),
             Token::Or => "OR".into(),

--- a/crates/areev-cal/src/parser.rs
+++ b/crates/areev-cal/src/parser.rs
@@ -3799,7 +3799,9 @@ impl Parser {
                     found: format!("{clause} clause out of order"),
                     span: Some(st.span),
                     suggestion: Some(
-                        "ASSEMBLE clauses are ordered: ASSEMBLE \"name\" FOR \"…\" FROM …                          [WHERE …] BUDGET n PRIORITY … FORMAT … WITH dedup. A clause written                          out of order used to be dropped silently — put it in this order."
+                        "ASSEMBLE clauses are ordered: ASSEMBLE \"name\" FOR \"…\" FROM … \
+                         [WHERE …] BUDGET n PRIORITY … FORMAT … WITH dedup. A clause written \
+                         out of order used to be dropped silently — put it in this order."
                             .into(),
                     ),
                 });

--- a/crates/areev-cal/src/parser.rs
+++ b/crates/areev-cal/src/parser.rs
@@ -3772,6 +3772,40 @@ impl Parser {
             (Vec::new(), Vec::new())
         };
 
+        // ── Out-of-order clauses are an error, not a silent detach ───────
+        //
+        // ASSEMBLE's clause order is fixed (OMS §8.2). Every clause is parsed
+        // by an `if self.at_exact(...)` that simply doesn't fire when the
+        // clause arrives late, so a misordered statement PARSED FINE and ran
+        // with the clause missing: `… FORMAT markdown BUDGET 900` silently
+        // dropped the budget and assembled to the 4000-token default. That is
+        // a security-adjacent failure — the guard you wrote is not the guard
+        // that ran — and it was a known bug (docs/facts/context-assembly.md
+        // §12) rather than an unknown one. Anything still sitting here that
+        // belongs to an earlier clause is now refused by name.
+        if let Some(st) = self.peek() {
+            let late = match st.token {
+                Token::Budget => Some("BUDGET"),
+                Token::Priority => Some("PRIORITY"),
+                Token::For => Some("FOR"),
+                Token::Where => Some("WHERE"),
+                Token::Format => Some("FORMAT"),
+                Token::From => Some("FROM"),
+                _ => None,
+            };
+            if let Some(clause) = late {
+                return Err(CalError::UnexpectedToken {
+                    expected: "end of the ASSEMBLE statement".into(),
+                    found: format!("{clause} clause out of order"),
+                    span: Some(st.span),
+                    suggestion: Some(
+                        "ASSEMBLE clauses are ordered: ASSEMBLE \"name\" FOR \"…\" FROM …                          [WHERE …] BUDGET n PRIORITY … FORMAT … WITH dedup. A clause written                          out of order used to be dropped silently — put it in this order."
+                            .into(),
+                    ),
+                });
+            }
+        }
+
         let span_end = self.prev_span();
         Ok(CalStatement::Assemble(AssembleStmt {
             topic,
@@ -3817,6 +3851,46 @@ impl Parser {
                 let sspan = self.current_span();
                 let label = self.parse_label()?;
                 self.expect_exact(&Token::Colon)?;
+                // `PIN` marks the source non-degradable. It sits between the
+                // colon and the body so it reads as a property of the body —
+                // `guardrail: PIN LITERAL "…"`, `turns: PIN (RECALL …)` — and
+                // so a source may still be LABELLED `pin`.
+                let pinned = self.eat_exact(&Token::Pin);
+                // `LITERAL "…"` — host text instead of a query.
+                if self.at_exact(&Token::Literal) {
+                    self.advance();
+                    let text = self.parse_string_literal()?;
+                    sources.push(NamedSource {
+                        label,
+                        // Placeholder: a literal source is never executed. Keeps
+                        // the serialized AST shape stable for existing readers.
+                        query: Box::new(CalStatement::Assemble(AssembleStmt {
+                            topic: String::new(),
+                            from: Source::Parameter {
+                                name: "_literal".to_string(),
+                            },
+                            where_clause: None,
+                            context_name: None,
+                            sources: None,
+                            budget: None,
+                            priority: None,
+                            format: None,
+                            for_whom: None,
+                            assemble_with: Vec::new(),
+                            with_options: Vec::new(),
+                            streaming: false,
+                            span: Some(sspan),
+                        })),
+                        literal: Some(text),
+                        pinned,
+                        with_options: Vec::new(),
+                        span: Some(sspan),
+                    });
+                    if !self.eat_exact(&Token::Comma) {
+                        break;
+                    }
+                    continue;
+                }
                 // Parse the sub-query (in parentheses or bare RECALL),
                 // accepting an optional WITH clause INSIDE the parens.
                 let (query, inside_with) = self.parse_assemble_source_query()?;
@@ -3831,6 +3905,8 @@ impl Parser {
                 sources.push(NamedSource {
                     label,
                     query: Box::new(query),
+                    literal: None,
+                    pinned,
                     with_options,
                     span: Some(sspan),
                 });

--- a/crates/areev-cal/src/render.rs
+++ b/crates/areev-cal/src/render.rs
@@ -273,6 +273,11 @@ pub fn render_grain_sml_at(
         .unwrap_or_default();
 
     match view.grain_type {
+        // An ASSEMBLE `LITERAL` section: host-authored text, emitted exactly
+        // as written. No truncation, no disclosure-level body cap, no summary
+        // form — the point of a literal is that a compliance-mandated
+        // instruction reaches the model unaltered.
+        "literal" => view.get_str("content").unwrap_or("").to_string(),
         "fact" => {
             let s = view.get_str("subject").unwrap_or("?");
             let r = view.get_str("relation").unwrap_or("?");
@@ -672,6 +677,9 @@ pub fn render_grain_summary(view: &GrainView) -> String {
 /// unknown type string.
 fn known_type_summary(view: &GrainView) -> Option<String> {
     let summary = match view.grain_type {
+        // Never summarised: a pinned literal that got shortened at 95% budget
+        // would break exactly the guarantee it exists to give.
+        "literal" => view.get_str("content").unwrap_or("").to_string(),
         "fact" => format!(
             "{} {} {}",
             view.get_str("subject").unwrap_or("?"),
@@ -781,6 +789,9 @@ pub fn render_grain_markdown_at(view: &GrainView, disclosure: Option<Disclosure>
     let get = |k: &str| map.get(k).and_then(|v| v.as_str()).unwrap_or("");
 
     let line = match view.grain_type {
+        // Verbatim, and deliberately unadorned — no bold, no prefix: the host
+        // authored this text for the model to read exactly as written.
+        "literal" => get("content").to_string(),
         "state" => format!("**State**: {}", state_label(view)),
         "workflow" => {
             let label = view
@@ -1056,6 +1067,7 @@ pub fn toon_row(view: &GrainView) -> String {
     let get_f64 = |key: &str| -> Option<f64> { fields.get(key).and_then(|v| v.as_f64()) };
 
     let values: Vec<String> = match view.grain_type {
+        "literal" => vec![String::new(), get_str("content"), String::new()],
         "fact" => {
             let subject = get_str("subject");
             let relation = get_str("relation");

--- a/crates/areev-cal/src/store_types.rs
+++ b/crates/areev-cal/src/store_types.rs
@@ -834,6 +834,23 @@ impl Default for HybridParamsRange {
     }
 }
 
+/// A sort key pushed into the store, rather than applied to whatever page the
+/// statement already returned.
+///
+/// Only fields the `grains` table carries as COLUMNS can be served this way —
+/// in practice `created_at`. Every other sort key callers use (`priority`,
+/// `status`, `confidence`, and all type-specific fields) lives inside the
+/// content-addressed blob, so ordering on it in SQL would mean materializing a
+/// column per field. Those are ranked in the executor instead, over a scan
+/// widened to `max_limit`, with `CAL-W015` when even that scan fills up.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SortKey {
+    /// The field to order by. Currently only `created_at` is index-backed.
+    pub field: String,
+    /// Descending when true.
+    pub descending: bool,
+}
+
 /// Parameters for recall queries.
 #[derive(Debug, Default, Clone)]
 pub struct RecallParams {
@@ -866,6 +883,20 @@ pub struct RecallParams {
     pub include_siblings: Option<bool>,
     /// Filter by user_id.
     pub user_id: Option<String>,
+    /// Filter to one conversation/session, pushed down to `idx_thread(ns,
+    /// session, seq)` rather than post-filtered.
+    ///
+    /// `session_id` is a *type-specific* field (Event, Observation, and the
+    /// other session-bearing types), so it is deliberately NOT in
+    /// `COMMON_FIELDS` — the post-retrieval filter still runs over it as a
+    /// backstop. What this field buys is the SCAN BOUND: without it,
+    /// `RECALL events WHERE session_id = "…"` fell into the unanchored
+    /// recent-by-type scan and filtered a `default_limit` page, so the tail of
+    /// a specific conversation in a busy namespace could be entirely outside
+    /// the window and the query answered "nothing". Set from
+    /// `WHERE session_id = "…"`; consumed by `AreevFacade::recall`, which
+    /// routes the unanchored path to `Areev::recent_in_session`.
+    pub session_id: Option<String>,
     /// Filter by grain type.
     pub grain_type: Option<GrainType>,
     /// Time range start (epoch milliseconds).
@@ -876,6 +907,9 @@ pub struct RecallParams {
     pub confidence_threshold: Option<f64>,
     /// Maximum results to return.
     pub limit: Option<usize>,
+    /// Index-backed ordering, pushed into the store's scan. See [`SortKey`]
+    /// for why this covers `created_at` and not the rest.
+    pub order_by: Option<SortKey>,
     /// Skip superseded grains (default: true).
     pub exclude_superseded: Option<bool>,
     /// Natural-language temporal expression (e.g., "last 7 days", "yesterday").

--- a/crates/areev-cal/tests/cal_integration.rs
+++ b/crates/areev-cal/tests/cal_integration.rs
@@ -2560,3 +2560,50 @@ fn a_pinned_query_source_is_not_degraded_either() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// #44 — the same statement text is parsed once, not once per turn
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repeated_statements_reuse_a_parsed_plan() {
+    let (ex, facade, _d) = setup();
+    add_bulk_events(&facade, 3);
+
+    assert_eq!(ex.plan_cache_len(), 0, "cold");
+    let stmt = r#"RECALL events RECENT 3"#;
+    for _ in 0..10 {
+        ex.execute(stmt, &facade).unwrap();
+    }
+    // Ten executions, one parse — the win a real-time turn actually needs,
+    // and it applies to every surface without an API change.
+    assert_eq!(ex.plan_cache_len(), 1, "one entry for one statement text");
+
+    // A different statement is its own entry; the cache keys on exact text.
+    ex.execute(r#"RECALL events RECENT 2"#, &facade).unwrap();
+    assert_eq!(ex.plan_cache_len(), 2);
+}
+
+#[test]
+fn a_cached_plan_is_not_mutated_by_execution() {
+    let (ex, facade, _d) = setup();
+    use areev_core::types::Fact;
+    for who in ["amy", "bo"] {
+        let mut f = Fact::new(who, "likes", "rust");
+        f.common.namespace = Some("caller".to_string());
+        facade.with_store(|m| m.add(&f)).unwrap();
+    }
+    // LET values are bound INTO the query at execution, so a cached AST that
+    // was handed out by reference would carry one call's bindings into the
+    // next. Same statement twice must give the same answer.
+    let stmt = r#"LET $who = SUBJECTS OF (RECALL facts WHERE relation = "likes");
+                  RECALL facts WHERE subject IN $who"#;
+    let first = ex.execute(stmt, &facade).unwrap();
+    let second = ex.execute(stmt, &facade).unwrap();
+    let n = |r: &areev_cal::executor::CalExecResult| match &r.result {
+        CalResultPayload::Grains { grains, .. } => grains.len(),
+        other => panic!("expected Grains, got {other:?}"),
+    };
+    assert_eq!(n(&first), n(&second), "a cached plan must stay pristine");
+    assert_eq!(n(&first), 2);
+}

--- a/crates/areev-cal/tests/cal_integration.rs
+++ b/crates/areev-cal/tests/cal_integration.rs
@@ -2360,6 +2360,42 @@ fn recency_weight_actually_reranks() {
 }
 
 #[test]
+fn a_zero_recency_weight_still_honours_the_limit() {
+    // `recency_weight` widens the candidate scan so the re-ranking sees the
+    // whole set instead of a page, then truncates back to the caller's bound.
+    // The widening was gated on `is_some()` and the truncation on `> 0.0`, so
+    // a weight of exactly zero — "no recency component", i.e. the same answer
+    // as no option at all — took the wide path and never came back: `RECENT 3`
+    // answered with 3 * RECALL_OVERFETCH grains. A bound that a no-op option
+    // can lift is not a bound.
+    let (ex, facade, _d) = setup();
+    use areev_core::types::Event;
+    for i in 0..12 {
+        let mut e = Event::new(&format!("turn {i}"));
+        e.common.namespace = Some("caller".to_string());
+        facade.with_store(|m| m.add(&e)).unwrap();
+    }
+
+    let n = |stmt: &str| match ex.execute(stmt, &facade).unwrap().result {
+        CalResultPayload::Grains { grains, .. } => grains.len(),
+        other => panic!("expected Grains, got {other:?}"),
+    };
+
+    let baseline = n("RECALL events RECENT 3");
+    assert_eq!(baseline, 3);
+    // Zero, negative and NaN all mean "no recency component" — every one of
+    // them must answer exactly like the bare statement.
+    for stmt in [
+        "RECALL events RECENT 3 WITH recency_weight(0)",
+        "RECALL events RECENT 3 WITH recency_weight(0.0)",
+    ] {
+        assert_eq!(n(stmt), baseline, "{stmt} must respect RECENT 3");
+    }
+    // A real weight still bounds the answer too — the widening is internal.
+    assert_eq!(n("RECALL events RECENT 3 WITH recency_weight(0.5)"), baseline);
+}
+
+#[test]
 fn order_by_created_at_is_pushed_down_and_exact() {
     let (ex, facade, _d) = setup();
     use areev_core::types::Event;

--- a/crates/areev-cal/tests/cal_integration.rs
+++ b/crates/areev-cal/tests/cal_integration.rs
@@ -2121,3 +2121,442 @@ fn warnings_survive_into_the_wire_payload() {
         "no warnings means no key, not an empty array"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #49 — `WHERE session_id` is pushed into the thread index, not post-filtered
+// ---------------------------------------------------------------------------
+
+/// Add `n` events on `session`, through the store directly (CAL text `ADD`
+/// covers fact/observation/goal/skill only).
+fn add_events(facade: &AreevFacade, session: &str, prefix: &str, n: usize) {
+    use areev_core::types::Event;
+    for i in 0..n {
+        let mut e = Event::new(&format!("{prefix} {i}"));
+        e.session_id = Some(session.to_string());
+        e.common.namespace = Some("caller".to_string());
+        facade.with_store(|m| m.add(&e)).unwrap();
+    }
+}
+
+#[test]
+fn recall_by_session_id_is_not_bounded_by_the_default_page() {
+    let (ex, facade, _d) = setup();
+    // The conversation we want, then far more than `default_limit` (50) newer
+    // events on other conversations burying it.
+    add_events(&facade, "call-7", "wanted", 5);
+    for i in 0..200 {
+        add_events(&facade, &format!("other-{i}"), "noise", 1);
+    }
+
+    let res = ex
+        .execute(r#"RECALL events WHERE session_id = "call-7""#, &facade)
+        .unwrap();
+    match res.result {
+        CalResultPayload::Grains { grains, .. } => {
+            // Before the pushdown this was 0: the recent-by-type scan returned
+            // a page of the newest 50 events, none of which were this session's,
+            // and the post-filter then had nothing to keep.
+            assert_eq!(
+                grains.len(),
+                5,
+                "the whole session must come back, not the part that fell in the page"
+            );
+            for g in &grains {
+                let v = serde_json::to_value(g).unwrap();
+                assert_eq!(v["fields"]["session_id"], "call-7");
+            }
+        }
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}
+
+#[test]
+fn recall_by_session_id_needs_no_grain_type() {
+    let (ex, facade, _d) = setup();
+    add_events(&facade, "s1", "turn", 3);
+    // A session is an anchor, so the bare form is bounded and allowed.
+    let res = ex
+        .execute(r#"RECALL WHERE session_id = "s1""#, &facade)
+        .unwrap();
+    match res.result {
+        CalResultPayload::Grains { grains, .. } => assert_eq!(grains.len(), 3),
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}
+
+#[test]
+fn recall_by_session_id_respects_recent_bound() {
+    let (ex, facade, _d) = setup();
+    add_events(&facade, "s1", "turn", 20);
+    let res = ex
+        .execute(r#"RECALL events WHERE session_id = "s1" RECENT 5"#, &facade)
+        .unwrap();
+    match res.result {
+        CalResultPayload::Grains { grains, .. } => {
+            assert_eq!(grains.len(), 5, "RECENT bounds turns of THIS session");
+            let v = serde_json::to_value(&grains[0]).unwrap();
+            assert_eq!(v["fields"]["content"], "turn 19", "newest first");
+        }
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #43 — post-retrieval stages see the whole matching set, not a page of it
+// ---------------------------------------------------------------------------
+
+/// `n` facts whose confidence DESCENDS with insertion order, so the
+/// highest-confidence grains are the OLDEST — outside any newest-first page.
+fn add_ranked_facts(facade: &AreevFacade, n: usize) {
+    use areev_core::types::Fact;
+    for i in 0..n {
+        let mut f = Fact::new(&format!("subj{i}"), "rates", "thing");
+        f.common.namespace = Some("caller".to_string());
+        f.common.confidence = 1.0 - (i as f64) / (n as f64);
+        facade.with_store(|m| m.add(&f)).unwrap();
+    }
+}
+
+#[test]
+fn order_by_ranks_the_whole_set_not_the_default_page() {
+    let (ex, facade, _d) = setup();
+    // 200 facts: the top-confidence ones are the first inserted, so a
+    // newest-first page of `default_limit` (50) contains none of them.
+    add_ranked_facts(&facade, 200);
+
+    let res = ex
+        .execute(
+            r#"RECALL facts ORDER BY confidence DESC LIMIT 5"#,
+            &facade,
+        )
+        .unwrap();
+    match res.result {
+        CalResultPayload::Grains { grains, .. } => {
+            assert_eq!(grains.len(), 5);
+            let top = serde_json::to_value(&grains[0]).unwrap();
+            // Before the widening this returned the top 5 of the newest 50 —
+            // i.e. subj150-ish, confidence ~0.25 — and looked exactly like a
+            // correct answer.
+            assert_eq!(
+                top["fields"]["subject"], "subj0",
+                "ORDER BY must rank the whole matching set, got: {top}"
+            );
+            let confs: Vec<f64> = grains
+                .iter()
+                .map(|g| {
+                    serde_json::to_value(g).unwrap()["fields"]["confidence"]
+                        .as_f64()
+                        .unwrap()
+                })
+                .collect();
+            assert!(
+                confs.windows(2).all(|w| w[0] >= w[1]),
+                "descending, got {confs:?}"
+            );
+            assert!(confs[0] > 0.99, "true top-k, got {confs:?}");
+        }
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_on_a_multi_source_assemble_warns_instead_of_vanishing() {
+    let (ex, facade, _d) = setup();
+    add_ranked_facts(&facade, 3);
+
+    let res = ex
+        .execute(
+            r#"ASSEMBLE "ctx" FROM a: (RECALL facts RECENT 2), b: (RECALL facts RECENT 1) ORDER BY confidence DESC"#,
+            &facade,
+        )
+        .unwrap();
+    // The stage cannot act on an assembly, but it must not disappear in
+    // silence — that was the "wrong answer with no signal" the report named.
+    assert!(
+        res.warnings.iter().any(|w| w.contains("CAL-W016")),
+        "expected CAL-W016, got: {:?}",
+        res.warnings
+    );
+    assert!(
+        res.warnings
+            .iter()
+            .any(|w| w.contains("FROM-clause order")),
+        "the warning should say what DOES control section order, got: {:?}",
+        res.warnings
+    );
+}
+
+#[test]
+fn post_retrieval_where_filter_searches_past_the_page() {
+    let (ex, facade, _d) = setup();
+    use areev_core::types::Goal;
+    // `description` is a Goal-specific field, so it cannot be pushed into
+    // RecallParams and is applied as a post-filter — the second half of the
+    // same defect as ORDER BY. The goal we want is the OLDEST; 200 newer ones
+    // bury it well past the default page.
+    let mut wanted = Goal::new("the needle");
+    wanted.common.namespace = Some("caller".to_string());
+    facade.with_store(|m| m.add(&wanted)).unwrap();
+    for i in 0..200 {
+        let mut g = Goal::new(&format!("hay {i}"));
+        g.common.namespace = Some("caller".to_string());
+        facade.with_store(|m| m.add(&g)).unwrap();
+    }
+
+    let res = ex
+        .execute(r#"RECALL goals WHERE description = "the needle""#, &facade)
+        .unwrap();
+    match res.result {
+        CalResultPayload::Grains { grains, .. } => {
+            assert_eq!(
+                grains.len(),
+                1,
+                "the post-filter must search the widened scan, not the newest page"
+            );
+        }
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}
+
+#[test]
+fn recency_weight_actually_reranks() {
+    let (ex, facade, _d) = setup();
+    use areev_core::types::Event;
+    // Three events, oldest first. Fusion order is newest-first, so without
+    // weighting "old" ranks last; with w=1.0 freshness dominates and the
+    // ordering is purely by age — the same direction, but now a real score.
+    for label in ["old", "mid", "new"] {
+        let mut e = Event::new(label);
+        e.common.namespace = Some("caller".to_string());
+        facade.with_store(|m| m.add(&e)).unwrap();
+    }
+
+    let weighted = ex
+        .execute(
+            r#"RECALL events RECENT 3 WITH recency_weight(0.9)"#,
+            &facade,
+        )
+        .unwrap();
+    match weighted.result {
+        CalResultPayload::Grains { grains, .. } => {
+            assert_eq!(grains.len(), 3);
+            // Every grain carries a real score now; before this the option
+            // parsed, ran, and left all three at the 1.0 sentinel.
+            let scores: Vec<f64> = grains
+                .iter()
+                .map(|g| serde_json::to_value(g).unwrap()["score"].as_f64().unwrap_or(1.0))
+                .collect();
+            assert!(
+                scores.windows(2).all(|w| w[0] >= w[1]),
+                "ranked descending, got {scores:?}"
+            );
+            assert!(
+                scores.iter().any(|s| (*s - 1.0).abs() > f64::EPSILON),
+                "recency_weight must produce real scores, not the 1.0 sentinel: {scores:?}"
+            );
+        }
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}
+
+#[test]
+fn order_by_created_at_is_pushed_down_and_exact() {
+    let (ex, facade, _d) = setup();
+    use areev_core::types::Event;
+    // Backdated: insertion order and created_at disagree, so seq-order and
+    // created_at-order are genuinely different answers. The oldest-by-clock
+    // grain is inserted LAST.
+    for (i, age_days) in [1_i64, 2, 3, 400].iter().enumerate() {
+        let mut e = Event::new(&format!("e{i}"));
+        e.common.namespace = Some("caller".to_string());
+        e.common.created_at = Some(now_ms() - age_days * 86_400_000);
+        facade.with_store(|m| m.add(&e)).unwrap();
+    }
+
+    let res = ex
+        .execute(r#"RECALL events ORDER BY created_at ASC LIMIT 1"#, &facade)
+        .unwrap();
+    match res.result {
+        CalResultPayload::Grains { grains, .. } => {
+            let g = serde_json::to_value(&grains[0]).unwrap();
+            assert_eq!(g["fields"]["content"], "e3", "oldest by clock, not by seq");
+        }
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64
+}
+
+// ---------------------------------------------------------------------------
+// #42 — pinned literal sections, and a render order that is a contract
+// ---------------------------------------------------------------------------
+
+const GUARDRAIL: &str = "Never diagnose, never interpret results, never recommend medication — route clinical questions to staff.";
+
+/// Enough events to blow any small budget several times over.
+fn add_bulk_events(facade: &AreevFacade, n: usize) {
+    use areev_core::types::Event;
+    for i in 0..n {
+        let mut e = Event::new(&format!(
+            "turn {i}: a long conversational message that costs a meaningful number of tokens all by itself"
+        ));
+        e.common.namespace = Some("caller".to_string());
+        facade.with_store(|m| m.add(&e)).unwrap();
+    }
+}
+
+fn rendered(res: &CalResultPayload) -> String {
+    match res {
+        CalResultPayload::Formatted { text, .. } => text.clone(),
+        other => panic!("expected Formatted, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_pinned_literal_survives_a_budget_far_below_the_assembled_size() {
+    let (ex, facade, _d) = setup();
+    add_bulk_events(&facade, 300);
+
+    // 60 tokens is far below what 300 events cost; without PIN the guardrail
+    // would be degraded or dropped like any other source.
+    let res = ex
+        .execute(
+            &format!(
+                r#"ASSEMBLE "turn" FROM guardrail: PIN LITERAL "{GUARDRAIL}", messages: (RECALL events RECENT 300) BUDGET 60 FORMAT markdown"#
+            ),
+            &facade,
+        )
+        .unwrap();
+    let text = rendered(&res.result);
+    assert!(
+        text.contains(GUARDRAIL),
+        "the pinned literal must survive verbatim, got:\n{text}"
+    );
+}
+
+#[test]
+fn a_pin_that_cannot_fit_errors_instead_of_degrading() {
+    let (ex, facade, _d) = setup();
+    // A budget smaller than the pinned text itself. There is no honest
+    // degraded answer here, so it must fail loudly.
+    let err = ex
+        .execute(
+            &format!(
+                r#"ASSEMBLE "turn" FROM guardrail: PIN LITERAL "{GUARDRAIL}", messages: (RECALL events RECENT 5) BUDGET 3 FORMAT markdown"#
+            ),
+            &facade,
+        )
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.starts_with("CAL-E122"), "expected CAL-E122, got: {msg}");
+    assert!(msg.contains("guardrail"), "names the offending source: {msg}");
+}
+
+#[test]
+fn a_literal_renders_at_its_authored_position() {
+    let (ex, facade, _d) = setup();
+    add_bulk_events(&facade, 3);
+
+    // The literal is authored SECOND, between two grain sources.
+    let res = ex
+        .execute(
+            r#"ASSEMBLE "turn" FROM head: (RECALL events RECENT 1), mid: LITERAL "=== MIDDLE MARKER ===", tail: (RECALL events RECENT 1) BUDGET 4000 FORMAT markdown"#,
+            &facade,
+        )
+        .unwrap();
+    let text = rendered(&res.result);
+    let marker = text.find("=== MIDDLE MARKER ===").expect("literal must render");
+    let first_turn = text.find("turn 2").expect("grain sections must render");
+    assert!(
+        first_turn < marker,
+        "the literal renders at its authored index, after the first source:\n{text}"
+    );
+}
+
+#[test]
+fn render_order_is_from_clause_order_not_priority_order() {
+    let (ex, facade, _d) = setup();
+    add_bulk_events(&facade, 2);
+
+    // PRIORITY deliberately names the sources in the REVERSE of FROM order.
+    // Section order must still follow FROM — PRIORITY weights the budget, it
+    // does not reorder. This test pins that contract.
+    let res = ex
+        .execute(
+            r#"ASSEMBLE "turn" FROM alpha: LITERAL "SECTION-ALPHA", beta: LITERAL "SECTION-BETA" BUDGET 4000 PRIORITY beta: 0.9, alpha: 0.1 FORMAT markdown"#,
+            &facade,
+        )
+        .unwrap();
+    let text = rendered(&res.result);
+    let a = text.find("SECTION-ALPHA").expect("alpha renders");
+    let b = text.find("SECTION-BETA").expect("beta renders");
+    assert!(
+        a < b,
+        "FROM-clause order wins over PRIORITY order:\n{text}"
+    );
+}
+
+#[test]
+fn budget_after_format_is_a_parse_error_not_a_silent_detach() {
+    let (ex, facade, _d) = setup();
+    // Before this, the BUDGET simply detached and the assembly ran at the
+    // 4000-token default — the guard you wrote was not the guard that ran.
+    let err = ex
+        .execute(
+            r#"ASSEMBLE "turn" FROM a: (RECALL events RECENT 5) FORMAT markdown BUDGET 900"#,
+            &facade,
+        )
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("BUDGET clause out of order"),
+        "must name the misordered clause, got: {msg}"
+    );
+    assert!(
+        msg.contains("ASSEMBLE clauses are ordered") || msg.contains("order"),
+        "must state the canonical order, got: {msg}"
+    );
+}
+
+#[test]
+fn priority_before_budget_is_also_refused() {
+    let (ex, facade, _d) = setup();
+    // The other half of the same footgun, recorded in
+    // docs/facts/context-assembly.md §12.
+    let err = ex
+        .execute(
+            r#"ASSEMBLE "turn" FROM a: (RECALL events RECENT 5) PRIORITY a: 1.0 BUDGET 900"#,
+            &facade,
+        )
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("BUDGET clause out of order"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn a_pinned_query_source_is_not_degraded_either() {
+    let (ex, facade, _d) = setup();
+    add_bulk_events(&facade, 200);
+
+    // PIN is not literal-only: the last 3 turns can be made non-degradable too.
+    let res = ex
+        .execute(
+            r#"ASSEMBLE "turn" FROM turns: PIN (RECALL events RECENT 3), history: (RECALL events RECENT 200) BUDGET 300 FORMAT markdown"#,
+            &facade,
+        )
+        .unwrap();
+    let text = rendered(&res.result);
+    for i in 197..200 {
+        assert!(
+            text.contains(&format!("turn {i}")),
+            "pinned turn {i} must survive the budget:\n{text}"
+        );
+    }
+}

--- a/crates/areev-cli/src/main.rs
+++ b/crates/areev-cli/src/main.rs
@@ -4811,13 +4811,39 @@ fn seed_demo(m: &mut Areev, ns: &str) -> Result<usize, String> {
     Ok(grains.len())
 }
 
+/// The stack `run` is given, independent of the platform default.
+///
+/// Windows hands a process's main thread 1 MiB; Linux and macOS hand it 8.
+/// The deepest CLI paths — `loop apply`, which threads the giant `run`
+/// dispatcher frame through the engine, the substrate adapter, the CAL facade
+/// and the store — sit just over that 1 MiB in a debug build, so the same
+/// command that works everywhere else aborted on Windows with
+/// STATUS_STACK_OVERFLOW and no message. Depending on the host default meant
+/// depending on a number the platform picks; this picks it.
+const CLI_STACK_BYTES: usize = 16 * 1024 * 1024;
+
 fn main() -> ExitCode {
-    match run() {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(e) => {
+    // Run the whole CLI on a thread whose stack size we chose. Cheap (one
+    // spawn per process) and it makes stack headroom identical on every
+    // platform instead of 8x smaller on one of them.
+    let worker = std::thread::Builder::new()
+        .stack_size(CLI_STACK_BYTES)
+        .spawn(run);
+    let result = match worker {
+        Ok(h) => h.join(),
+        // Spawning failed (a resource limit, not a bug in `run`): fall back to
+        // this thread rather than refusing to run at all.
+        Err(_) => Ok(run()),
+    };
+    match result {
+        Ok(Ok(())) => ExitCode::SUCCESS,
+        Ok(Err(e)) => {
             eprintln!("areev: {e}");
             ExitCode::FAILURE
         }
+        // The worker panicked. Its own hook has already printed the panic;
+        // adding a second message would just bury it.
+        Err(_) => ExitCode::FAILURE,
     }
 }
 

--- a/crates/areev-cli/src/main.rs
+++ b/crates/areev-cli/src/main.rs
@@ -209,6 +209,11 @@ COMMANDS:
                                       keyword cues, dictionary). Reads stdin
                                       when --text is absent; prints JSON.
                                       Pure text — needs no memory file.
+  anonymize test --fixtures F [--policy-file F]
+                                      Assert a policy against a fixture file
+                                      of must-redact / must-not-redact strings.
+                                      Exits non-zero on any miss or false
+                                      positive — run it in CI.
   anonymize set --ns NS (--policy-file F | --policy JSON)
                                       declare a per-namespace egress/audit
                                       policy (travels with the file; stamps
@@ -1012,6 +1017,77 @@ Nothing was written — apply the snippet yourself (or rerun with your own paths
             "{}",
             serde_json::to_string_pretty(&out).map_err(|e| e.to_string())?
         );
+        return Ok(());
+    }
+
+    // `anonymize test` is pure text processing too: a policy plus a fixture
+    // file, no store. It exists because an untestable egress control is close
+    // to an unusable one — an operator could not assert "this policy must
+    // redact these strings and must not redact those" and have CI fail on a
+    // regression, which is the first artifact an auditor asks to see.
+    if cmd == "anonymize" && positional.first().map(String::as_str) == Some("test") {
+        let path = flag(&flags, "fixtures")
+            .ok_or("anonymize test requires --fixtures <FILE> (JSON)")?;
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| format!("--fixtures {path}: {e}"))?;
+        let fx: serde_json::Value =
+            serde_json::from_str(&raw).map_err(|e| format!("--fixtures {path}: {e}"))?;
+        let must_redact = fixture_strings(&fx, "must_redact", &path)?;
+        let must_not_redact = fixture_strings(&fx, "must_not_redact", &path)?;
+        // A policy on the CLI overrides the one in the file, so one fixture
+        // set can be run against a candidate policy before it is deployed.
+        let policy = match flag(&flags, "policy-file") {
+            Some(pp) => {
+                let json = std::fs::read_to_string(&pp)
+                    .map_err(|e| format!("--policy-file {pp}: {e}"))?;
+                areev_core::anon::AnonPolicy::from_json(&json).map_err(|e| e.to_string())?
+            }
+            None => match fx.get("policy") {
+                Some(v) => areev_core::anon::AnonPolicy::from_json(&v.to_string())
+                    .map_err(|e| e.to_string())?,
+                None => return Err(format!("{path} has no \"policy\" and no --policy-file given")),
+            },
+        };
+
+        let mut misses: Vec<String> = Vec::new();
+        let mut false_positives: Vec<String> = Vec::new();
+        for want in &must_redact {
+            let got = areev_core::anon::anonymize(want, &policy, &[], None)
+                .map_err(|e| e.to_string())?;
+            // "Redacted" means the text changed: the policy acted on it,
+            // whether by pseudonym, mask or redaction.
+            if got.text == *want {
+                misses.push(want.clone());
+            }
+        }
+        for want in &must_not_redact {
+            let got = areev_core::anon::anonymize(want, &policy, &[], None)
+                .map_err(|e| e.to_string())?;
+            if got.text != *want {
+                false_positives.push(format!("{want}  ->  {}", got.text));
+            }
+        }
+
+        let total = must_redact.len() + must_not_redact.len();
+        let failed = misses.len() + false_positives.len();
+        for m in &misses {
+            eprintln!("MISS (should have been redacted): {m}");
+        }
+        for f in &false_positives {
+            eprintln!("FALSE POSITIVE (should have been left alone): {f}");
+        }
+        println!(
+            "{} fixtures: {} passed, {} failed ({} missed, {} false positive)",
+            total,
+            total - failed,
+            failed,
+            misses.len(),
+            false_positives.len()
+        );
+        if failed > 0 {
+            // Non-zero exit is the point: this runs in CI.
+            std::process::exit(1);
+        }
         return Ok(());
     }
 
@@ -2688,6 +2764,37 @@ Nothing was written — apply the snippet yourself (or rerun with your own paths
 /// every other bulk erasure. The governed alternative is the loop's
 /// `retention_sweep` analyzer, which proposes the same purge through review
 /// and audit instead of performing it.
+/// A declarative anonymization fixture set (issue #47).
+///
+/// ```json
+/// {
+///   "policy": { "mode": "egress", "categories": { "sg_nric": "redact" } },
+///   "must_redact":     ["NRIC S1234567D", "MRN 00456123"],
+///   "must_not_redact": ["invoice 4471820", "2026-08-19"]
+/// }
+/// ```
+///
+/// Deliberately symmetric: a policy that redacts everything passes
+/// `must_redact` trivially, so the `must_not_redact` half is what stops an
+/// over-broad policy from looking correct.
+///
+/// Read with the `serde_json` value API rather than a derive — this crate
+/// hand-rolls its argument parsing and carries no `serde` derive dependency.
+fn fixture_strings(root: &serde_json::Value, key: &str, path: &str) -> Result<Vec<String>, String> {
+    match root.get(key) {
+        None => Ok(Vec::new()),
+        Some(serde_json::Value::Array(items)) => items
+            .iter()
+            .map(|v| {
+                v.as_str()
+                    .map(str::to_string)
+                    .ok_or_else(|| format!("{path}: every \"{key}\" entry must be a string"))
+            })
+            .collect(),
+        Some(_) => Err(format!("{path}: \"{key}\" must be an array of strings")),
+    }
+}
+
 /// `areev anonymize <set|list|clear|mappings>` — the per-namespace policy
 /// surface (docs/anonymization-proposal.md P1). `scan` is handled pre-open.
 fn run_anonymize(

--- a/crates/areev-cli/tests/cli_smoke.rs
+++ b/crates/areev-cli/tests/cli_smoke.rs
@@ -1465,3 +1465,56 @@ fn blob_put_get_roundtrip() {
     assert!(!ok, "an unknown subcommand must fail");
     assert!(err.contains("blob put|get"), "the refusal should name the verbs: {err}");
 }
+
+/// `areev anonymize test --fixtures` — the CI gate for an egress policy
+/// (issue #47). An untestable policy on an egress path is close to an
+/// unusable one; this is the artifact an auditor asks for, so its exit code
+/// is the contract, not its output.
+#[test]
+fn anonymize_fixtures_gate_a_policy_in_both_directions() {
+    let dir = TempDir::new().unwrap();
+    let good = dir.path().join("good.json");
+    std::fs::write(
+        &good,
+        r#"{
+          "policy": {
+            "mode": "egress",
+            "default_action": "allow",
+            "categories": { "sg_nric": "redact", "mrn": "redact", "email": "redact" }
+          },
+          "must_redact": [
+            "NRIC S1234567D on file",
+            "MRN 00456123 admitted",
+            "contact jane@example.com"
+          ],
+          "must_not_redact": [
+            "invoice total 4471820 aed",
+            "S1234567A is not a valid NRIC",
+            "the ward saw 12345678 visitors"
+          ]
+        }"#,
+    )
+    .unwrap();
+    let (ok, out, err) = areev(&["anonymize", "test", "--fixtures", good.to_str().unwrap()]);
+    assert!(ok, "a satisfied fixture set must exit 0\nstdout: {out}\nstderr: {err}");
+    assert!(out.contains("6 passed"), "got: {out}");
+
+    // The negative half is what stops an over-broad policy from looking
+    // correct: redacting everything passes must_redact trivially.
+    let bad = dir.path().join("bad.json");
+    std::fs::write(
+        &bad,
+        r#"{
+          "policy": { "mode": "egress", "default_action": "redact" },
+          "must_redact": ["NRIC S1234567D"],
+          "must_not_redact": ["contact jane@example.com"]
+        }"#,
+    )
+    .unwrap();
+    let (ok, out, err) = areev(&["anonymize", "test", "--fixtures", bad.to_str().unwrap()]);
+    assert!(!ok, "a false positive must fail the run\nstdout: {out}");
+    assert!(
+        err.contains("FALSE POSITIVE"),
+        "the failure must name what went wrong, got: {err}"
+    );
+}

--- a/crates/areev-conformance/Cargo.toml
+++ b/crates/areev-conformance/Cargo.toml
@@ -23,3 +23,11 @@ serde_json = "1"
 # The CAL-over-backend smoke drives the full stack (executor -> facade ->
 # store) against each backend.
 areev-cal = { path = "../areev-cal" }
+# ONLY for the reconnect-after-outage case: simulating a managed-Postgres
+# restart means terminating the store's backend from a SECOND connection
+# (`pg_terminate_backend`), which no public store API can or should do. Both
+# crates are already in the tree behind `areev-store/postgres`; this is a
+# dev-dependency on a `publish = false` crate, so it adds nothing to any
+# shipped artifact.
+tokio = { version = "1", features = ["rt", "macros"] }
+tokio-postgres = "0.7"

--- a/crates/areev-conformance/src/cases/meta_registry.rs
+++ b/crates/areev-conformance/src/cases/meta_registry.rs
@@ -210,7 +210,7 @@ pub fn vault_rows_never_replicate(b: &dyn Backend) {
 /// unencrypted file, or ANY Postgres schema (the page cipher is
 /// file-backend-only) — must refuse those declarations loudly at `set`,
 /// never degrade to unkeyed derivation. Plain egress stays available.
-pub fn value_derived_anon_refuses_without_page_key(b: &dyn Backend) {
+pub fn value_derived_anon_refuses_without_key_material(b: &dyn Backend) {
     let mut m = b.open_named("anon_nokey");
     for policy in [
         r#"{"mode": "ingress"}"#,
@@ -220,8 +220,8 @@ pub fn value_derived_anon_refuses_without_page_key(b: &dyn Backend) {
     ] {
         let err = m.set_anon_policy("ns", policy).unwrap_err().to_string();
         assert!(
-            err.contains("encrypted"),
-            "expected an encrypted-memory refusal for {policy}, got: {err}"
+            err.contains("anon_key"),
+            "the refusal must name the fix that works on EVERY backend, got: {err}"
         );
     }
     // The keyless-safe modes still work end to end.
@@ -229,6 +229,47 @@ pub fn value_derived_anon_refuses_without_page_key(b: &dyn Backend) {
     m.add(&fact("ns", "caller:john", "prefers", "tea")).unwrap();
     let got = m.recall("ns", "caller:john", None, 4).unwrap();
     assert_eq!(got[0].fields["subject"], "[PERSON_1]", "egress must work keyless");
+}
+
+/// A host-supplied `anon_key` unlocks value-derived tokens and the mapping
+/// vault on EVERY backend — the gap that made reversible pseudonymisation
+/// unusable exactly where it was most wanted.
+///
+/// The Postgres backend refuses `encryption_key` (it is a page-cipher
+/// capability), and the vault key used to be HKDF-derived from that page key
+/// alone. So on a stateless host — Cloud Run, ECS, Kubernetes, i.e. the
+/// deployments the Postgres backend exists to serve — mappings could not
+/// persist and deterministic tokens were unavailable entirely. The key is
+/// host-supplied and never persisted, so this case also pins that the vault
+/// rows survive a REOPEN with the same key: that is what makes de-anonymisation
+/// work across processes and instances rather than within one lifetime.
+pub fn host_anon_key_unlocks_the_vault(b: &dyn Backend) {
+    let key = [7u8; 32];
+    let opts = || areev_store::AreevOptions {
+        anon_key: Some(key),
+        ..Default::default()
+    };
+
+    let mut m = b.open_named_with("anon_hostkey", opts());
+    // A vault-enabled policy is accepted with no page cipher in sight.
+    m.set_anon_policy("ns", r#"{"mode": "egress", "scope": "memory", "vault": true}"#)
+        .expect("a host-supplied anon_key must satisfy a vault-enabled policy");
+    m.add(&fact("ns", "caller:john", "prefers", "tea")).unwrap();
+    let first = m.recall("ns", "caller:john", None, 4).unwrap();
+    let token = first[0].fields["subject"].as_str().unwrap().to_string();
+    assert_ne!(token, "caller:john", "the identity must not reach the caller");
+    drop(m);
+
+    // Reopened with the SAME key: the token is reproducible, which is the
+    // property counter tokens cannot give and the whole reason for HMAC-derived
+    // ones. Vault rows written before the drop are still readable.
+    let mut m2 = b.open_named_with("anon_hostkey", opts());
+    m2.add(&fact("ns", "caller:john", "drinks", "coffee")).unwrap();
+    let again = m2.recall("ns", "caller:john", None, 8).unwrap();
+    assert!(
+        again.iter().all(|g| g.fields["subject"] == serde_json::json!(token)),
+        "the same identity must map to the same pseudonym across processes"
+    );
 }
 
 // ---- trigger evaluation state (`trg:`) -----------------------------------

--- a/crates/areev-conformance/src/lib.rs
+++ b/crates/areev-conformance/src/lib.rs
@@ -31,6 +31,13 @@ pub trait Backend {
     /// isolation unit.
     fn open_named(&self, name: &str) -> Areev;
 
+    /// [`open_named`](Self::open_named) with explicit host options — the seam
+    /// for capabilities that are host config rather than file-truths (an
+    /// `anon_key`, an embedder). Each backend routes to its own
+    /// `open_with`-family constructor, so a case can assert that a capability
+    /// behaves identically whether the memory is a file or a schema.
+    fn open_named_with(&self, name: &str, opts: areev_store::AreevOptions) -> Areev;
+
     /// A scratch directory for interchange files (bundles). Backend-neutral:
     /// bundles are files regardless of where the store lives.
     fn scratch(&self) -> &Path;
@@ -59,6 +66,11 @@ impl Backend for TursoBackend {
     fn open_named(&self, name: &str) -> Areev {
         let path = self.dir.path().join(format!("{name}.db"));
         Areev::open(path.to_str().expect("utf8 path")).expect("open turso store")
+    }
+
+    fn open_named_with(&self, name: &str, opts: areev_store::AreevOptions) -> Areev {
+        let path = self.dir.path().join(format!("{name}.db"));
+        Areev::open_with(path.to_str().expect("utf8 path"), opts).expect("open turso store")
     }
 
     fn scratch(&self) -> &Path {
@@ -114,6 +126,12 @@ impl Backend for PgBackend {
         let schema = format!("{}_{}", self.prefix, name);
         self.opened.borrow_mut().insert(schema.clone());
         Areev::open_postgres(&self.url, &schema).expect("open postgres store")
+    }
+
+    fn open_named_with(&self, name: &str, opts: areev_store::AreevOptions) -> Areev {
+        let schema = format!("{}_{}", self.prefix, name);
+        self.opened.borrow_mut().insert(schema.clone());
+        Areev::open_postgres_with(&self.url, &schema, opts).expect("open postgres store")
     }
 
     fn scratch(&self) -> &Path {
@@ -186,7 +204,8 @@ macro_rules! for_each_conformance_case {
         $per_case!(vault_rows_never_replicate);
         $per_case!(trigger_state_never_replicates);
         $per_case!(meta_cas_admits_one_claimer_and_fences_the_loser);
-        $per_case!(value_derived_anon_refuses_without_page_key);
+        $per_case!(value_derived_anon_refuses_without_key_material);
+        $per_case!(host_anon_key_unlocks_the_vault);
         // CAS blobs + hybrid legs
         $per_case!(cas_blob_roundtrip_and_gc);
         $per_case!(forget_reclaims_sole_referenced_blob);

--- a/crates/areev-conformance/tests/pg.rs
+++ b/crates/areev-conformance/tests/pg.rs
@@ -255,3 +255,89 @@ fn file_only_capabilities_are_rejected() {
     };
     assert!(err.to_string().contains("file-backend capability"), "{err}");
 }
+
+/// A managed database restarts under a long-lived handle.
+///
+/// This is the finding that would have caused a production incident: `PgDb`
+/// held ONE `tokio_postgres::Client` with no reconnect, so a routine Cloud SQL
+/// maintenance restart (`57P01 terminating connection due to administrator
+/// command`) permanently poisoned the handle — the process stayed alive and
+/// every later call failed until the instance happened to be recycled.
+///
+/// The contract asserted here is deliberately asymmetric:
+///   * a READ is replayed transparently — it had no effect, so running it
+///     twice is running it once;
+///   * a WRITE is NOT replayed — the connection may have died AFTER the server
+///     committed it, and replaying would risk applying it twice. It reports the
+///     failure and reconnects for the next call.
+///
+/// The kill is scoped by `application_name` to THIS handle's connection.
+/// Terminating every backend on the database (the obvious way to write it)
+/// also kills the connections of every other test sharing the server, since
+/// cargo runs them in parallel.
+#[test]
+fn a_handle_recovers_from_a_database_outage() {
+    let Some(b) = backend() else { return };
+    let base = pg_url().unwrap();
+    let schema = b.schema_for("outage");
+    const APP: &str = "areev_outage_probe";
+    let sep = if base.contains('?') { '&' } else { '?' };
+    let tagged = format!("{base}{sep}application_name={APP}");
+
+    let mut m = areev_store::Areev::open_postgres(&tagged, &schema).unwrap();
+    m.add(&areev_conformance::fact("ns", "before", "wrote", "ok"))
+        .unwrap();
+    assert_eq!(m.count().unwrap(), 1);
+
+    // What a restart or failover looks like from the client's side.
+    let kill = |url: &str| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (client, conn) = tokio_postgres::connect(url, tokio_postgres::NoTls)
+                .await
+                .unwrap();
+            tokio::spawn(async move {
+                let _ = conn.await;
+            });
+            client
+                .simple_query(&format!(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+                     WHERE datname = current_database() AND application_name = '{APP}' \
+                       AND pid <> pg_backend_pid()"
+                ))
+                .await
+                .unwrap();
+        });
+    };
+
+    // ── A read survives the outage ───────────────────────────────────────
+    kill(&base);
+    assert_eq!(
+        m.count().unwrap(),
+        1,
+        "a read must reconnect and replay — before this it failed forever"
+    );
+
+    // ── Reads keep working afterwards (the statement cache was rebuilt) ──
+    // A reconnect that kept the old session's prepared statements would fail
+    // here with 26000 invalid_sql_statement_name instead.
+    assert_eq!(
+        m.recall("ns", "before", Some("wrote"), 4).unwrap().len(),
+        1,
+        "hot/prepared paths must work on the new session"
+    );
+
+    // ── A write is not silently replayed, but the handle recovers ────────
+    kill(&base);
+    // This call may fail (its connection is gone) — what must NOT happen is
+    // the handle staying dead.
+    let _ = m.add(&areev_conformance::fact("ns", "during", "wrote", "maybe"));
+    m.add(&areev_conformance::fact("ns", "after", "wrote", "ok"))
+        .expect("the handle must be usable again after an outage");
+
+    // And it is a real, queryable write on the same memory.
+    assert_eq!(m.recall("ns", "after", Some("wrote"), 4).unwrap().len(), 1);
+}

--- a/crates/areev-core/src/anon/detect.rs
+++ b/crates/areev-core/src/anon/detect.rs
@@ -33,6 +33,11 @@ pub const KNOWN_CATEGORIES: &[&str] = &[
     "otp",
     "account_number",
     "custom",
+    // National / health identifiers (issue #47). Every one of these is
+    // checksum-validated or cue-gated — see the individual detectors.
+    "sg_nric",
+    "ae_eid",
+    "mrn",
 ];
 
 fn re(cell: &'static OnceLock<Regex>, pattern: &str) -> &'static Regex {
@@ -61,6 +66,7 @@ pub(super) fn run_tier0(
     text: &str,
     custom_terms: &[String],
     known_identities: &[String],
+    term_sets: &std::collections::BTreeMap<String, Vec<String>>,
 ) -> Result<Vec<Detection>> {
     let mut out = Vec::new();
     detect_email(text, &mut out);
@@ -72,9 +78,18 @@ pub(super) fn run_tier0(
     detect_date(text, &mut out);
     detect_credit_card(text, &mut out);
     detect_iban(text, &mut out);
+    detect_sg_nric(text, &mut out);
+    detect_ae_eid(text, &mut out);
+    detect_mrn(text, &mut out);
     detect_secret(text, &mut out);
     detect_keyword_proximity(text, &mut out);
     detect_terms(text, custom_terms, "custom", "tier0.dictionary", &mut out)?;
+    // Named dictionaries: each set emits its OWN category, which is what makes
+    // a co-occurrence rule expressible ("person near condition"). One shared
+    // `custom` bucket could not distinguish the two halves of the rule.
+    for (category, terms) in term_sets {
+        detect_terms(text, terms, category, "tier0.term_set", &mut out)?;
+    }
     let identity_terms = identity_match_terms(known_identities);
     detect_terms(text, &identity_terms, "person", "tier0.known_identity", &mut out)?;
     Ok(out)
@@ -257,6 +272,109 @@ fn detect_iban(text: &str, out: &mut Vec<Detection>) {
     for m in re.find_iter(text) {
         if boundary_ok(text, m.start(), m.end()) && iban_mod97_ok(m.as_str()) {
             out.push(det(m.start(), m.end(), "iban", "tier0.iban"));
+        }
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// National / health identifiers (issue #47)
+// ---------------------------------------------------------------------------
+//
+// These are the identifiers a health regulator actually asks about, and the
+// reason they belong in a precision-first tier is that the important ones
+// carry checksums: an NRIC-shaped string that fails its check digit is not an
+// NRIC, so the false-positive rate is near zero rather than "one letter
+// followed by seven digits". Where a family has no checksum (MRN), the
+// detector is gated on a nearby cue word instead of matching bare digit runs.
+
+/// Singapore NRIC / FIN — `[STFGM]` + 7 digits + a check letter.
+///
+/// Weighted mod-11 over the seven digits (weights 2,7,6,5,4,3,2), an offset
+/// that encodes the issue era (T/G +4, M +3), and a prefix-class letter table.
+/// Wrong check letter → not a detection.
+fn detect_sg_nric(text: &str, out: &mut Vec<Detection>) {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = re(&RE, r"[STFGMstfgm][0-9]{7}[A-Za-z]");
+    for m in re.find_iter(text) {
+        if boundary_ok(text, m.start(), m.end()) && sg_nric_ok(m.as_str()) {
+            out.push(det(m.start(), m.end(), "sg_nric", "tier0.sg_nric"));
+        }
+    }
+}
+
+fn sg_nric_ok(s: &str) -> bool {
+    let up = s.to_ascii_uppercase();
+    let b = up.as_bytes();
+    if b.len() != 9 {
+        return false;
+    }
+    const W: [u32; 7] = [2, 7, 6, 5, 4, 3, 2];
+    let mut sum: u32 = 0;
+    for i in 0..7 {
+        let d = (b[1 + i] as char).to_digit(10);
+        match d {
+            Some(v) => sum += v * W[i],
+            None => return false,
+        }
+    }
+    // Era offset: T/G are the 2000s series, M the 2022 foreigner series.
+    let (offset, table): (u32, &[u8; 11]) = match b[0] {
+        b'S' => (0, b"JZIHGFEDCBA"),
+        b'T' => (4, b"JZIHGFEDCBA"),
+        b'F' => (0, b"XWUTRQPNMLK"),
+        b'G' => (4, b"XWUTRQPNMLK"),
+        b'M' => (3, b"KLJNPQRTUWX"),
+        _ => return false,
+    };
+    table[((sum + offset) % 11) as usize] == b[8]
+}
+
+/// UAE Emirates ID — 15 digits, `784-YYYY-NNNNNNN-C`, Luhn-checked.
+///
+/// The `784` issuer prefix plus a Luhn check makes this specific enough to
+/// run unconditionally; without the prefix check, any 15-digit run that
+/// happened to satisfy Luhn would match.
+fn detect_ae_eid(text: &str, out: &mut Vec<Detection>) {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = re(&RE, r"784[- ]?[0-9]{4}[- ]?[0-9]{7}[- ]?[0-9]");
+    for m in re.find_iter(text) {
+        let digits: String = m.as_str().chars().filter(char::is_ascii_digit).collect();
+        let vals: Vec<u8> = digits
+            .chars()
+            .filter_map(|c| c.to_digit(10).map(|d| d as u8))
+            .collect();
+        if vals.len() == 15 && boundary_ok(text, m.start(), m.end()) && luhn_ok(&vals) {
+            out.push(det(m.start(), m.end(), "ae_eid", "tier0.ae_eid"));
+        }
+    }
+}
+
+/// Medical record numbers — shape alone is a bare digit run, which is why
+/// this is CUE-GATED rather than pattern-only: a 6–12 digit run counts only
+/// when an MRN cue word sits within 40 characters before it. Matching bare
+/// digit runs would redact every quantity in a clinical note.
+fn detect_mrn(text: &str, out: &mut Vec<Detection>) {
+    static CUE: OnceLock<Regex> = OnceLock::new();
+    static NUM: OnceLock<Regex> = OnceLock::new();
+    let cue = re(
+        &CUE,
+        r"(?i)\b(mrn|medical record (no\.?|number)|patient (id|number)|chart (no\.?|number)|hospital number)\b",
+    );
+    let num = re(&NUM, r"[A-Za-z]{0,3}[0-9]{6,12}");
+    let cues: Vec<usize> = cue.find_iter(text).map(|m| m.end()).collect();
+    if cues.is_empty() {
+        return;
+    }
+    for m in num.find_iter(text) {
+        if !boundary_ok(text, m.start(), m.end()) {
+            continue;
+        }
+        let near = cues
+            .iter()
+            .any(|c| m.start() >= *c && m.start().saturating_sub(*c) <= 40);
+        if near {
+            out.push(det(m.start(), m.end(), "mrn", "tier0.mrn"));
         }
     }
 }
@@ -463,7 +581,7 @@ mod tests {
     use super::*;
 
     fn cats(text: &str) -> Vec<(String, String)> {
-        let dets = run_tier0(text, &[], &[]).unwrap();
+        let dets = run_tier0(text, &[], &[], &Default::default()).unwrap();
         dets.iter().map(|d| (d.category.clone(), text[d.start..d.end].to_string())).collect()
     }
 
@@ -485,5 +603,81 @@ mod tests {
     #[test]
     fn plain_digit_runs_are_not_phones() {
         assert!(cats("in 2026 there were 1462 cases").is_empty());
+    }
+}
+
+#[cfg(test)]
+mod national_id_tests {
+    use super::*;
+
+    fn cats(text: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        run_tier0(text, &[], &[], &Default::default()).unwrap();
+        let mut d = Vec::new();
+        detect_sg_nric(text, &mut d);
+        detect_ae_eid(text, &mut d);
+        detect_mrn(text, &mut d);
+        for x in d {
+            out.push(format!("{}:{}", x.category, &text[x.start..x.end]));
+        }
+        out
+    }
+
+    #[test]
+    fn sg_nric_checksum_gates_the_detection() {
+        // One valid value per prefix class, each with its era offset applied.
+        for valid in ["S1234567D", "T1234567J", "F1234567N", "G1234567X", "M1234567X"] {
+            assert!(sg_nric_ok(valid), "{valid} must validate");
+            assert_eq!(cats(&format!("nric {valid} on file")).len(), 1, "{valid}");
+        }
+        // Same shape, wrong check letter — precision-first means this is NOT a
+        // detection, not a low-confidence one.
+        for invalid in ["S1234567A", "T1234567D", "F1234567D", "Z1234567D"] {
+            assert!(!sg_nric_ok(invalid), "{invalid} must not validate");
+            assert!(cats(&format!("nric {invalid}")).is_empty(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn sg_nric_is_case_insensitive_but_bounded() {
+        assert_eq!(cats("s1234567d").len(), 1);
+        // Embedded in a longer alphanumeric run: not a standalone identifier.
+        assert!(cats("XS1234567D9").is_empty());
+    }
+
+    #[test]
+    fn ae_eid_needs_the_issuer_prefix_and_luhn() {
+        // 784-1985-1234567-C: solve for the Luhn check digit.
+        let base = "78419851234567";
+        let vals: Vec<u8> = base.chars().map(|c| c.to_digit(10).unwrap() as u8).collect();
+        let check = (0..10u8)
+            .find(|c| {
+                let mut v = vals.clone();
+                v.push(*c);
+                luhn_ok(&v)
+            })
+            .expect("a Luhn check digit always exists");
+        let eid = format!("784-1985-1234567-{check}");
+        assert_eq!(cats(&format!("emirates id {eid}")).len(), 1, "{eid}");
+
+        // Wrong check digit, and a 15-digit run without the 784 prefix.
+        let bad = format!("784-1985-1234567-{}", (check + 1) % 10);
+        assert!(cats(&bad).is_empty(), "{bad} must fail Luhn");
+        assert!(cats("123456789012345").is_empty(), "no issuer prefix");
+    }
+
+    #[test]
+    fn mrn_needs_a_cue_word() {
+        // Cue-gated: the same digit run is PHI next to "MRN" and a quantity
+        // otherwise. Matching bare runs would redact every number in a note.
+        assert_eq!(cats("MRN 00456123 admitted").len(), 1);
+        assert_eq!(cats("Medical Record Number: 4471820").len(), 1);
+        assert!(
+            cats("the ward handled 4471820 samples last year").is_empty(),
+            "a bare digit run is not an MRN"
+        );
+        // Cue present but far away — outside the proximity window.
+        let far = format!("MRN was not recorded.{} 4471820", " ".repeat(60));
+        assert!(cats(&far).is_empty(), "proximity window must bound the cue");
     }
 }

--- a/crates/areev-core/src/anon/mod.rs
+++ b/crates/areev-core/src/anon/mod.rs
@@ -168,6 +168,32 @@ fn default_min_confidence() -> f32 {
     0.5
 }
 
+/// "Redact category A when category B appears within N characters."
+///
+/// Expressed as a RE-CATEGORIZATION rather than a bare action override: the
+/// matching detection takes `as_category`, and the policy's ordinary
+/// `categories` map then decides what happens to it. That keeps one place
+/// where actions are decided, and it makes the output self-explaining — the
+/// placeholder says `[PHI_1]` rather than `[PERSON_1]`, so a reader can see
+/// WHY the span was treated more strictly than a bare name would be.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CoOccurrence {
+    /// The category to escalate (e.g. `person`).
+    pub when: String,
+    /// The category whose nearby presence triggers it (e.g. `condition`,
+    /// usually supplied via [`AnonPolicy::term_sets`]).
+    pub near: String,
+    /// Proximity window in characters, measured between span edges.
+    #[serde(default = "default_within_chars")]
+    pub within_chars: usize,
+    /// The category the `when` detection takes on when the rule fires.
+    pub as_category: String,
+}
+
+fn default_within_chars() -> usize {
+    120
+}
+
 /// The declarative anonymization policy (proposal §8.1). Serialized as the
 /// JSON value of an `anon:<ns>` meta row from P1 on; in P0 it is supplied
 /// explicitly to the text APIs.
@@ -190,6 +216,23 @@ pub struct AnonPolicy {
     /// User dictionary; matches become category `custom`.
     #[serde(default)]
     pub custom_terms: Vec<String>,
+    /// Named dictionaries: `category -> terms`. Each set's matches carry that
+    /// category, so the policy can act on them separately and — the reason
+    /// they exist — so a [`CoOccurrence`] rule can NAME one side of the
+    /// relationship. The single `custom_terms` bucket cannot express
+    /// "a person near a condition" because both halves land in `custom`.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub term_sets: BTreeMap<String, Vec<String>>,
+    /// Context-sensitive escalation: re-categorize a detection when another
+    /// category appears close to it.
+    ///
+    /// This is the rule healthcare actually needs and no per-category action
+    /// can express. A name alone may be acceptable in a prompt; a name
+    /// *together with* a condition, medication or procedure in the same span
+    /// is health data under most privacy regimes. The distinction is not a
+    /// property of either detection — it is a property of the pair.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub co_occurrence: Vec<CoOccurrence>,
     /// Pseudonym stability scope. P0 supports `context` only (per-call
     /// numbering); `session`/`memory` arrive with the store boundary.
     #[serde(default = "default_scope")]
@@ -250,6 +293,8 @@ impl Default for AnonPolicy {
             categories: BTreeMap::new(),
             default_action: default_action(),
             custom_terms: Vec::new(),
+            term_sets: BTreeMap::new(),
+            co_occurrence: Vec::new(),
             scope: default_scope(),
             placeholder: default_placeholder(),
             min_confidence: default_min_confidence(),
@@ -453,7 +498,7 @@ pub fn scan_with(
     policy.validate()?;
     let text = nfc(text).into_owned();
     let mut detections = if policy.detectors.iter().any(|d| d == "tier0") {
-        detect::run_tier0(&text, &policy.custom_terms, known_identities)?
+        detect::run_tier0(&text, &policy.custom_terms, known_identities, &policy.term_sets)?
     } else {
         Vec::new()
     };
@@ -489,9 +534,60 @@ pub fn scan_with(
         }
     }
     detections.retain(|d| d.confidence >= policy.min_confidence);
+    apply_co_occurrence(&mut detections, policy);
     let mut survivors = resolve_overlaps(detections, policy);
     survivors.retain(|d| policy.action_for(&d.category) != Action::Allow);
     Ok(ScanOutcome { text, detections: survivors })
+}
+
+/// Re-categorize detections whose neighbours make them more sensitive.
+///
+/// Runs BEFORE overlap resolution and before the `Allow` drop, which is the
+/// whole point: `person` is frequently mapped to `allow`, and the rule exists
+/// to stop that drop when a condition/medication/procedure sits beside the
+/// name. Running it afterwards would find the detection already gone.
+///
+/// Proximity is edge-to-edge in characters, so "Jane Doe — type 2 diabetes"
+/// counts the gap between the two spans rather than their start offsets, and a
+/// long name does not push its own neighbour out of range.
+///
+/// Categories are read from a snapshot taken up front, so one rule firing can
+/// never cascade into another rule's `near` test — the escalation is decided
+/// by the ORIGINAL detections, which keeps the result independent of rule
+/// order.
+fn apply_co_occurrence(detections: &mut [Detection], policy: &AnonPolicy) {
+    if policy.co_occurrence.is_empty() {
+        return;
+    }
+    let snapshot: Vec<(String, usize, usize)> = detections
+        .iter()
+        .map(|d| (d.category.clone(), d.start, d.end))
+        .collect();
+    for (i, d) in detections.iter_mut().enumerate() {
+        for rule in &policy.co_occurrence {
+            if d.category != rule.when {
+                continue;
+            }
+            let hit = snapshot.iter().enumerate().any(|(j, (cat, start, end))| {
+                if i == j || cat != &rule.near {
+                    return false;
+                }
+                // Edge-to-edge gap; overlapping spans have gap 0.
+                let gap = if *start >= d.end {
+                    start - d.end
+                } else if d.start >= *end {
+                    d.start - end
+                } else {
+                    0
+                };
+                gap <= rule.within_chars
+            });
+            if hit {
+                d.category = rule.as_category.clone();
+                break;
+            }
+        }
+    }
 }
 
 /// Detect, then apply the policy's actions, producing prompt-safe text plus
@@ -1116,5 +1212,75 @@ mod tests {
         let c = anonymize("mail me at a@b.co", &policy, &[], Some(b"k1")).unwrap();
         assert_ne!(a.mapping_id, b.mapping_id); // key changes the id
         assert_eq!(b.mapping_id, c.mapping_id); // same inputs + key → same id
+    }
+}
+
+#[cfg(test)]
+mod co_occurrence_tests {
+    use super::*;
+
+    /// A name alone is fine; the same name beside a condition is health data.
+    /// No per-category action can express that, because the sensitivity is a
+    /// property of the PAIR, not of either detection.
+    fn policy() -> AnonPolicy {
+        let mut p = AnonPolicy {
+            mode: "egress".into(),
+            default_action: "allow".into(),
+            ..Default::default()
+        };
+        p.categories.insert("person".into(), "allow".into());
+        p.categories.insert("condition".into(), "allow".into());
+        p.categories.insert("phi".into(), "pseudonym".into());
+        p.term_sets.insert(
+            "condition".into(),
+            vec!["type 2 diabetes".into(), "hypertension".into()],
+        );
+        p.co_occurrence.push(CoOccurrence {
+            when: "person".into(),
+            near: "condition".into(),
+            within_chars: 40,
+            as_category: "phi".into(),
+        });
+        p
+    }
+
+    fn run(text: &str) -> String {
+        let known = vec![KnownIdentity {
+            value: "Jane Doe".into(),
+            category: "person".into(),
+        }];
+        let p = AnonPolicy { known, ..policy() };
+        anonymize(text, &p, &[], None).unwrap().text
+    }
+
+    #[test]
+    fn a_bare_name_passes_but_a_name_near_a_condition_does_not() {
+        // `person` is mapped to allow, so on its own the name survives.
+        let alone = run("Jane Doe called about the invoice.");
+        assert!(alone.contains("Jane Doe"), "bare name stays: {alone}");
+
+        // Same name, a condition within the window: escalated to `phi`, which
+        // the policy pseudonymizes. The placeholder names the ESCALATED
+        // category, so the reason is visible in the output.
+        let together = run("Jane Doe was diagnosed with type 2 diabetes.");
+        assert!(
+            !together.contains("Jane Doe"),
+            "a name beside a condition must not survive: {together}"
+        );
+        assert!(
+            together.contains("[PHI_1]"),
+            "the placeholder should say why it was escalated: {together}"
+        );
+    }
+
+    #[test]
+    fn the_proximity_window_bounds_the_rule() {
+        // Same two categories, far apart: not the same claim about a patient.
+        let far = format!(
+            "Jane Doe called about the invoice.{} Separately, type 2 diabetes rates rose.",
+            " ".repeat(60)
+        );
+        let out = run(&far);
+        assert!(out.contains("Jane Doe"), "outside the window: {out}");
     }
 }

--- a/crates/areev-js/README.md
+++ b/crates/areev-js/README.md
@@ -11,7 +11,7 @@ memory is one file, opened with a namespace, giving JavaScript agents durable
 add / recall / supersede / forget over content-addressed memory.
 
 ```js
-const { Areev } = require('areev')
+const { Areev } = require('@areev/areev')
 
 const mem = new Areev('caller.db', 'caller') // 3rd arg: passphrase for AES-256 at rest
 const h = await mem.addFact('john', 'prefers', 'tea', 0.95)

--- a/crates/areev-js/__test__/smoke.mjs
+++ b/crates/areev-js/__test__/smoke.mjs
@@ -939,3 +939,59 @@ test('readBlobOffline works WHILE a handle is open, and refuses bad addresses', 
   assert.throws(() => readBlobOffline(path, 'cas://sha256:' + 'a'.repeat(HEX64)), /STO-E001/)
   m.close()
 })
+
+test('threadTail reads one conversation past the default page (#49)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'areev-thread-'))
+  const m = new Areev(join(dir, 'thread.db'), 'caller')
+
+  // The session we want, then far more than default_limit newer events on
+  // other sessions burying it.
+  const wanted = []
+  for (let i = 0; i < 5; i++) {
+    wanted.push({ type: 'event', fields: { content: `call-7 turn ${i}`, session_id: 'call-7' } })
+  }
+  await m.addBatch(JSON.stringify(wanted))
+  const noise = []
+  for (let i = 0; i < 200; i++) {
+    noise.push({ type: 'event', fields: { content: `noise ${i}`, session_id: `other-${i}` } })
+  }
+  await m.addBatch(JSON.stringify(noise))
+
+  const tail = JSON.parse(await m.threadTail('call-7', 20))
+  assert.equal(tail.session, 'call-7')
+  assert.equal(tail.grains.length, 5, 'the whole session, not the part inside a page')
+  // Transcript order: oldest first.
+  assert.equal(tail.grains[0].fields.content, 'call-7 turn 0')
+  assert.equal(tail.grains[4].fields.content, 'call-7 turn 4')
+
+  // The CAL spelling of the same read is pushed into the thread index too, so
+  // it is not bounded by the newest-50 page either.
+  const viaCal = JSON.parse(await m.cal('RECALL events WHERE session_id = "call-7"'))
+  assert.equal(viaCal.grains.length, 5, 'WHERE session_id must push down')
+
+  m.close()
+})
+
+test('calPrepare validates and warms a statement (#44)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'areev-prepare-'))
+  const m = new Areev(join(dir, 'prep.db'), 'caller')
+  await m.addFact('amy', 'likes', 'rust')
+
+  const first = JSON.parse(await m.calPrepare('RECALL facts RECENT 5'))
+  assert.equal(first.statement, 'RECALL facts RECENT 5')
+  assert.equal(first.cached, 1, 'one plan held')
+
+  // A second distinct statement is its own entry; the executor lives on the
+  // handle, so plans survive between calls.
+  const second = JSON.parse(await m.calPrepare('RECALL facts RECENT 9'))
+  assert.equal(second.cached, 2)
+
+  // A bad statement fails at prepare time — a startup error, not a
+  // first-turn error.
+  await assert.rejects(() => m.calPrepare('RECALL facts FORMAT []'))
+
+  // The prepared statement still executes normally.
+  const res = JSON.parse(await m.cal('RECALL facts RECENT 5'))
+  assert.equal(res.grains.length, 1)
+  m.close()
+})

--- a/crates/areev-js/index.d.ts
+++ b/crates/areev-js/index.d.ts
@@ -274,6 +274,18 @@ export declare class Areev {
    */
   stepActions(workflow: string, node?: string | undefined | null, limit?: number | undefined | null, ns?: string | undefined | null): Promise<string>
   /**
+   * Last `n` grains of one conversation, oldest→newest (transcript order).
+   *
+   * The read a chat or voice agent makes on every single turn. Backed by
+   * `idx_thread(ns, session, seq)`, so the bound is n turns of THIS session
+   * rather than n rows of the namespace — unlike a namespace scan filtered
+   * afterwards, which can miss the conversation entirely on a busy
+   * namespace. Exact namespace only: a session lives in one by construction.
+   *
+   * Returns `{ns, session, grains: [{hash, type, fields}]}`.
+   */
+  threadTail(session: string, n?: number | undefined | null, ns?: string | undefined | null): Promise<string>
+  /**
    * Record a tool call as a Tool grain — the flagship analyzer's food.
    *
    * `callId` is the invocation's own id (the provider's `tool_call_id`),

--- a/crates/areev-js/index.d.ts
+++ b/crates/areev-js/index.d.ts
@@ -169,6 +169,21 @@ export declare class Areev {
    * (absent when the query raised none).
    */
   cal(query: string): Promise<string>
+  /**
+   * Parse and validate a statement now, and keep the plan, so the first
+   * real turn does not pay for it.
+   *
+   * The handle is the statement TEXT — there is no opaque handle object to
+   * leak or invalidate, because the executor already keys its plan cache on
+   * exactly that. Call this at startup for each statement your agent runs
+   * on the hot path: it turns a bad statement into a startup error instead
+   * of a first-turn error, and guarantees the plan is warm rather than
+   * hoping it is.
+   *
+   * Returns `{statement, cached}` where `cached` is the number of plans
+   * held.
+   */
+  calPrepare(query: string): Promise<string>
   /** Supersession-chain history for (subject, relation), newest first. */
   history(subject: string, relation: string, ns?: string | undefined | null): Promise<string>
   /**

--- a/crates/areev-js/index.js
+++ b/crates/areev-js/index.js
@@ -75,8 +75,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-android-arm64')
-        const bindingPackageVersion = require('areev-android-arm64/package.json').version
+        const binding = require('@areev/areev-android-arm64')
+        const bindingPackageVersion = require('@areev/areev-android-arm64/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -91,8 +91,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-android-arm-eabi')
-        const bindingPackageVersion = require('areev-android-arm-eabi/package.json').version
+        const binding = require('@areev/areev-android-arm-eabi')
+        const bindingPackageVersion = require('@areev/areev-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -112,8 +112,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-x64-gnu')
-        const bindingPackageVersion = require('areev-win32-x64-gnu/package.json').version
+        const binding = require('@areev/areev-win32-x64-gnu')
+        const bindingPackageVersion = require('@areev/areev-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -128,8 +128,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-x64-msvc')
-        const bindingPackageVersion = require('areev-win32-x64-msvc/package.json').version
+        const binding = require('@areev/areev-win32-x64-msvc')
+        const bindingPackageVersion = require('@areev/areev-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -145,8 +145,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-ia32-msvc')
-        const bindingPackageVersion = require('areev-win32-ia32-msvc/package.json').version
+        const binding = require('@areev/areev-win32-ia32-msvc')
+        const bindingPackageVersion = require('@areev/areev-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -161,8 +161,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-arm64-msvc')
-        const bindingPackageVersion = require('areev-win32-arm64-msvc/package.json').version
+        const binding = require('@areev/areev-win32-arm64-msvc')
+        const bindingPackageVersion = require('@areev/areev-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -180,8 +180,8 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      const binding = require('areev-darwin-universal')
-      const bindingPackageVersion = require('areev-darwin-universal/package.json').version
+      const binding = require('@areev/areev-darwin-universal')
+      const bindingPackageVersion = require('@areev/areev-darwin-universal/package.json').version
       if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -196,8 +196,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-darwin-x64')
-        const bindingPackageVersion = require('areev-darwin-x64/package.json').version
+        const binding = require('@areev/areev-darwin-x64')
+        const bindingPackageVersion = require('@areev/areev-darwin-x64/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -212,8 +212,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-darwin-arm64')
-        const bindingPackageVersion = require('areev-darwin-arm64/package.json').version
+        const binding = require('@areev/areev-darwin-arm64')
+        const bindingPackageVersion = require('@areev/areev-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -232,8 +232,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-freebsd-x64')
-        const bindingPackageVersion = require('areev-freebsd-x64/package.json').version
+        const binding = require('@areev/areev-freebsd-x64')
+        const bindingPackageVersion = require('@areev/areev-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -248,8 +248,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-freebsd-arm64')
-        const bindingPackageVersion = require('areev-freebsd-arm64/package.json').version
+        const binding = require('@areev/areev-freebsd-arm64')
+        const bindingPackageVersion = require('@areev/areev-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -269,8 +269,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-x64-musl')
-          const bindingPackageVersion = require('areev-linux-x64-musl/package.json').version
+          const binding = require('@areev/areev-linux-x64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -285,8 +285,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-x64-gnu')
-          const bindingPackageVersion = require('areev-linux-x64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-x64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -303,8 +303,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm64-musl')
-          const bindingPackageVersion = require('areev-linux-arm64-musl/package.json').version
+          const binding = require('@areev/areev-linux-arm64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -319,8 +319,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm64-gnu')
-          const bindingPackageVersion = require('areev-linux-arm64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-arm64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -337,8 +337,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm-musleabihf')
-          const bindingPackageVersion = require('areev-linux-arm-musleabihf/package.json').version
+          const binding = require('@areev/areev-linux-arm-musleabihf')
+          const bindingPackageVersion = require('@areev/areev-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -353,8 +353,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('areev-linux-arm-gnueabihf/package.json').version
+          const binding = require('@areev/areev-linux-arm-gnueabihf')
+          const bindingPackageVersion = require('@areev/areev-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -371,8 +371,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-loong64-musl')
-          const bindingPackageVersion = require('areev-linux-loong64-musl/package.json').version
+          const binding = require('@areev/areev-linux-loong64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -387,8 +387,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-loong64-gnu')
-          const bindingPackageVersion = require('areev-linux-loong64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-loong64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -405,8 +405,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-riscv64-musl')
-          const bindingPackageVersion = require('areev-linux-riscv64-musl/package.json').version
+          const binding = require('@areev/areev-linux-riscv64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -421,8 +421,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-riscv64-gnu')
-          const bindingPackageVersion = require('areev-linux-riscv64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-riscv64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -438,8 +438,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-linux-ppc64-gnu')
-        const bindingPackageVersion = require('areev-linux-ppc64-gnu/package.json').version
+        const binding = require('@areev/areev-linux-ppc64-gnu')
+        const bindingPackageVersion = require('@areev/areev-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -454,8 +454,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-linux-s390x-gnu')
-        const bindingPackageVersion = require('areev-linux-s390x-gnu/package.json').version
+        const binding = require('@areev/areev-linux-s390x-gnu')
+        const bindingPackageVersion = require('@areev/areev-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -474,8 +474,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-openharmony-arm64')
-        const bindingPackageVersion = require('areev-openharmony-arm64/package.json').version
+        const binding = require('@areev/areev-openharmony-arm64')
+        const bindingPackageVersion = require('@areev/areev-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -490,8 +490,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-openharmony-x64')
-        const bindingPackageVersion = require('areev-openharmony-x64/package.json').version
+        const binding = require('@areev/areev-openharmony-x64')
+        const bindingPackageVersion = require('@areev/areev-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -506,8 +506,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-openharmony-arm')
-        const bindingPackageVersion = require('areev-openharmony-arm/package.json').version
+        const binding = require('@areev/areev-openharmony-arm')
+        const bindingPackageVersion = require('@areev/areev-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '1.2.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -643,16 +643,16 @@ if (!nativeBinding || forceWasi) {
     let candidateError = null
     let candidateFailed = false
     try {
-      candidateError = __napiWasiResolveCandidate('areev-wasm32-wasi', true, undefined)
+      candidateError = __napiWasiResolveCandidate('@areev/areev-wasm32-wasi', true, undefined)
       candidateFailed = candidateError !== null
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          const bindingPackageVersion = require('areev-wasm32-wasi/package.json').version
+          const bindingPackageVersion = require('@areev/areev-wasm32-wasi/package.json').version
           if (bindingPackageVersion !== '1.2.2') {
             throw new Error(`WASI binding package version mismatch, expected 1.2.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
-        wasiBinding = require('areev-wasm32-wasi')
+        wasiBinding = require('@areev/areev-wasm32-wasi')
         nativeBinding = wasiBinding
         wasiBindingLoaded = true
       }

--- a/crates/areev-js/package.json
+++ b/crates/areev-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "areev",
+  "name": "@areev/areev",
   "version": "1.2.2",
   "description": "Node.js bindings for Areev, the embedded memory engine for AI agents.",
   "license": "MIT OR Apache-2.0",

--- a/crates/areev-js/scripts/prepare-npm.mjs
+++ b/crates/areev-js/scripts/prepare-npm.mjs
@@ -2,54 +2,66 @@
 //
 // Runs after `napi create-npm-dirs` + `napi artifacts` have populated `npm/<platform>/`.
 // It:
-//   1. stamps every platform package with the main package's release version,
-//   2. wires the main package's `optionalDependencies` to *all* platform packages
-//      (including any deferred one, so a later same-version publish resolves for
-//      existing installs), and
-//   3. prints — one per line on stdout — the platform package dirs that should be
-//      published now (everything except the deferred names).
+//   1. asserts that every target declared in `napi.targets` produced a package
+//      directory holding a built `.node` — a declared-but-missing target is a
+//      failed release, not a warning,
+//   2. stamps every platform package with the main package's release version,
+//   3. wires the main package's `optionalDependencies` to all platform packages, and
+//   4. prints — one per line on stdout — the platform package dirs to publish.
 //
-// DEFER lists platform package names to skip on this publish run (e.g. a name
-// currently tripping npm's spam filter). A deferred package's build still
-// runs and its binary is collected, so once the name is unblocked it can be
-// published at the same version by removing it from DEFER and re-running
-// release-npm (the publish step skips packages already on the registry, so
-// only the newly-undeferred one goes out).
-//
-// History, corrected 2026-08-17: the 2026-07-17 whitelist was granted for
-// this package's FORMER name — `dejadb-win32-x64-msvc` (published at 1.2.0,
-// the frozen pre-rename release). `areev-win32-x64-msvc` has never been
-// whitelisted; the v1.1.0 publish 403 is a fresh spam-filter rejection of a
-// new name, not a regression. Exception request for the areev-* names is
-// user-tracked with npm support; the release-npm workflow skips this one
-// name loudly until it lands.
+// Why the packages are SCOPED (`@areev/areev-win32-x64-msvc`, …): npm's
+// similarity/spam filter rejects the unscoped `areev-*` names — it 403'd
+// `areev-win32-x64-msvc` on every release since the rename, so `@areev/areev`
+// shipped declaring an optionalDependency that did not exist. npm silently
+// skips a missing optional dependency at install and napi then fails at
+// `require()` with its misleading "Cannot find native binding … npm optional
+// dependencies bug" — i.e. Windows was broken by a *registry-name* problem
+// reported as a build problem. Scoping the main package makes
+// `napi create-npm-dirs` derive scoped platform names from it and makes the
+// generated `index.js` require those names, so nothing hits the filter.
+// (The 2026-07-17 whitelist covered only the FORMER `dejadb-win32-x64-msvc`;
+// the unscoped `areev-*` exception is still user-tracked with npm support and
+// is no longer on the release path.)
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
-
-const DEFER = new Set();
 
 const mainPath = 'package.json';
 const main = JSON.parse(readFileSync(mainPath, 'utf8'));
 const version = main.version;
+const declared = main.napi?.targets ?? [];
 
 const npmDir = 'npm';
 const optionalDependencies = {};
 const toPublish = [];
+const built = [];
 
 for (const entry of existsSync(npmDir) ? readdirSync(npmDir).sort() : []) {
   const pkgPath = `${npmDir}/${entry}/package.json`;
   if (!existsSync(pkgPath)) continue;
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  // `napi artifacts` drops the built addon in beside the manifest. An empty
+  // dir means the matrix leg produced nothing for this target.
+  const addon = readdirSync(`${npmDir}/${entry}`).find((f) => f.endsWith('.node'));
+  if (!addon) {
+    console.error(`::error::${pkg.name}@${version} has no .node artifact — the ${entry} build leg produced nothing`);
+    process.exit(1);
+  }
   pkg.version = version;
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
-  // Every platform package is referenced by the main package, even a deferred
-  // one — npm silently ignores a missing optional dependency at install time and
-  // picks it up once it exists.
   optionalDependencies[pkg.name] = version;
-  if (DEFER.has(pkg.name)) {
-    console.error(`defer ${pkg.name}@${version} (npm name blocked; publish once unblocked)`);
-    continue;
-  }
   toPublish.push(`${npmDir}/${entry}`);
+  built.push(entry);
+}
+
+// Every declared target must have produced a package. Without this the release
+// publishes a main package whose optionalDependencies promise a platform that
+// was never built — the exact silent-install / loud-require failure above.
+if (built.length !== declared.length) {
+  console.error(
+    `::error::napi.targets declares ${declared.length} targets (${declared.join(', ')}) ` +
+      `but only ${built.length} package dirs were built (${built.join(', ') || 'none'}). ` +
+      `Fix the build or remove the target from napi.targets — the manifest must not promise a platform that does not ship.`,
+  );
+  process.exit(1);
 }
 
 main.optionalDependencies = optionalDependencies;

--- a/crates/areev-js/src/lib.rs
+++ b/crates/areev-js/src/lib.rs
@@ -1536,6 +1536,43 @@ impl Areev {
         })
     }
 
+    /// Last `n` grains of one conversation, oldest→newest (transcript order).
+    ///
+    /// The read a chat or voice agent makes on every single turn. Backed by
+    /// `idx_thread(ns, session, seq)`, so the bound is n turns of THIS session
+    /// rather than n rows of the namespace — unlike a namespace scan filtered
+    /// afterwards, which can miss the conversation entirely on a busy
+    /// namespace. Exact namespace only: a session lives in one by construction.
+    ///
+    /// Returns `{ns, session, grains: [{hash, type, fields}]}`.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn thread_tail(
+        &self,
+        session: String,
+        n: Option<u32>,
+        ns: Option<String>,
+    ) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let slot = self.facade.clone();
+        let ns = ns.unwrap_or_else(|| self.ns.clone());
+        let n = n.unwrap_or(20) as usize;
+        StringJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            check_verb(&facade, areev_core::authz::Verb::Read, &ns)?;
+            let tail = facade.with_store(|m| m.thread_tail(&ns, &session, n)).map_err(err)?;
+            let grains: Vec<serde_json::Value> = tail
+                .iter()
+                .map(|g| {
+                    serde_json::json!({
+                        "hash": g.hash.to_hex(),
+                        "type": g.grain_type.as_str(),
+                        "fields": g.fields.clone().into_iter().collect::<serde_json::Map<_, _>>(),
+                    })
+                })
+                .collect();
+            Ok(json!({"ns": ns, "session": session, "grains": grains}).to_string())
+        })
+    }
+
     // ── Areev Loop: the governed self-improvement loop (§6.6) ────────────────────
 
     /// Record a tool call as a Tool grain — the flagship analyzer's food.

--- a/crates/areev-js/src/lib.rs
+++ b/crates/areev-js/src/lib.rs
@@ -313,6 +313,15 @@ pub struct Areev {
     ns: String,
     /// Host-asserted actor label stamped on every loop audit grain (§6.6).
     actor: String,
+    /// ONE executor for the life of the handle, so its parse cache survives
+    /// between calls.
+    ///
+    /// A real-time turn calls this binding with a statement STRING and used to
+    /// build a fresh `CalExecutor` per call — which meant lexing, parsing and
+    /// validating the same statement on every single turn, with a cache that
+    /// could never hit. Hoisting the executor onto the handle is what makes
+    /// the plan cache reachable from JavaScript at all.
+    executor: std::sync::Arc<CalExecutor>,
 }
 
 #[napi]
@@ -412,7 +421,12 @@ impl Areev {
             None => (session, actor),
         };
         let facade = std::sync::Arc::new(std::sync::Mutex::new(Some(std::sync::Arc::new(session))));
-        Ok(Areev { facade, ns, actor })
+        Ok(Areev {
+            facade,
+            ns,
+            actor,
+            executor: std::sync::Arc::new(CalExecutor::new(CalExecutorConfig::default())),
+        })
     }
 
     /// Release this handle's claim on the memory file.
@@ -1079,11 +1093,32 @@ impl Areev {
     #[napi(ts_return_type = "Promise<string>")]
     pub fn cal(&self, query: String) -> napi::bindgen_prelude::AsyncTask<StringJob> {
         let slot = self.facade.clone();
+        let ex = self.executor.clone();
         StringJob::spawn(move || {
             let facade = take_facade(&slot)?;
-            let ex = CalExecutor::new(CalExecutorConfig::default());
             let res = ex.execute(&query, &*facade).map_err(err)?;
             serde_json::to_string(&res.payload_json().map_err(err)?).map_err(err)
+        })
+    }
+
+    /// Parse and validate a statement now, and keep the plan, so the first
+    /// real turn does not pay for it.
+    ///
+    /// The handle is the statement TEXT — there is no opaque handle object to
+    /// leak or invalidate, because the executor already keys its plan cache on
+    /// exactly that. Call this at startup for each statement your agent runs
+    /// on the hot path: it turns a bad statement into a startup error instead
+    /// of a first-turn error, and guarantees the plan is warm rather than
+    /// hoping it is.
+    ///
+    /// Returns `{statement, cached}` where `cached` is the number of plans
+    /// held.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn cal_prepare(&self, query: String) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let ex = self.executor.clone();
+        StringJob::spawn(move || {
+            ex.parse_cached(&query).map_err(err)?;
+            Ok(json!({"statement": query, "cached": ex.plan_cache_len()}).to_string())
         })
     }
 

--- a/crates/areev-llm/Cargo.toml
+++ b/crates/areev-llm/Cargo.toml
@@ -12,6 +12,26 @@ homepage.workspace = true
 keywords = ["ai-agents", "llm", "loop", "self-improvement", "areev"]
 categories = ["api-bindings"]
 
+[features]
+# Providers are individually selectable so a regulated build can state exactly
+# which model endpoints its artifact can REACH: a disabled provider's factory
+# arm is compiled out, so no code path can construct it and the spec is
+# refused by name. (`openrouter` has no adapter of its own — it is a factory
+# arm over the OpenAI-compatible client — so disabling it removes it
+# entirely; `openai`/`anthropic`/`ollama` keep their adapter types compiled
+# for the ToolCallLlm seam.) The three defaults are first-party APIs or a
+# local runtime; the opt-ins are the ones a compliance reviewer asks about:
+#   * `openrouter` — a third-party router, i.e. an extra jurisdiction and an
+#     extra set of upstream defaults in the transfer path.
+#   * `vertex` — pulls in the Google ADC credential path (metadata server /
+#     gcloud well-known file).
+default = ["openai", "anthropic", "ollama"]
+openai = []
+anthropic = []
+ollama = []
+openrouter = ["openai"]
+vertex = ["openai"]
+
 [dependencies]
 areev-loop = { path = "../areev-loop", version = "1.2.2" }
 # Wave 0 (governed-agents §6.11): the ToolCallLlm seam renders Tool
@@ -23,3 +43,7 @@ serde_json = "1"
 # A small BLOCKING HTTP client — matches the sync-over-private-runtime / std
 # TcpListener posture of the rest of the tree; no tokio/reqwest enters here.
 ureq = "3"
+
+[dev-dependencies]
+# The ADC credential test writes a fake credentials file.
+tempfile = "3"

--- a/crates/areev-llm/src/cred.rs
+++ b/crates/areev-llm/src/cred.rs
@@ -97,16 +97,41 @@ impl GoogleAdc {
         std::env::var("GCE_METADATA_HOST").unwrap_or_else(|_| "169.254.169.254".to_string())
     }
 
+    /// The metadata server gets its OWN agent, not the shared LLM one.
+    ///
+    /// `crate::agent()` is tuned for a model call — 30s to connect, 120s to
+    /// answer — which is exactly wrong here. `169.254.169.254` is a
+    /// link-local address that, off GCP, usually blackholes rather than
+    /// refusing: the connect does not fail, it hangs. With the shared agent
+    /// every uncached `token()` on a developer machine or a non-GCP host paid
+    /// 30s before reaching the ADC file that was going to answer anyway, and
+    /// paid it again on the next call because nothing is cached on failure.
+    ///
+    /// On a real GCP workload this endpoint answers in single-digit
+    /// milliseconds over the loopback-ish link, so a 1s connect / 3s response
+    /// budget is generous there and near-instant everywhere else. A miss here
+    /// is not an error — it is "not on GCP", and the file path below is the
+    /// answer.
+    fn metadata_agent() -> ureq::Agent {
+        ureq::Agent::config_builder()
+            .timeout_connect(Some(Duration::from_secs(1)))
+            .timeout_recv_response(Some(Duration::from_secs(3)))
+            .timeout_recv_body(Some(Duration::from_secs(3)))
+            .build()
+            .into()
+    }
+
     /// Ask the instance metadata server for the attached service account's
-    /// token. Short timeout: off-GCP this endpoint is a black hole, and the
-    /// file path below is the real fallback, not an error.
+    /// token. Short timeout (see [`metadata_agent`](Self::metadata_agent)):
+    /// off-GCP this endpoint is a black hole, and the file path below is the
+    /// real fallback, not an error.
     fn fetch_from_metadata_server(&self) -> Result<(String, u64)> {
         let url = format!(
             "http://{}/computeMetadata/v1/instance/service-accounts/default/token?scopes={}",
             Self::metadata_host(),
             urlencode(&self.scope)
         );
-        let text = crate::agent()
+        let text = Self::metadata_agent()
             .get(&url)
             .header("Metadata-Flavor", "Google")
             .call()

--- a/crates/areev-llm/src/cred.rs
+++ b/crates/areev-llm/src/cred.rs
@@ -100,7 +100,7 @@ impl GoogleAdc {
     /// Ask the instance metadata server for the attached service account's
     /// token. Short timeout: off-GCP this endpoint is a black hole, and the
     /// file path below is the real fallback, not an error.
-    fn from_metadata_server(&self) -> Result<(String, u64)> {
+    fn fetch_from_metadata_server(&self) -> Result<(String, u64)> {
         let url = format!(
             "http://{}/computeMetadata/v1/instance/service-accounts/default/token?scopes={}",
             Self::metadata_host(),
@@ -135,7 +135,7 @@ impl GoogleAdc {
     }
 
     /// Exchange a gcloud `authorized_user` refresh token for an access token.
-    fn from_adc_file(&self) -> Result<(String, u64)> {
+    fn fetch_from_adc_file(&self) -> Result<(String, u64)> {
         let path = Self::adc_file_path()
             .ok_or_else(|| Error::LlmBackend("no ADC file found".into()))?;
         let raw = std::fs::read_to_string(&path)
@@ -209,9 +209,9 @@ impl Credential for GoogleAdc {
         }
         // Metadata server first: on a GCP workload it is authoritative and the
         // file usually is not there at all.
-        let (tok, ttl) = match self.from_metadata_server() {
+        let (tok, ttl) = match self.fetch_from_metadata_server() {
             Ok(v) => v,
-            Err(meta_err) => self.from_adc_file().map_err(|file_err| {
+            Err(meta_err) => self.fetch_from_adc_file().map_err(|file_err| {
                 Error::LlmBackend(format!(
                     "no Application Default Credentials: metadata server ({meta_err}); \
                      ADC file ({file_err})"
@@ -278,7 +278,7 @@ mod tests {
         std::fs::write(&p, r#"{"type":"service_account","project_id":"x"}"#).unwrap();
         // SAFETY: single-threaded test process; the var is restored below.
         unsafe { std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", &p) };
-        let err = GoogleAdc::new().from_adc_file().unwrap_err().to_string();
+        let err = GoogleAdc::new().fetch_from_adc_file().unwrap_err().to_string();
         unsafe { std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS") };
         assert!(err.contains("service-account KEY file"), "got: {err}");
         assert!(err.contains("workload identity"), "must name the fix: {err}");

--- a/crates/areev-llm/src/cred.rs
+++ b/crates/areev-llm/src/cred.rs
@@ -1,0 +1,286 @@
+//! Per-request credentials for the LLM backends.
+//!
+//! Every backend used to hold a `String` read once from the environment, which
+//! excludes every cloud-native auth model: Vertex AI with Application Default
+//! Credentials, Azure managed identity, AWS SigV4. Those exist precisely so
+//! that no key sits on disk — many organizations have an org policy that
+//! blocks service-account key creation outright — so "read a static key from
+//! an env var" is not a smaller version of them, it is the thing they forbid.
+//!
+//! The seam is deliberately narrow: a credential mints the value that goes in
+//! the auth header, and may refresh it. Everything else — which header, which
+//! endpoint — stays with the backend.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use areev_loop::{Error, Result};
+
+/// A source of the value a backend puts in its auth header.
+///
+/// Implementations must be cheap on the hot path: `token()` is called per
+/// request, so anything with an expiry caches until shortly before it.
+pub trait Credential: Send + Sync {
+    /// The current bearer token / API key. May perform I/O to refresh.
+    fn token(&self) -> Result<String>;
+
+    /// Short label for diagnostics. Never includes key material.
+    fn kind(&self) -> &'static str;
+}
+
+/// A fixed key, read once — the historical behaviour, unchanged.
+pub struct StaticKey(String);
+
+impl StaticKey {
+    pub fn new(key: impl Into<String>) -> Self {
+        StaticKey(key.into())
+    }
+}
+
+impl Credential for StaticKey {
+    fn token(&self) -> Result<String> {
+        Ok(self.0.clone())
+    }
+    fn kind(&self) -> &'static str {
+        "static"
+    }
+}
+
+/// Google Application Default Credentials, for workloads that must not hold a
+/// key.
+///
+/// Two sources, tried in order, matching what ADC actually does on a GCP
+/// workload and on a developer machine:
+///
+/// 1. **The metadata server** (`GCE_METADATA_HOST`, default
+///    `169.254.169.254`) — the attached service account of a Cloud Run / GKE /
+///    GCE workload. This is workload identity: no key material anywhere.
+/// 2. **The gcloud well-known file** (`GOOGLE_APPLICATION_CREDENTIALS`, else
+///    `~/.config/gcloud/application_default_credentials.json`) when it holds
+///    an `authorized_user` — a refresh token exchanged at Google's OAuth
+///    endpoint.
+///
+/// **Deliberately NOT supported: `service_account` key JSON.** Honouring it
+/// means signing a JWT with RS256, i.e. pulling an RSA implementation into a
+/// tree whose stated policy is dependency-light — and the deployments this
+/// exists for are exactly the ones whose org policy forbids creating such keys
+/// in the first place. A `service_account` file is refused by name, with the
+/// two supported paths in the message, rather than failing as "no credentials".
+///
+/// Tokens are cached until 60s before expiry, so a normal turn pays no
+/// refresh; ADC tokens are short-lived (~1h) and this is what makes a
+/// long-lived process keep working.
+pub struct GoogleAdc {
+    scope: String,
+    // A `Mutex`, not a `RefCell`: `Credential` is `Sync`, so `token()` can be
+    // called from several threads at once and interior mutability has to be
+    // thread-safe. At worst two threads mint a token concurrently and the
+    // later write wins — both are valid, so the lock is never held across the
+    // network call.
+    cached: Mutex<Option<(String, Instant)>>,
+}
+
+impl GoogleAdc {
+    /// The cloud-platform scope covers Vertex AI.
+    pub fn new() -> Self {
+        Self::with_scope("https://www.googleapis.com/auth/cloud-platform")
+    }
+
+    pub fn with_scope(scope: impl Into<String>) -> Self {
+        GoogleAdc {
+            scope: scope.into(),
+            cached: Mutex::new(None),
+        }
+    }
+
+    fn metadata_host() -> String {
+        std::env::var("GCE_METADATA_HOST").unwrap_or_else(|_| "169.254.169.254".to_string())
+    }
+
+    /// Ask the instance metadata server for the attached service account's
+    /// token. Short timeout: off-GCP this endpoint is a black hole, and the
+    /// file path below is the real fallback, not an error.
+    fn from_metadata_server(&self) -> Result<(String, u64)> {
+        let url = format!(
+            "http://{}/computeMetadata/v1/instance/service-accounts/default/token?scopes={}",
+            Self::metadata_host(),
+            urlencode(&self.scope)
+        );
+        let text = crate::agent()
+            .get(&url)
+            .header("Metadata-Flavor", "Google")
+            .call()
+            .map_err(|e| Error::LlmBackend(format!("metadata server: {e}")))?
+            .body_mut()
+            .read_to_string()
+            .map_err(|e| Error::LlmBackend(format!("metadata server: {e}")))?;
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|e| Error::LlmBackend(format!("metadata server response: {e}")))?;
+        let tok = v
+            .get("access_token")
+            .and_then(|s| s.as_str())
+            .ok_or_else(|| Error::LlmBackend("metadata server returned no access_token".into()))?;
+        let ttl = v.get("expires_in").and_then(serde_json::Value::as_u64).unwrap_or(3600);
+        Ok((tok.to_string(), ttl))
+    }
+
+    fn adc_file_path() -> Option<std::path::PathBuf> {
+        if let Ok(p) = std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
+            return Some(std::path::PathBuf::from(p));
+        }
+        let home = std::env::var("HOME").ok()?;
+        let p = std::path::Path::new(&home)
+            .join(".config/gcloud/application_default_credentials.json");
+        p.exists().then_some(p)
+    }
+
+    /// Exchange a gcloud `authorized_user` refresh token for an access token.
+    fn from_adc_file(&self) -> Result<(String, u64)> {
+        let path = Self::adc_file_path()
+            .ok_or_else(|| Error::LlmBackend("no ADC file found".into()))?;
+        let raw = std::fs::read_to_string(&path)
+            .map_err(|e| Error::LlmBackend(format!("{}: {e}", path.display())))?;
+        let v: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| Error::LlmBackend(format!("{}: {e}", path.display())))?;
+        match v.get("type").and_then(|s| s.as_str()) {
+            Some("authorized_user") => {}
+            Some("service_account") => {
+                return Err(Error::LlmBackend(format!(
+                    "{} is a service-account KEY file, which this backend deliberately does \
+                     not support (signing its JWT needs an RSA implementation this tree does \
+                     not carry, and the deployments ADC exists for typically forbid creating \
+                     such keys). Use workload identity — an attached service account, reached \
+                     through the metadata server — or `gcloud auth application-default login`.",
+                    path.display()
+                )))
+            }
+            other => {
+                return Err(Error::LlmBackend(format!(
+                    "{}: unsupported ADC credential type {other:?}",
+                    path.display()
+                )))
+            }
+        }
+        let get = |k: &str| {
+            v.get(k)
+                .and_then(|s| s.as_str())
+                .map(str::to_string)
+                .ok_or_else(|| Error::LlmBackend(format!("{}: missing {k}", path.display())))
+        };
+        let body = format!(
+            "client_id={}&client_secret={}&refresh_token={}&grant_type=refresh_token",
+            urlencode(&get("client_id")?),
+            urlencode(&get("client_secret")?),
+            urlencode(&get("refresh_token")?),
+        );
+        let text = crate::agent()
+            .post("https://oauth2.googleapis.com/token")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .send(&body)
+            .map_err(|e| Error::LlmBackend(format!("oauth2 token exchange: {e}")))?
+            .body_mut()
+            .read_to_string()
+            .map_err(|e| Error::LlmBackend(format!("oauth2 token exchange: {e}")))?;
+        let v: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|e| Error::LlmBackend(format!("oauth2 response: {e}")))?;
+        let tok = v
+            .get("access_token")
+            .and_then(|s| s.as_str())
+            .ok_or_else(|| Error::LlmBackend(format!("oauth2 returned no access_token: {text}")))?;
+        let ttl = v.get("expires_in").and_then(serde_json::Value::as_u64).unwrap_or(3600);
+        Ok((tok.to_string(), ttl))
+    }
+}
+
+impl Default for GoogleAdc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Credential for GoogleAdc {
+    fn token(&self) -> Result<String> {
+        if let Ok(guard) = self.cached.lock() {
+            if let Some((tok, exp)) = guard.as_ref() {
+                if Instant::now() < *exp {
+                    return Ok(tok.clone());
+                }
+            }
+        }
+        // Metadata server first: on a GCP workload it is authoritative and the
+        // file usually is not there at all.
+        let (tok, ttl) = match self.from_metadata_server() {
+            Ok(v) => v,
+            Err(meta_err) => self.from_adc_file().map_err(|file_err| {
+                Error::LlmBackend(format!(
+                    "no Application Default Credentials: metadata server ({meta_err}); \
+                     ADC file ({file_err})"
+                ))
+            })?,
+        };
+        // Refresh a minute early so a token never expires mid-request.
+        let ttl = Duration::from_secs(ttl.saturating_sub(60).max(30));
+        if let Ok(mut guard) = self.cached.lock() {
+            *guard = Some((tok.clone(), Instant::now() + ttl));
+        }
+        Ok(tok)
+    }
+
+    fn kind(&self) -> &'static str {
+        "google-adc"
+    }
+}
+
+/// Minimal percent-encoding for the few values that reach a URL or form body
+/// here (OAuth scopes, client ids, refresh tokens). Hand-rolled rather than
+/// pulling a crate for it, matching the tree's dependency posture.
+fn urlencode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn static_key_round_trips() {
+        let c = StaticKey::new("sk-test");
+        assert_eq!(c.token().unwrap(), "sk-test");
+        assert_eq!(c.kind(), "static");
+    }
+
+    #[test]
+    fn urlencode_escapes_what_a_scope_and_a_token_contain() {
+        assert_eq!(
+            urlencode("https://www.googleapis.com/auth/cloud-platform"),
+            "https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcloud-platform"
+        );
+        assert_eq!(urlencode("a-b_c.d~e"), "a-b_c.d~e");
+        assert_eq!(urlencode("1//abc+def=="), "1%2F%2Fabc%2Bdef%3D%3D");
+    }
+
+    /// A service-account key file must be refused BY NAME, not reported as
+    /// "no credentials": the operator needs to know the file was found and
+    /// deliberately not used.
+    #[test]
+    fn service_account_key_files_are_refused_by_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("sa.json");
+        std::fs::write(&p, r#"{"type":"service_account","project_id":"x"}"#).unwrap();
+        // SAFETY: single-threaded test process; the var is restored below.
+        unsafe { std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", &p) };
+        let err = GoogleAdc::new().from_adc_file().unwrap_err().to_string();
+        unsafe { std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS") };
+        assert!(err.contains("service-account KEY file"), "got: {err}");
+        assert!(err.contains("workload identity"), "must name the fix: {err}");
+    }
+}

--- a/crates/areev-llm/src/lib.rs
+++ b/crates/areev-llm/src/lib.rs
@@ -27,6 +27,7 @@
 //! text passed to `remember()` into Fact drafts, so the extraction seam is
 //! reachable from the CLI and the bindings and not just from in-process Rust.
 
+pub mod cred;
 pub mod extract;
 pub mod llm_detect;
 pub mod pseudonymize;
@@ -181,13 +182,30 @@ fn op_schema(op: &str) -> Option<Value> {
 
 pub struct OpenAiCompat {
     pub(crate) base_url: String,
-    pub(crate) api_key: String,
+    /// Minted per request, so a short-lived cloud token works here as well as
+    /// a static key — see [`crate::cred`].
+    pub(crate) cred: Box<dyn crate::cred::Credential>,
     pub(crate) model: String,
 }
 
 impl OpenAiCompat {
     pub fn new(base_url: impl Into<String>, api_key: impl Into<String>, model: impl Into<String>) -> Self {
-        OpenAiCompat { base_url: base_url.into(), api_key: api_key.into(), model: model.into() }
+        Self::with_credential(
+            base_url,
+            Box::new(crate::cred::StaticKey::new(api_key)),
+            model,
+        )
+    }
+
+    /// The general form: any [`Credential`](crate::cred::Credential), which is
+    /// what lets an in-region Vertex endpoint be reached under Application
+    /// Default Credentials with no key material on disk.
+    pub fn with_credential(
+        base_url: impl Into<String>,
+        cred: Box<dyn crate::cred::Credential>,
+        model: impl Into<String>,
+    ) -> Self {
+        OpenAiCompat { base_url: base_url.into(), cred, model: model.into() }
     }
 
     fn build_body(&self, system: &str, user: &str, op: &str, use_schema: bool) -> Value {
@@ -231,7 +249,7 @@ impl LlmBackend for OpenAiCompat {
         let op = request_op(request);
         let (system, user) = split_request(request);
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
-        let auth = format!("Bearer {}", self.api_key);
+        let auth = format!("Bearer {}", self.cred.token()?);
         // Prefer schema-constrained decoding; fall back to plain json_object if
         // the endpoint/model rejects json_schema (gateways/local models vary).
         match post_json(&url, &[("Authorization", &auth)], &self.build_body(&system, &user, &op, true)) {
@@ -248,15 +266,23 @@ impl LlmBackend for OpenAiCompat {
 // ---- Anthropic (native /v1/messages) ---------------------------------------
 
 pub struct Anthropic {
-    pub(crate) api_key: String,
+    pub(crate) cred: Box<dyn crate::cred::Credential>,
     pub(crate) model: String,
     pub(crate) base_url: String,
 }
 
 impl Anthropic {
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self::with_credential(Box::new(crate::cred::StaticKey::new(api_key)), model)
+    }
+
+    /// The general form — see [`OpenAiCompat::with_credential`].
+    pub fn with_credential(
+        cred: Box<dyn crate::cred::Credential>,
+        model: impl Into<String>,
+    ) -> Self {
         Anthropic {
-            api_key: api_key.into(),
+            cred,
             model: model.into(),
             base_url: "https://api.anthropic.com".into(),
         }
@@ -303,9 +329,10 @@ impl LlmBackend for Anthropic {
         }
         let (system, user) = split_request(request);
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let key = self.cred.token()?;
         let resp = post_json(
             &url,
-            &[("x-api-key", &self.api_key), ("anthropic-version", "2023-06-01")],
+            &[("x-api-key", key.as_str()), ("anthropic-version", "2023-06-01")],
             &self.build_body(&system, &user),
         )?;
         Ok(Self::extract(&resp))
@@ -422,7 +449,9 @@ fn build_provider(spec: &str, base_url: Option<&str>, key_env: Option<&str>) -> 
         return Err(Error::LlmBackend("--model: empty model name".into()));
     }
     match provider.as_str() {
+        #[cfg(feature = "anthropic")]
         "anthropic" | "claude" => Ok(Provider::Anthropic(Anthropic::new(read_key(key_env, "anthropic")?, model))),
+        #[cfg(feature = "openai")]
         "openai" | "gpt" | "openai-compat" | "compat" => {
             let base = base_url
                 .map(str::to_string)
@@ -430,6 +459,7 @@ fn build_provider(spec: &str, base_url: Option<&str>, key_env: Option<&str>) -> 
                 .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
             Ok(Provider::OpenAi(OpenAiCompat::new(base, read_key(key_env, "openai")?, model)))
         }
+        #[cfg(feature = "ollama")]
         "ollama" | "local" => {
             let host = base_url
                 .map(str::to_string)
@@ -437,8 +467,83 @@ fn build_provider(spec: &str, base_url: Option<&str>, key_env: Option<&str>) -> 
                 .unwrap_or_else(|| "http://localhost:11434".to_string());
             Ok(Provider::Ollama(Ollama::new(host, model)))
         }
+        // Vertex AI, in-region, under Application Default Credentials.
+        //
+        // Reuses `OpenAiCompat` rather than adding a native `generateContent`
+        // adapter: Vertex publishes an OpenAI-compatible chat/completions
+        // endpoint per region, so the whole delta is the URL and the
+        // credential. What matters for a data-residency obligation is that the
+        // host is `{location}-aiplatform.googleapis.com` — the REGIONAL
+        // endpoint, never `global` — and that the token is minted from the
+        // attached service account with no key on disk.
+        //
+        // Spec: `vertex:<model>`, with the project and region from
+        // `--llm-base-url` (`<project>/<location>`) or the standard env vars.
+        #[cfg(feature = "vertex")]
+        "vertex" | "vertexai" => {
+            let (project, location) = match base_url {
+                Some(b) => {
+                    let (p, l) = b.split_once('/').ok_or_else(|| {
+                        Error::LlmBackend(
+                            "vertex: --llm-base-url must be <project>/<location>, e.g. \
+                             my-proj/asia-southeast1"
+                                .into(),
+                        )
+                    })?;
+                    (p.to_string(), l.to_string())
+                }
+                None => {
+                    let p = std::env::var("GOOGLE_CLOUD_PROJECT")
+                        .or_else(|_| std::env::var("GCLOUD_PROJECT"))
+                        .map_err(|_| {
+                            Error::LlmBackend(
+                                "vertex: set $GOOGLE_CLOUD_PROJECT or pass \
+                                 --llm-base-url <project>/<location>"
+                                    .into(),
+                            )
+                        })?;
+                    let l = std::env::var("GOOGLE_CLOUD_LOCATION")
+                        .or_else(|_| std::env::var("GOOGLE_CLOUD_REGION"))
+                        .map_err(|_| {
+                            Error::LlmBackend(
+                                "vertex: set $GOOGLE_CLOUD_LOCATION to the region your data \
+                                 must stay in (there is deliberately no default — picking one \
+                                 for you could move model traffic across a border)"
+                                    .into(),
+                            )
+                        })?;
+                    (p, l)
+                }
+            };
+            if location == "global" {
+                return Err(Error::LlmBackend(
+                    "vertex: location 'global' routes to whichever region Google chooses, \
+                     which defeats the reason for using Vertex under a residency obligation \
+                     — name the region explicitly"
+                        .into(),
+                ));
+            }
+            let base = format!(
+                "https://{location}-aiplatform.googleapis.com/v1beta1/projects/{project}/\
+                 locations/{location}/endpoints/openapi"
+            )
+            .replace(char::is_whitespace, "");
+            Ok(Provider::OpenAi(OpenAiCompat::with_credential(
+                base,
+                Box::new(cred::GoogleAdc::new()),
+                format!("google/{}", model.trim_start_matches("google/")),
+            )))
+        }
         // OpenRouter is OpenAI-compatible (one key → hundreds of models,
         // named `vendor/model`, e.g. `openrouter:openai/gpt-4o-mini`).
+        //
+        // Feature-gated and OFF by default: a third-party model router is an
+        // intermediary in another jurisdiction with its own upstream defaults,
+        // which can break a "comparable protection" obligation for cross-border
+        // transfer. Even unused, its presence in a built artifact is something
+        // a reviewer asks about — so a regulated build can now compile it out
+        // entirely rather than merely not calling it.
+        #[cfg(feature = "openrouter")]
         "openrouter" => {
             let base = base_url
                 .map(str::to_string)
@@ -447,6 +552,31 @@ fn build_provider(spec: &str, base_url: Option<&str>, key_env: Option<&str>) -> 
             let key = read_key(key_env.or(Some("OPENROUTER_API_KEY")), "openai")?;
             Ok(Provider::OpenAi(OpenAiCompat::new(base, key, model)))
         }
+        // A provider that exists in the source but was compiled out says so,
+        // rather than reading as a typo.
+        #[cfg(not(feature = "openrouter"))]
+        "openrouter" => Err(Error::LlmBackend(
+            "openrouter support was not compiled into this build (cargo feature \"openrouter\", \
+             off by default because a third-party router is an extra jurisdiction in the \
+             transfer path)"
+                .into(),
+        )),
+        #[cfg(not(feature = "vertex"))]
+        "vertex" | "vertexai" => Err(Error::LlmBackend(
+            "vertex support was not compiled into this build (cargo feature \"vertex\")".into(),
+        )),
+        #[cfg(not(feature = "anthropic"))]
+        "anthropic" | "claude" => Err(Error::LlmBackend(
+            "anthropic support was not compiled into this build (cargo feature \"anthropic\")".into(),
+        )),
+        #[cfg(not(feature = "openai"))]
+        "openai" | "gpt" | "openai-compat" | "compat" => Err(Error::LlmBackend(
+            "openai support was not compiled into this build (cargo feature \"openai\")".into(),
+        )),
+        #[cfg(not(feature = "ollama"))]
+        "ollama" | "local" => Err(Error::LlmBackend(
+            "ollama support was not compiled into this build (cargo feature \"ollama\")".into(),
+        )),
         other => Err(Error::LlmBackend(format!(
             "unknown provider {other:?} (use anthropic|openai|ollama, or provider:model, or --llm-cmd)"
         ))),
@@ -628,5 +758,60 @@ mod tests {
             Ok(_) => panic!("expected a missing-key error"),
         };
         assert!(e.to_string().contains("DEFINITELY_UNSET_VAR_XYZ"));
+    }
+}
+
+#[cfg(test)]
+mod provider_gate_tests {
+    /// A provider that was compiled out must say so — reading as "unknown
+    /// provider" would send an operator hunting for a typo in their config.
+    #[test]
+    #[cfg(not(feature = "openrouter"))]
+    fn openrouter_is_absent_by_default_and_says_why() {
+        let err = match super::resolve("openrouter:openai/gpt-4o-mini", None, None) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("openrouter must not resolve without its feature"),
+        };
+        assert!(err.contains("not compiled into this build"), "got: {err}");
+        assert!(err.contains("openrouter"), "must name the feature: {err}");
+    }
+
+    #[cfg(feature = "vertex")]
+    mod vertex {
+        /// The region is the whole point under a residency obligation, so it
+        /// is never defaulted and `global` is refused outright.
+        #[test]
+        fn vertex_refuses_the_global_endpoint() {
+            let err = match crate::resolve("vertex:gemini-2.0-flash", Some("proj/global"), None) {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("the global endpoint must be refused"),
+            };
+            assert!(err.contains("global"), "got: {err}");
+            assert!(err.contains("name the region"), "got: {err}");
+        }
+
+        #[test]
+        fn vertex_requires_a_project_and_location() {
+            let err = match crate::resolve("vertex:gemini-2.0-flash", Some("no-slash"), None) {
+                Err(e) => e.to_string(),
+                Ok(_) => panic!("a base-url without <project>/<location> must be refused"),
+            };
+            assert!(err.contains("<project>/<location>"), "got: {err}");
+        }
+
+        /// The endpoint must be the REGIONAL host, and must carry no key: the
+        /// credential is ADC, so nothing is read from an API-key env var.
+        #[test]
+        fn vertex_builds_an_in_region_endpoint_under_adc() {
+            let b = match crate::resolve(
+                "vertex:gemini-2.0-flash",
+                Some("my-proj/asia-southeast1"),
+                None,
+            ) {
+                Ok(b) => b,
+                Err(e) => panic!("vertex must resolve with no API key present: {e}"),
+            };
+            assert_eq!(b.model(), "google/gemini-2.0-flash");
+        }
     }
 }

--- a/crates/areev-llm/src/toolcall.rs
+++ b/crates/areev-llm/src/toolcall.rs
@@ -365,7 +365,7 @@ impl ToolCallLlm for crate::OpenAiCompat {
     fn call(&self, req: &ToolCallRequest<'_>) -> ToolCallResult<ToolCallResponse> {
         let body = openai_body(req, &self.model)?;
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
-        let auth = format!("Bearer {}", self.api_key);
+        let auth = format!("Bearer {}", self.cred.token().map_err(|e| terminal(e.to_string()))?);
         openai_parse(&post_json_classified(&url, &[("Authorization", &auth)], &body)?)
     }
     fn call_streaming(
@@ -379,7 +379,7 @@ impl ToolCallLlm for crate::OpenAiCompat {
         // stream is refused (§6.7: budgets need the figures).
         body["stream_options"] = json!({"include_usage": true});
         let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
-        let auth = format!("Bearer {}", self.api_key);
+        let auth = format!("Bearer {}", self.cred.token().map_err(|e| terminal(e.to_string()))?);
         let lines =
             crate::toolcall_stream::post_stream_lines(&url, &[("Authorization", &auth)], &body)?;
         crate::toolcall_stream::openai_accumulate(lines, on_token)
@@ -515,9 +515,10 @@ impl ToolCallLlm for crate::Anthropic {
     fn call(&self, req: &ToolCallRequest<'_>) -> ToolCallResult<ToolCallResponse> {
         let body = anthropic_body(req, &self.model)?;
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let key = self.cred.token().map_err(|e| terminal(e.to_string()))?;
         anthropic_parse(&post_json_classified(
             &url,
-            &[("x-api-key", &self.api_key), ("anthropic-version", ANTHROPIC_HEADERS_VERSION)],
+            &[("x-api-key", key.as_str()), ("anthropic-version", ANTHROPIC_HEADERS_VERSION)],
             &body,
         )?)
     }
@@ -529,9 +530,10 @@ impl ToolCallLlm for crate::Anthropic {
         let mut body = anthropic_body(req, &self.model)?;
         body["stream"] = json!(true);
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let key = self.cred.token().map_err(|e| terminal(e.to_string()))?;
         let lines = crate::toolcall_stream::post_stream_lines(
             &url,
-            &[("x-api-key", &self.api_key), ("anthropic-version", ANTHROPIC_HEADERS_VERSION)],
+            &[("x-api-key", key.as_str()), ("anthropic-version", ANTHROPIC_HEADERS_VERSION)],
             &body,
         )?;
         crate::toolcall_stream::anthropic_accumulate(lines, on_token)

--- a/crates/areev-loop-adapter/src/substrate.rs
+++ b/crates/areev-loop-adapter/src/substrate.rs
@@ -157,6 +157,9 @@ macro_rules! impl_substrate {
             fn validate_cal(&self, cal: &str) -> WResult<()> {
                 validate_cal(cal)
             }
+            fn definition_inverse(&self, statement: &str) -> WResult<Option<String>> {
+                definition_inverse(self.facade_ref(), statement)
+            }
             fn load_state(&self) -> WResult<Value> {
                 load_state(self.facade_ref())
             }
@@ -573,6 +576,73 @@ fn execute_cal(f: &AreevFacade, cal: &str) -> WResult<Vec<Value>> {
         }
     }
     Ok(rows)
+}
+
+/// The CAL that restores the definition a `DEFINE QUERY` / `DEFINE TEMPLATE`
+/// is about to replace — the rollback inverse for a change that writes no
+/// grain (issue #28).
+///
+/// Reconstructed from the registry rather than remembered anywhere: the
+/// `qry:`/`tpl:` rows travel with the file, so the inverse is derived from the
+/// same state the apply is about to overwrite. When nothing is defined under
+/// that name the inverse is a `DROP`, which restores "no such definition" —
+/// the correct prior state, not a no-op.
+///
+/// A BUILT-IN definition has no inverse and returns `None`, which the engine
+/// turns into a refusal: built-ins are immutable, so a proposal to redefine
+/// one could not be rolled back and must not be applied.
+fn definition_inverse(f: &AreevFacade, statement: &str) -> WResult<Option<String>> {
+    let up = statement.trim_start().to_ascii_uppercase();
+    let (kind, after) = if let Some(rest) = up.strip_prefix("DEFINE QUERY") {
+        ("QUERY", &statement.trim_start()[statement.trim_start().len() - rest.len()..])
+    } else if let Some(rest) = up.strip_prefix("DEFINE TEMPLATE") {
+        ("TEMPLATE", &statement.trim_start()[statement.trim_start().len() - rest.len()..])
+    } else {
+        return Ok(None);
+    };
+    // The name is the first token, bare or quoted — both spellings parse.
+    let name = after
+        .trim_start()
+        .trim_start_matches('"')
+        .split(['"', '(', ' ', '\t'])
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if name.is_empty() {
+        return Ok(None);
+    }
+    if kind == "QUERY" {
+        match f.get_query(&name) {
+            // Built-ins are immutable; a rewrite of one is unapplicable.
+            Some(e) if e.builtin => Ok(None),
+            Some(e) => {
+                let params = if e.params.is_empty() {
+                    String::new()
+                } else {
+                    let list: Vec<String> =
+                        e.params.iter().map(|p| format!("${}", p.name)).collect();
+                    format!("({})", list.join(", "))
+                };
+                Ok(Some(format!(
+                    "DEFINE QUERY \"{name}\"{params} DESCRIPTION \"{}\" AS {{ {} }}",
+                    e.description.replace('"', "'"),
+                    e.body
+                )))
+            }
+            None => Ok(Some(format!("DROP QUERY \"{name}\""))),
+        }
+    } else {
+        match f.get_template(&name) {
+            Some(t) if t.builtin => Ok(None),
+            Some(t) => Ok(Some(format!(
+                "DEFINE TEMPLATE \"{name}\" DESCRIPTION \"{}\" AS {{ {} }}",
+                t.description.replace('"', "'"),
+                t.source
+            ))),
+            None => Ok(Some(format!("DROP TEMPLATE \"{name}\""))),
+        }
+    }
 }
 
 fn validate_cal(cal: &str) -> WResult<()> {

--- a/crates/areev-loop-adapter/tests/adapter.rs
+++ b/crates/areev-loop-adapter/tests/adapter.rs
@@ -428,3 +428,65 @@ fn destructive_cal_beyond_forget_hash_is_refused() {
     assert!(sub.validate_cal(r#"RECALL facts WHERE subject = "acme""#).is_ok());
     assert!(sub.validate_cal(r#"ADD fact {"subject":"a","relation":"r","object":"o"}"#).is_ok());
 }
+
+/// A saved-query rewrite is executable AND undoable (issue #28).
+///
+/// The loop can already evolve grains; it could not evolve the saved CAL that
+/// assembles a prompt, which is exactly where a self-improving agent's
+/// behaviour lives. What made that unsafe was the missing inverse: `DEFINE
+/// QUERY` writes a `qry:` registry row, not a grain, so a rollback that only
+/// retracts `created_hashes` would report success while the new definition
+/// stayed live. This pins the round trip.
+#[test]
+fn a_definition_rewrite_records_an_inverse_that_restores_the_previous_body() {
+    use areev_cal::facade::CalStoreFacade;
+    let (_d, store) = open_temp();
+    let facade = AreevFacade::with_session(store, Some("caller".into()), None);
+    let sub = BorrowedSubstrate::new(&facade);
+
+    // Nothing defined yet: the inverse is a DROP, which restores "no such
+    // definition" — the correct prior state, not a no-op.
+    let first = r#"DEFINE QUERY "triage_ctx" AS { RECALL facts RECENT 5 }"#;
+    let inv = sub.definition_inverse(first).unwrap().expect("an inverse");
+    assert!(inv.starts_with("DROP QUERY"), "got: {inv}");
+
+    // Define it, then ask for the inverse of a REWRITE: now it must reproduce
+    // the body that is about to be replaced.
+    run_cal(&facade, first);
+    let rewrite = r#"DEFINE QUERY "triage_ctx" AS { RECALL facts RECENT 20 }"#;
+    let inv2 = sub.definition_inverse(rewrite).unwrap().expect("an inverse");
+    assert!(inv2.contains("RECENT 5"), "must carry the OLD body: {inv2}");
+    assert!(inv2.starts_with("DEFINE QUERY"), "got: {inv2}");
+
+    // Applying the inverse really restores the previous definition.
+    run_cal(&facade, rewrite);
+    assert!(facade.get_query("triage_ctx").unwrap().body.contains("RECENT 20"));
+    run_cal(&facade, &inv2);
+    assert!(
+        facade.get_query("triage_ctx").unwrap().body.contains("RECENT 5"),
+        "the inverse must restore the prior body"
+    );
+
+    // And the DROP inverse really removes a definition that did not exist
+    // before the apply.
+    run_cal(&facade, &inv);
+    assert!(
+        facade.get_query("triage_ctx").is_none(),
+        "the DROP inverse must restore 'no such definition'"
+    );
+}
+
+/// A non-definition proposal is untouched: no inverse, nothing to restore.
+#[test]
+fn ordinary_proposals_have_no_definition_inverse() {
+    let (_d, store) = open_temp();
+    let facade = AreevFacade::with_session(store, Some("caller".into()), None);
+    let sub = BorrowedSubstrate::new(&facade);
+    assert!(sub.definition_inverse("ADD fact {}").unwrap().is_none());
+    assert!(sub.definition_inverse("FORGET abc").unwrap().is_none());
+}
+
+fn run_cal(facade: &AreevFacade, cal: &str) {
+    let ex = areev_cal::CalExecutor::new(areev_cal::CalExecutorConfig::default());
+    ex.execute(cal, facade).unwrap_or_else(|e| panic!("{cal}: {e}"));
+}

--- a/crates/areev-loop/src/config.rs
+++ b/crates/areev-loop/src/config.rs
@@ -176,6 +176,17 @@ pub struct AppliedRecord {
     /// Grain hashes created by the apply, retracted on rollback (ADD inverse).
     #[serde(default)]
     pub created_hashes: Vec<String>,
+    /// CAL that undoes a change with no grain to retract.
+    ///
+    /// `created_hashes` is the inverse of an ADD: rollback retracts what the
+    /// apply created. A `DEFINE QUERY` / `DEFINE TEMPLATE` creates no grain —
+    /// it replaces a `qry:`/`tpl:` registry row — so retracting nothing would
+    /// let a rollback report success while the new definition stayed live.
+    /// This holds the statement that restores the previous definition (or
+    /// `DROP` when there was none), captured at apply time from the state
+    /// being replaced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inverse_cal: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metric: Option<MetricSnapshot>,
 }

--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -888,7 +888,9 @@ impl Engine {
             // inverse and no human BECAUSE — refuse instead.
             if cal.lines().map(str::trim).any(is_definition_statement) {
                 return Err(Error::InvalidProposal(
-                    "a definition rewrite (DEFINE QUERY / DEFINE TEMPLATE) is never                      auto-applied: it changes what every future context contains, so it                      requires a human APPROVE + APPLY with BECAUSE"
+                    "a definition rewrite (DEFINE QUERY / DEFINE TEMPLATE) is never \
+                     auto-applied: it changes what every future context contains, so it \
+                     requires a human APPROVE + APPLY with BECAUSE"
                         .into(),
                 ));
             }

--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -882,6 +882,16 @@ impl Engine {
     ) -> Result<()> {
         let mut created = Vec::new();
         if let Proposal::Cal { cal } = &rec.proposal {
+            // Belt and braces over the policy: `grants_auto_apply` already
+            // excludes the `query` class, so a definition rewrite cannot reach
+            // this path. If one ever did, it would apply with no recorded
+            // inverse and no human BECAUSE — refuse instead.
+            if cal.lines().map(str::trim).any(is_definition_statement) {
+                return Err(Error::InvalidProposal(
+                    "a definition rewrite (DEFINE QUERY / DEFINE TEMPLATE) is never                      auto-applied: it changes what every future context contains, so it                      requires a human APPROVE + APPLY with BECAUSE"
+                        .into(),
+                ));
+            }
             for r in sub.execute_cal(cal)? {
                 if let Some(h) = r.get("hash").and_then(Value::as_str) {
                     created.push(h.to_string());
@@ -893,6 +903,7 @@ impl Engine {
             target_ref: rec.target_ref.clone(),
             rollbackable: rec.rollbackable,
             created_hashes: created,
+            inverse_cal: None,
             metric: rec.metric.clone(),
         };
         let prev = p.audit_heads.get(&rec.hash).cloned();
@@ -1159,8 +1170,27 @@ impl Engine {
 
         // Execute the proposal.
         let mut created = Vec::new();
+        // The inverse of a change that creates no grain — see
+        // `AppliedRecord::inverse_cal`. Captured BEFORE execution, because
+        // afterwards the previous definition is gone.
+        let mut inverse_cal: Option<String> = None;
         match &rec.proposal {
             Proposal::Cal { cal } => {
+                for line in cal.lines().map(str::trim).filter(|l| !l.is_empty()) {
+                    if !is_definition_statement(line) {
+                        continue;
+                    }
+                    match sub.definition_inverse(line)? {
+                        Some(inv) => inverse_cal = Some(inv),
+                        None => {
+                            return Err(Error::InvalidProposal(format!(
+                                "this substrate cannot record a rollback inverse for {line:?}; \
+                                 a definition rewrite that ROLLBACK could not undo is refused \
+                                 rather than applied"
+                            )))
+                        }
+                    }
+                }
                 let rows = sub.execute_cal(cal)?;
                 for r in rows {
                     if let Some(h) = r.get("hash").and_then(Value::as_str) {
@@ -1228,6 +1258,7 @@ impl Engine {
             target_ref: rec.target_ref.clone(),
             rollbackable: rec.rollbackable,
             created_hashes: created,
+            inverse_cal,
             metric: rec.metric.clone(),
         };
         let prev = p.audit_heads.get(rec_hash).cloned();
@@ -1290,6 +1321,15 @@ impl Engine {
         }
         for h in &applied.created_hashes {
             sub.retract(h, &format!("rollback of {rec_hash}"))?;
+        }
+        // A definition rewrite creates no grain, so retracting `created_hashes`
+        // undoes nothing. Restoring it means re-running the statement captured
+        // at apply time — the previous definition, or a DROP when there was
+        // none. Runs BEFORE the audit is written, so a failed restore leaves
+        // the recommendation `applied` (still true) rather than recording a
+        // rollback that did not happen.
+        if let Some(inverse) = &applied.inverse_cal {
+            sub.execute_cal(inverse)?;
         }
         let prev = p.audit_heads.get(rec_hash).cloned();
         let audit = AuditRecord {
@@ -2087,6 +2127,18 @@ fn load_rec<S: SubstrateRead>(sub: &S, rec_hash: &str) -> Result<Recommendation>
     Recommendation::from_fields(rec_hash, &g.fields)
 }
 
+/// Is this line a definition rewrite — a statement that changes a saved
+/// `qry:`/`tpl:` registry row rather than writing a grain?
+///
+/// A keyword test, not a parse: the engine deliberately contains a CAL
+/// *writer*, never a parser (parsing is the substrate's job). Both spellings
+/// are matched case-insensitively, and `DROP` is intentionally absent — the
+/// loop may propose defining a query, never removing one.
+pub(crate) fn is_definition_statement(line: &str) -> bool {
+    let up = line.trim_start().to_ascii_uppercase();
+    up.starts_with("DEFINE QUERY") || up.starts_with("DEFINE TEMPLATE")
+}
+
 /// The refusal an advisory `Edit` earns. The engine has no executable edit
 /// primitive; the change belongs in the host.
 const ADVISORY_EDIT: &str = "This recommendation is advisory: the engine cannot execute this edit. \
@@ -2124,5 +2176,25 @@ pub(crate) fn ensure_executable(proposal: &Proposal) -> Result<()> {
                 Err(Error::InvalidProposal(ADVISORY_DATA.into()))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod definition_proposal_tests {
+    use super::is_definition_statement;
+
+    #[test]
+    fn definition_statements_are_recognized_in_both_spellings() {
+        assert!(is_definition_statement(r#"DEFINE QUERY "triage" AS { RECALL facts }"#));
+        assert!(is_definition_statement("  define template foo AS { x }"));
+        assert!(is_definition_statement("DEFINE TEMPLATE bar AS { y }"));
+        // Ordinary proposals are untouched.
+        assert!(!is_definition_statement("ADD fact {}"));
+        assert!(!is_definition_statement("SUPERSEDE abc WITH fact {}"));
+        assert!(!is_definition_statement("FORGET abc"));
+        // `DROP` is never proposable, so it is deliberately NOT a definition
+        // statement here — a proposal containing one still fails validation
+        // rather than being handed an inverse.
+        assert!(!is_definition_statement(r#"DROP QUERY "triage""#));
     }
 }

--- a/crates/areev-loop/src/policy.rs
+++ b/crates/areev-loop/src/policy.rs
@@ -81,9 +81,16 @@ impl Policy {
     }
 
     /// Does a grant permit auto-applying this family to `target_class` at
-    /// `severity`? Only `memory`/`query` classes are ever eligible.
+    /// `severity`? Only the `memory` class is ever eligible.
+    ///
+    /// `query` was eligible until definition rewrites became executable
+    /// (issue #28). A grain edit changes one remembered value; a saved-query
+    /// or template rewrite changes what EVERY future context contains — the
+    /// blast radius is every turn from now on, not one fact. So a definition
+    /// rewrite always requires a human APPROVE + APPLY with `BECAUSE`, and
+    /// the class is excluded here by name, exactly as `code`/`evalset` are.
     pub fn grants_auto_apply(&self, family: &str, target_class: &str, severity: Severity) -> bool {
-        if !self.auto_apply_enabled || !matches!(target_class, "memory" | "query") {
+        if !self.auto_apply_enabled || target_class != "memory" {
             return false;
         }
         self.auto_apply.iter().any(|g| {

--- a/crates/areev-loop/src/substrate.rs
+++ b/crates/areev-loop/src/substrate.rs
@@ -209,6 +209,23 @@ pub trait OmsSubstrate: SubstrateRead {
     /// [`Error::CalUnsupported`]: crate::error::Error::CalUnsupported
     fn execute_cal(&mut self, cal: &str) -> Result<Vec<Value>>;
 
+    /// The CAL that would restore the CURRENT definition named by a
+    /// `DEFINE QUERY` / `DEFINE TEMPLATE` statement — the rollback inverse,
+    /// captured before the definition is replaced.
+    ///
+    /// Returns `Ok(None)` when the substrate cannot produce one, which the
+    /// engine treats as "this definition rewrite is not applicable": a
+    /// definition change with no recorded inverse is one that `ROLLBACK`
+    /// would silently fail to undo, and a rollback that reports success
+    /// without restoring anything is worse than a refusal.
+    ///
+    /// The default implementation returns `None`, so a substrate that does
+    /// not model saved definitions simply cannot execute definition
+    /// rewrites — fail closed, no opt-out needed.
+    fn definition_inverse(&self, _statement: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
+
     /// Validate a CAL batch without executing it (statement classification,
     /// destructive-op detection). Delegated to the substrate — the engine
     /// contains a CAL *writer*, never a parser.

--- a/crates/areev-py/src/lib.rs
+++ b/crates/areev-py/src/lib.rs
@@ -1174,6 +1174,41 @@ impl Areev {
         Ok(json!({"workflow": wf.to_hex(), "steps": steps}).to_string())
     }
 
+    /// Last `n` grains of one conversation, oldest→newest (transcript order).
+    ///
+    /// The read a chat or voice agent makes on every single turn. Backed by
+    /// `idx_thread(ns, session, seq)`, so the bound is n turns of THIS session
+    /// rather than n rows of the namespace — unlike a namespace scan filtered
+    /// afterwards, which can miss the conversation entirely on a busy
+    /// namespace. Exact namespace only: a session lives in one by construction.
+    ///
+    /// Returns `{ns, session, grains: [{hash, type, fields}]}`.
+    #[pyo3(signature = (session, n = 20, ns = None))]
+    fn thread_tail(
+        &self,
+        py: Python<'_>,
+        session: String,
+        n: usize,
+        ns: Option<String>,
+    ) -> PyResult<String> {
+        let ns = ns.unwrap_or_else(|| self.ns.clone());
+        check_verb(&self.facade, areev_core::authz::Verb::Read, &ns)?;
+        let tail = py
+            .detach(|| self.facade.with_store(|m| m.thread_tail(&ns, &session, n)))
+            .map_err(err)?;
+        let grains: Vec<serde_json::Value> = tail
+            .iter()
+            .map(|g| {
+                json!({
+                    "hash": g.hash.to_hex(),
+                    "type": g.grain_type.as_str(),
+                    "fields": g.fields.clone().into_iter().collect::<serde_json::Map<_, _>>(),
+                })
+            })
+            .collect();
+        Ok(json!({"ns": ns, "session": session, "grains": grains}).to_string())
+    }
+
     /// What a run recorded, and what it produced downstream.
     ///
     /// Returns `{run_id, trace, produced}` — `trace` is the run's own grains,

--- a/crates/areev-py/src/lib.rs
+++ b/crates/areev-py/src/lib.rs
@@ -246,6 +246,11 @@ struct Areev {
     ns: String,
     /// Host-asserted actor label stamped on every loop audit grain (§6.6).
     actor: String,
+    /// ONE executor for the life of the handle, so its parse cache survives
+    /// between calls — see the Node binding's field of the same name. A fresh
+    /// executor per `cal()` re-lexed and re-parsed the same statement on every
+    /// turn and could never hit its own cache.
+    executor: std::sync::Arc<CalExecutor>,
 }
 
 #[pymethods]
@@ -322,7 +327,12 @@ impl Areev {
             }
             None => (facade, actor),
         };
-        Ok(Areev { facade: std::sync::Arc::new(facade), ns, actor })
+        Ok(Areev {
+            facade: std::sync::Arc::new(facade),
+            ns,
+            actor,
+            executor: std::sync::Arc::new(CalExecutor::new(CalExecutorConfig::default())),
+        })
     }
 
     /// Reconciliation warnings from open (file-vs-host declaration changes,
@@ -924,12 +934,24 @@ impl Areev {
     /// (absent when the query raised none).
     fn cal(&self, py: Python<'_>, query: String) -> PyResult<String> {
         let res = py
-            .detach(|| {
-                let ex = CalExecutor::new(CalExecutorConfig::default());
-                ex.execute(&query, &*self.facade)
-            })
+            .detach(|| self.executor.execute(&query, &*self.facade))
             .map_err(err)?;
         serde_json::to_string(&res.payload_json().map_err(err)?).map_err(err)
+    }
+
+    /// Parse and validate a statement now, and keep the plan, so the first
+    /// real turn does not pay for it.
+    ///
+    /// The handle is the statement TEXT — there is no opaque handle object to
+    /// leak or invalidate, because the executor already keys its plan cache on
+    /// exactly that. Call this at startup for each statement on the hot path:
+    /// it turns a bad statement into a startup error rather than a first-turn
+    /// error, and guarantees the plan is warm instead of hoping it is.
+    ///
+    /// Returns `{statement, cached}`.
+    fn cal_prepare(&self, py: Python<'_>, query: String) -> PyResult<String> {
+        py.detach(|| self.executor.parse_cached(&query)).map_err(err)?;
+        Ok(json!({"statement": query, "cached": self.executor.plan_cache_len()}).to_string())
     }
 
     /// Anthropic memory-tool command (LR-13): pass the tool-call dict as

--- a/crates/areev-py/tests/test_areev.py
+++ b/crates/areev-py/tests/test_areev.py
@@ -1182,3 +1182,54 @@ def test_read_blob_offline_works_while_a_handle_is_open(tmp_path):
     uri = db.put_blob(b"during a run")
     assert areev.read_blob_offline(path, uri) == b"during a run"
     assert db.get_blob(uri) == b"during a run"
+
+
+def test_thread_tail_reads_one_conversation_past_the_default_page(tmp_path):
+    """The read a chat/voice agent makes every turn (#49).
+
+    Backed by ``idx_thread(ns, session, seq)``, so it is bounded by turns of
+    THIS session rather than rows of the namespace — before the pushdown a
+    conversation buried under newer traffic came back empty.
+    """
+    db = areev.Areev(str(tmp_path / "thread.db"), ns="caller")
+    wanted = [
+        {"type": "event", "fields": {"content": f"call-7 turn {i}", "session_id": "call-7"}}
+        for i in range(5)
+    ]
+    db.add_batch(json.dumps(wanted))
+    noise = [
+        {"type": "event", "fields": {"content": f"noise {i}", "session_id": f"other-{i}"}}
+        for i in range(200)
+    ]
+    db.add_batch(json.dumps(noise))
+
+    tail = json.loads(db.thread_tail("call-7", 20))
+    assert tail["session"] == "call-7"
+    assert len(tail["grains"]) == 5, "the whole session, not the part inside a page"
+    # Transcript order: oldest first.
+    assert tail["grains"][0]["fields"]["content"] == "call-7 turn 0"
+    assert tail["grains"][4]["fields"]["content"] == "call-7 turn 4"
+
+    # The CAL spelling of the same read pushes down too.
+    via_cal = json.loads(db.cal('RECALL events WHERE session_id = "call-7"'))
+    assert len(via_cal["grains"]) == 5
+
+
+def test_cal_prepare_validates_and_warms_a_statement(tmp_path):
+    """`cal_prepare` turns a bad statement into a startup error rather than a
+    first-turn error, and keeps the plan (#44)."""
+    db = areev.Areev(str(tmp_path / "prep.db"), ns="caller")
+    db.add_fact("amy", "likes", "rust")
+
+    first = json.loads(db.cal_prepare("RECALL facts RECENT 5"))
+    assert first["statement"] == "RECALL facts RECENT 5"
+    assert first["cached"] == 1
+
+    # One executor lives on the handle, so plans survive between calls.
+    second = json.loads(db.cal_prepare("RECALL facts RECENT 9"))
+    assert second["cached"] == 2
+
+    with pytest.raises(ValueError):
+        db.cal_prepare("RECALL facts FORMAT []")
+
+    assert len(json.loads(db.cal("RECALL facts RECENT 5"))["grains"]) == 1

--- a/crates/areev-store/CLAUDE.md
+++ b/crates/areev-store/CLAUDE.md
@@ -189,6 +189,48 @@ erasure it mirrors), and the policy setters (retention/floor/hold/anon).
 Conformance: `cases/ns_scope.rs`, both backends; store tests:
 `tests/ns_scope_tests.rs`.
 
+## Session-scoped and ordered reads
+
+`recent_in_session[_scoped](ns, session, gtype, limit, live_only)` reads
+`idx_thread(ns, session, seq)` directly — newest-first, `live_only`-aware,
+optionally type-narrowed. It exists because `recent`/`recent_live` can only
+scan a namespace by insertion order, so a session filter layered on top is a
+post-filter over whatever page the scan returned: on a busy namespace the tail
+of one conversation can be entirely outside that window, and the query answers
+"nothing" instead of "the last N turns". The CAL facade routes
+`WHERE session_id = "…"` here (issue #49). `thread_tail` is the same index in
+transcript order (oldest→newest, all types, heads and superseded alike).
+
+`recent_ordered[_scoped](…, RecentOrder)` serves an ORDER BY from the scan.
+`RecentOrder::CreatedAt{Desc,Asc}` is the ONLY non-seq ordering, and
+deliberately so: `created_at` is the only sort key the `grains` table carries
+as a column. Every other field a caller might order by lives inside the
+immutable blob, so SQL cannot reach it without materializing a column per
+field — CAL ranks those in the executor over a widened scan instead
+(`CAL-W015`). The two orders differ whenever grains are backdated or imported
+out of order, which is exactly when a caller asks for `created_at` explicitly.
+
+## Anonymization key material
+
+Three keys are HKDF-derived from ONE root, with their own domain-separation
+strings: the session key (`areev.anon.session.v1`), the memory key
+(`areev.anon.memory.v1`, value-derived tokens) and the vault key
+(`areev.vault.v1`, sealed mapping rows).
+
+The root is `AreevOptions::anon_key` when the host supplies one, else the page
+key. Before the `anon_key` seam existed the root could ONLY be the page key,
+which the Postgres backend refuses outright (it is a page-cipher capability) —
+so the backend built for stateless hosts could not use the egress control built
+for untrusted egress, and value-derived tokens were unavailable on plaintext
+files too. The vault itself was never the problem: its rows live in `meta`
+under `VAULT_PREFIX`, which both backends have, and `forget_subject` scrubs
+them through the same path on both.
+
+The host key is never persisted — not in `meta`, not in a bundle, not in the
+file. Rotating it makes existing vault rows permanently unreadable and changes
+every derived token; that is a crypto-erasure lever as much as an operational
+hazard. Conformance: `host_anon_key_unlocks_the_vault`, both backends.
+
 ## Hybrid recall
 
 `recall_hybrid` = structural (`recall_seqs`) + BM25 (`search_text`, our own

--- a/crates/areev-store/src/lib.rs
+++ b/crates/areev-store/src/lib.rs
@@ -1078,6 +1078,31 @@ pub struct AreevOptions {
     /// sidecar. Attachments written before blob encryption landed stay
     /// plaintext until [`Areev::encrypt_blobs`] migrates them.
     pub encryption_key: Option<[u8; 32]>,
+    /// Host-supplied 32-byte root for the anonymization keys, independent of
+    /// the page cipher.
+    ///
+    /// The pseudonymise → LLM → rehydrate round trip needs stable key material
+    /// so the same identity maps to the same token across processes and
+    /// instances, and so the vault's sealed mapping rows can be reopened
+    /// later. That material used to come only from `encryption_key`, which the
+    /// Postgres backend refuses outright (it is a page-cipher capability) —
+    /// so the backend built for stateless hosts could not use the egress
+    /// control built for untrusted egress. Supplying the root directly fixes
+    /// that, and also unblocks value-derived tokens on a PLAINTEXT file, where
+    /// the same gap existed.
+    ///
+    /// Trust model: whoever holds this key can re-identify every pseudonym in
+    /// the vault, so it belongs in a KMS or secret manager (Cloud KMS, AWS
+    /// KMS, Vault) and is never persisted in the memory — not in `meta`, not
+    /// in a bundle, not in the file. Rotating it makes existing vault rows
+    /// permanently unreadable and changes every derived token, which is a
+    /// crypto-erasure lever as much as an operational hazard: rotate
+    /// deliberately, not on a schedule.
+    ///
+    /// Takes precedence over `encryption_key` when both are set, so a file can
+    /// be encrypted at rest under one key and pseudonymised under another —
+    /// which is what separating the two roles is for.
+    pub anon_key: Option<[u8; 32]>,
     /// Recall-telemetry retention for the `<file>.telemetry.db` sidecar.
     /// Host-only capability (never persisted in the file, like the embedder):
     /// a bare `open()` leaves it `Off`, so the library default records nothing;
@@ -1104,6 +1129,7 @@ impl Default for AreevOptions {
             entity_relations: ents.iter().map(|s| s.to_string()).collect(),
             index_text: true,
             encryption_key: None,
+            anon_key: None,
             telemetry: TelemetryMode::Off,
         }
     }
@@ -1855,7 +1881,11 @@ impl Areev {
             if o.encryption_key.is_some() {
                 return Err(AreevError::Validation(
                     "encryption_key is a file-backend capability (page cipher); on the postgres \
-                     backend use TDE/pgcrypto at the deployment layer"
+                     backend use TDE/pgcrypto at the deployment layer. If you wanted it for \
+                     ANONYMIZATION — deterministic value-derived pseudonyms and the mapping \
+                     vault — use AreevOptions::anon_key instead: a host-supplied 32-byte key \
+                     (from your KMS) that works on every backend and is independent of \
+                     encryption at rest"
                         .into(),
                 ));
             }
@@ -1897,7 +1927,14 @@ impl Areev {
         // has no memory key and refuses them at `set` time (Q5 resolved
         // conservatively). Neither key is ever persisted.
         let page_key = explicit.as_ref().and_then(|o| o.encryption_key.as_ref());
-        let anon_memory_key: Option<[u8; 32]> = page_key.map(|pk| {
+        // The anonymization root: the host-supplied key when given, else the
+        // page key. Same HKDF domain separations either way, so a file that
+        // was using the page-derived keys keeps exactly the tokens it had.
+        let anon_root = explicit
+            .as_ref()
+            .and_then(|o| o.anon_key.as_ref())
+            .or(page_key);
+        let anon_memory_key: Option<[u8; 32]> = anon_root.map(|pk| {
             let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, pk);
             let mut out = [0u8; 32];
             hk.expand(b"areev.anon.memory.v1", &mut out).expect("32-byte HKDF output");
@@ -1906,13 +1943,13 @@ impl Areev {
         // The vault subkey (proposal §7): destroying the page key destroys
         // the sealed mapping rows with it — crypto-erasure reaches the vault
         // by construction. Its own domain-separation string, like blobcrypt.
-        let anon_vault_key: Option<[u8; 32]> = page_key.map(|pk| {
+        let anon_vault_key: Option<[u8; 32]> = anon_root.map(|pk| {
             let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, pk);
             let mut out = [0u8; 32];
             hk.expand(b"areev.vault.v1", &mut out).expect("32-byte HKDF output");
             out
         });
-        let anon_session_key: [u8; 32] = match page_key {
+        let anon_session_key: [u8; 32] = match anon_root {
             Some(pk) => {
                 let hk = hkdf::Hkdf::<sha2::Sha256>::new(None, pk);
                 let mut out = [0u8; 32];
@@ -1979,6 +2016,7 @@ impl Areev {
                 entity_relations: declared_rels
                     .unwrap_or_else(|| AreevOptions::default().entity_relations),
                 encryption_key: None,
+                anon_key: None,
                 // Telemetry is host config, not a file-truth: a bare `open()`
                 // never turns it on.
                 telemetry: TelemetryMode::Off,
@@ -2456,9 +2494,11 @@ impl Areev {
             || policy.vault;
         if needs_memory_key && !self.anon.has_memory_key() {
             return Err(AreevError::Validation(format!(
-                "anonymization mode \"{}\" / scope \"{}\" needs an encrypted memory: \
-                 value-derived pseudonym tokens are keyed from the page key \
-                 (open with --passphrase-env / open_encrypted first)",
+                "anonymization mode \"{}\" / scope \"{}\" needs key material: \
+                 value-derived pseudonym tokens and the mapping vault are keyed from \
+                 either AreevOptions::anon_key (a host-supplied 32-byte key from your \
+                 KMS — works on every backend, including postgres) or, on the file \
+                 backend, the page key (open with --passphrase-env / open_encrypted)",
                 policy.mode, policy.scope
             )));
         }

--- a/crates/areev-store/src/lib.rs
+++ b/crates/areev-store/src/lib.rs
@@ -620,6 +620,26 @@ impl QueryExpander for EnglishExpander {
     }
 }
 
+/// Ordering for the recent-by-type scan (`recent_ordered`).
+///
+/// `Seq` — insertion order, newest first — is the default and what `recent` /
+/// `recent_live` have always returned. The `created_at` variants exist because
+/// that is the ONLY other sort key the `grains` table carries as a column, and
+/// therefore the only one an ORDER BY can be pushed down onto: every other
+/// field a caller might sort by lives inside the immutable, content-addressed
+/// blob. The two differ whenever grains are backdated or imported out of
+/// order, which is exactly when a caller asks for `created_at` explicitly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RecentOrder {
+    /// File-global `seq` — insertion recency, newest first.
+    #[default]
+    Seq,
+    /// The grain's own `created_at`, newest first.
+    CreatedAtDesc,
+    /// The grain's own `created_at`, oldest first.
+    CreatedAtAsc,
+}
+
 /// Post-fusion recall refinements. All default off — a bare
 /// `recall_hybrid` behaves exactly as before. Applied inside the recall
 /// deadline; each stage degrades to plain fusion order when its backend or
@@ -4067,6 +4087,52 @@ impl Areev {
         Ok(ids)
     }
 
+    /// [`recent`](Self::recent) / [`recent_live`](Self::recent_live) with an
+    /// explicit ordering.
+    ///
+    /// The scan's ORDER BY *is* the result order on this path, so a caller
+    /// ordering by `created_at` can have it served from the index rather than
+    /// re-sorting a page afterwards. `created_at` is the only non-seq ordering
+    /// available, and deliberately so: it is the only sort key the `grains`
+    /// table carries as a column. Everything else a caller might order by
+    /// (`priority`, `status`, `confidence`, every type-specific field) lives
+    /// inside the immutable blob, where SQL cannot reach it without
+    /// materializing a column per field — CAL ranks those in the executor over
+    /// a widened scan instead (see `RecallParams::order_by`).
+    pub fn recent_ordered(
+        &mut self,
+        ns: &str,
+        gtype: Option<areev_core::types::GrainType>,
+        limit: usize,
+        live_only: bool,
+        order: RecentOrder,
+    ) -> Result<Vec<DeserializedGrain>> {
+        let ids = self.ns_param_ids(ns)?;
+        let hint = (!NsScope::is_pattern(ns)).then_some(ns);
+        self.recent_ids_ordered(&ids, hint, gtype, limit, live_only, order)
+    }
+
+    /// [`recent_ordered`](Self::recent_ordered) over an already-resolved
+    /// namespace list.
+    pub fn recent_ordered_scoped(
+        &mut self,
+        ns_list: &[String],
+        gtype: Option<areev_core::types::GrainType>,
+        limit: usize,
+        live_only: bool,
+        order: RecentOrder,
+    ) -> Result<Vec<DeserializedGrain>> {
+        let mut ids = Vec::with_capacity(ns_list.len());
+        for ns in ns_list {
+            require_exact_ns("a resolved recall scope element", ns)?;
+            if let Some(id) = self.term_lookup(ns)? {
+                ids.push(id);
+            }
+        }
+        let single = (ns_list.len() == 1).then(|| ns_list[0].as_str());
+        self.recent_ids_ordered(&ids, single, gtype, limit, live_only, order)
+    }
+
     /// Recent grains in a namespace, newest first, bounded by `limit`. With
     /// `gtype = None`, every type is returned. This is the "reflect over recent
     /// experience" read path — recent Events / Observations that have no
@@ -4161,6 +4227,18 @@ impl Areev {
         limit: usize,
         live_only: bool,
     ) -> Result<Vec<DeserializedGrain>> {
+        self.recent_ids_ordered(ns_ids, egress_hint, gtype, limit, live_only, RecentOrder::Seq)
+    }
+
+    fn recent_ids_ordered(
+        &mut self,
+        ns_ids: &[i64],
+        egress_hint: Option<&str>,
+        gtype: Option<areev_core::types::GrainType>,
+        limit: usize,
+        live_only: bool,
+        order: RecentOrder,
+    ) -> Result<Vec<DeserializedGrain>> {
         if ns_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -4172,19 +4250,150 @@ impl Areev {
         // The `gtype` column stores the enum ordinal (see `extract_view`:
         // `view.grain_type as u8`), not the .mg header type-byte.
         let gt_ord = gtype.map(|g| g as u8 as i64);
-        // Per-namespace probes (each already newest-first), merged on the
-        // file-global seq. One namespace — the overwhelmingly common case —
-        // skips the merge entirely.
+        // The sort column doubles as the merge key, so a multi-namespace scan
+        // merges on the SAME ordering each probe was bounded by. `seq` breaks
+        // created_at ties so the order stays total and deterministic.
+        let (sort_col, sort_sql) = match order {
+            RecentOrder::Seq => ("seq", "seq DESC"),
+            RecentOrder::CreatedAtDesc => ("created_at", "created_at DESC, seq DESC"),
+            RecentOrder::CreatedAtAsc => ("created_at", "created_at ASC, seq ASC"),
+        };
+        // Per-namespace probes (each already in the requested order), merged on
+        // the sort key. One namespace — the overwhelmingly common case — skips
+        // the merge entirely.
+        // `(sort key, seq)` — seq is the global tiebreak, so the cross-namespace
+        // merge is a total order even when created_at collides.
+        let mut merged: Vec<((i64, i64), Vec<u8>)> = Vec::new();
+        for ns_id in ns_ids {
+            let rows = match gt_ord {
+                Some(gt) => self.db.query(
+                    &format!("SELECT {sort_col}, seq, blob FROM grains WHERE ns=?1 AND gtype=?2{live} ORDER BY {sort_sql} LIMIT ?3"),
+                    vec![pi(*ns_id), pi(gt), pi(limit as i64)],
+                )?,
+                None => self.db.query(
+                    &format!("SELECT {sort_col}, seq, blob FROM grains WHERE ns=?1{live} ORDER BY {sort_sql} LIMIT ?2"),
+                    vec![pi(*ns_id), pi(limit as i64)],
+                )?,
+            };
+            for row in &rows {
+                if let (Some(key), Some(seq), Some(b)) = (row.i64(0), row.i64(1), row.blob(2)) {
+                    merged.push(((key, seq), b));
+                }
+            }
+        }
+        if ns_ids.len() > 1 {
+            match order {
+                RecentOrder::CreatedAtAsc => merged.sort_unstable_by_key(|(k, _)| *k),
+                _ => merged.sort_unstable_by_key(|(k, _)| std::cmp::Reverse(*k)),
+            }
+            merged.truncate(limit);
+        }
+        let mut out: Vec<DeserializedGrain> = merged
+            .iter()
+            .map(|(_, b)| deserialize_blob(b))
+            .collect::<Result<_>>()?;
+        self.egress_exit(egress_hint, &mut out)?;
+        Ok(out)
+    }
+
+    /// Recent grains of ONE session, newest first — the index-backed form of
+    /// `RECALL … WHERE session_id = "…"`.
+    ///
+    /// `recent`/`recent_live` can only scan a namespace by insertion order, so
+    /// a session filter layered on top of them is a post-filter over whatever
+    /// page the scan returned: on a busy namespace the tail of a specific
+    /// conversation may not be in that page at all, and the query answers
+    /// "nothing" instead of "here are the last N turns". This reads
+    /// `idx_thread(ns, session, seq)` directly, so the bound is N turns *of
+    /// this session* rather than N rows of the namespace.
+    ///
+    /// The session column is populated for ANY grain carrying `session_id`
+    /// (see the `thread_idx` insert on the write path), not just Events, so
+    /// `gtype` narrows rather than defines the result.
+    ///
+    /// Related: [`thread_tail`](Self::thread_tail) is the same index read in
+    /// transcript order (oldest→newest, no type filter, heads and superseded
+    /// alike); this one keeps `recent`'s newest-first contract and its
+    /// `live_only` distinction so the CAL facade can swap it in directly.
+    /// The namespace accepts a `"org.*"` prefix scope like every plural read.
+    pub fn recent_in_session(
+        &mut self,
+        ns: &str,
+        session: &str,
+        gtype: Option<areev_core::types::GrainType>,
+        limit: usize,
+        live_only: bool,
+    ) -> Result<Vec<DeserializedGrain>> {
+        let ids = self.ns_param_ids(ns)?;
+        let hint = (!NsScope::is_pattern(ns)).then_some(ns);
+        self.session_ids(&ids, hint, session, gtype, limit, live_only)
+    }
+
+    /// [`recent_in_session`](Self::recent_in_session) over an already-resolved
+    /// namespace list — the CAL facade's path once scopes have expanded and
+    /// authorization has run per namespace.
+    pub fn recent_in_session_scoped(
+        &mut self,
+        ns_list: &[String],
+        session: &str,
+        gtype: Option<areev_core::types::GrainType>,
+        limit: usize,
+        live_only: bool,
+    ) -> Result<Vec<DeserializedGrain>> {
+        let mut ids = Vec::with_capacity(ns_list.len());
+        for ns in ns_list {
+            require_exact_ns("a resolved recall scope element", ns)?;
+            if let Some(id) = self.term_lookup(ns)? {
+                ids.push(id);
+            }
+        }
+        let single = (ns_list.len() == 1).then(|| ns_list[0].as_str());
+        self.session_ids(&ids, single, session, gtype, limit, live_only)
+    }
+
+    fn session_ids(
+        &mut self,
+        ns_ids: &[i64],
+        egress_hint: Option<&str>,
+        session: &str,
+        gtype: Option<areev_core::types::GrainType>,
+        limit: usize,
+        live_only: bool,
+    ) -> Result<Vec<DeserializedGrain>> {
+        // An unknown session term means no grain ever carried it — an empty
+        // answer, not an error. Same posture as `thread_tail`.
+        let sess_id = match self.term_lookup(session)? {
+            Some(x) => x,
+            None => return Ok(Vec::new()),
+        };
+        if ns_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let live = if live_only {
+            " AND g.superseded_by IS NULL"
+        } else {
+            ""
+        };
+        // `gtype` stores the enum ordinal, matching `recent_ids`.
+        let gt_ord = gtype.map(|g| g as u8 as i64);
         let mut merged: Vec<(i64, Vec<u8>)> = Vec::new();
         for ns_id in ns_ids {
             let rows = match gt_ord {
                 Some(gt) => self.db.query(
-                    &format!("SELECT seq, blob FROM grains WHERE ns=?1 AND gtype=?2{live} ORDER BY seq DESC LIMIT ?3"),
-                    vec![pi(*ns_id), pi(gt), pi(limit as i64)],
+                    &format!(
+                        "SELECT ti.seq, g.blob FROM thread_idx ti JOIN grains g ON g.seq = ti.seq \
+                          WHERE ti.ns=?1 AND ti.session=?2 AND g.gtype=?3{live} \
+                          ORDER BY ti.seq DESC LIMIT ?4"
+                    ),
+                    vec![pi(*ns_id), pi(sess_id), pi(gt), pi(limit as i64)],
                 )?,
                 None => self.db.query(
-                    &format!("SELECT seq, blob FROM grains WHERE ns=?1{live} ORDER BY seq DESC LIMIT ?2"),
-                    vec![pi(*ns_id), pi(limit as i64)],
+                    &format!(
+                        "SELECT ti.seq, g.blob FROM thread_idx ti JOIN grains g ON g.seq = ti.seq \
+                          WHERE ti.ns=?1 AND ti.session=?2{live} \
+                          ORDER BY ti.seq DESC LIMIT ?3"
+                    ),
+                    vec![pi(*ns_id), pi(sess_id), pi(limit as i64)],
                 )?,
             };
             for row in &rows {

--- a/crates/areev-store/src/pg.rs
+++ b/crates/areev-store/src/pg.rs
@@ -142,10 +142,27 @@ pub(crate) const PG_SEED: &[&str] = &[
 
 pub(crate) struct PgDb {
     rt: tokio::runtime::Runtime,
-    client: tokio_postgres::Client,
+    /// Kept so a dead session can be replaced in place. A managed Postgres
+    /// restarts, fails over, and drops idle connections as ROUTINE
+    /// maintenance, not as an incident — before this, one such event
+    /// permanently poisoned a long-lived handle and every later call failed
+    /// until the process was recycled.
+    url: String,
+    schema: String,
+    client: RefCell<tokio_postgres::Client>,
     /// Prepared statements keyed by the ORIGINAL (untranslated) SQL, so hot
     /// callers hit the cache without re-translating.
+    ///
+    /// MUST be cleared on reconnect: a `tokio_postgres::Statement` names a
+    /// server-side prepared statement belonging to ONE session, so carrying
+    /// the cache across a reconnect makes every hot call fail forever with
+    /// `26000 invalid_sql_statement_name` — a reconnect that reconnects and
+    /// still cannot serve a query.
     cache: RefCell<HashMap<String, tokio_postgres::Statement>>,
+    /// Whether a transaction is open on this handle. Nothing is replayed while
+    /// it is: the transaction died with the connection, so silently re-running
+    /// one statement would apply it outside the atomic unit it was written for.
+    in_txn: std::cell::Cell<bool>,
     /// Cached BM25 collection stats — a COUNT/SUM over fts_doc is O(corpus)
     /// and would otherwise run on EVERY text query. Invalidated on this
     /// handle's own writes (reserve_write); other writers' documents stay
@@ -220,7 +237,87 @@ impl PgDb {
                 .await;
             boot
         })?;
-        Ok(Self { rt, client, cache: RefCell::new(HashMap::new()), stats: RefCell::new(None) })
+        Ok(Self {
+            rt,
+            url: url.to_string(),
+            schema: schema.to_string(),
+            client: RefCell::new(client),
+            cache: RefCell::new(HashMap::new()),
+            in_txn: std::cell::Cell::new(false),
+            stats: RefCell::new(None),
+        })
+    }
+
+    /// Is this error the CONNECTION dying, as opposed to the statement failing?
+    ///
+    /// Only these justify replacing the client: an ordinary constraint
+    /// violation must stay an ordinary error. Covers the client noticing the
+    /// socket is gone (`is_closed`), SQLSTATE class 08 (connection exception),
+    /// and the three 57Pnn shutdown codes a managed Postgres sends on
+    /// restart/failover — `57P01 terminating connection due to administrator
+    /// command` is the one a Cloud SQL maintenance window produces.
+    fn is_connection_dead(e: &AreevError) -> bool {
+        let AreevError::Storage(msg) = e else {
+            return false;
+        };
+        msg.contains("57P01")
+            || msg.contains("57P02")
+            || msg.contains("57P03")
+            || msg.contains("postgres error 08")
+            || msg.contains("connection closed")
+            || msg.contains("connection unexpectedly closed")
+    }
+
+    /// Replace the dead session with a fresh one.
+    ///
+    /// Deliberately does NOT re-run the bootstrap DDL: the schema already
+    /// exists, and re-taking the bootstrap advisory lock on every blip would
+    /// serialise recovery across every handle on the database. Only the
+    /// session-local state has to be restored — `search_path` — and the two
+    /// caches that belonged to the old session have to go.
+    fn reconnect(&self) -> Result<()> {
+        let (client, connection) = self
+            .rt
+            .block_on(tokio_postgres::connect(&self.url, tokio_postgres::NoTls))
+            .map_err(pg_err)?;
+        self.rt.spawn(async move {
+            let _ = connection.await;
+        });
+        self.rt.block_on(client.batch_execute(&format!(
+            "SET search_path TO \"{}\", public, ext",
+            self.schema
+        )))
+        .map_err(pg_err)?;
+        // Order matters only in that both must happen before the next call:
+        // a Statement from the old session is invalid, and the BM25 collection
+        // stats were cached against a connection that can no longer confirm them.
+        self.cache.borrow_mut().clear();
+        *self.stats.borrow_mut() = None;
+        *self.client.borrow_mut() = client;
+        Ok(())
+    }
+
+    /// Reconnect after a connection-level failure, and report whether the
+    /// failed call may be replayed.
+    ///
+    /// `replayable` is the whole safety argument. A READ outside a transaction
+    /// can be re-run: it had no effect, so running it twice is running it
+    /// once. A WRITE cannot — the connection may have died AFTER the server
+    /// committed it, and nothing on this side can tell the difference, so
+    /// replaying risks applying it twice. Those calls get the fresh connection
+    /// for NEXT time and this error now, which is the honest outcome: the host
+    /// learns its unit of work did not complete.
+    fn recover(&self, e: &AreevError, replayable: bool) -> bool {
+        if !Self::is_connection_dead(e) || self.in_txn.get() {
+            return false;
+        }
+        // A failed reconnect leaves the handle dead-but-retryable rather than
+        // erroring here: the caller's original error is the more useful one,
+        // and the next call tries again.
+        if self.reconnect().is_err() {
+            return false;
+        }
+        replayable
     }
 
     /// Prepare-and-cache. ONLY the `_hot` calls come through here: their SQL
@@ -233,41 +330,72 @@ impl PgDb {
             return Ok(st.clone());
         }
         let translated = translate(sql)?;
-        let st = self.rt.block_on(self.client.prepare(&translated)).map_err(|e| {
+        let st = self.rt.block_on(self.client.borrow().prepare(&translated)).map_err(|e| {
             AreevError::Storage(format!("prepare failed: {e} — translated SQL: {translated}"))
         })?;
         self.cache.borrow_mut().insert(sql.to_string(), st.clone());
         Ok(st)
     }
 
-    fn run_query(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<Vec<Row>> {
+    fn query_once(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<Vec<Row>> {
         let vals: Vec<PgVal> = params.into_iter().map(PgVal).collect();
         let refs: Vec<&(dyn ToSql + Sync)> =
             vals.iter().map(|v| v as &(dyn ToSql + Sync)).collect();
         let rows = if hot {
             let st = self.prepared(sql)?;
-            self.rt.block_on(self.client.query(&st, &refs))
+            self.rt.block_on(self.client.borrow().query(&st, &refs))
         } else {
             // Uncached path: the temporary statement is closed on drop, so
             // dynamic SQL leaves nothing behind on either side.
             let translated = translate(sql)?;
-            self.rt.block_on(self.client.query(translated.as_str(), &refs))
+            self.rt.block_on(self.client.borrow().query(translated.as_str(), &refs))
         }
         .map_err(pg_err)?;
         rows.iter().map(row_to_row).collect()
     }
 
+    /// A read, replayed once if the connection died under it.
+    ///
+    /// Replay is safe here precisely because it is a read: no effect to
+    /// duplicate. This is what turns a routine managed-Postgres restart from
+    /// "this handle is dead until the process is recycled" into one slow call.
+    fn run_query(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<Vec<Row>> {
+        match self.query_once(sql, params.clone(), hot) {
+            Ok(rows) => Ok(rows),
+            Err(e) => {
+                if self.recover(&e, true) {
+                    self.query_once(sql, params, hot)
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    /// A write. Reconnects for the NEXT call but never replays this one — see
+    /// [`recover`](Self::recover) for why a possibly-committed write must not
+    /// be re-run.
     fn run_execute(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<u64> {
+        match self.execute_once(sql, params, hot) {
+            Ok(n) => Ok(n),
+            Err(e) => {
+                self.recover(&e, false);
+                Err(e)
+            }
+        }
+    }
+
+    fn execute_once(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<u64> {
         let vals: Vec<PgVal> = params.into_iter().map(PgVal).collect();
         let refs: Vec<&(dyn ToSql + Sync)> =
             vals.iter().map(|v| v as &(dyn ToSql + Sync)).collect();
         if hot {
             let st = self.prepared(sql)?;
-            self.rt.block_on(self.client.execute(&st, &refs)).map_err(pg_err)
+            self.rt.block_on(self.client.borrow().execute(&st, &refs)).map_err(pg_err)
         } else {
             let translated = translate(sql)?;
             self.rt
-                .block_on(self.client.execute(translated.as_str(), &refs))
+                .block_on(self.client.borrow().execute(translated.as_str(), &refs))
                 .map_err(pg_err)
         }
     }
@@ -291,15 +419,45 @@ impl Db for PgDb {
     }
 
     fn begin(&self) -> Result<()> {
-        self.rt.block_on(self.client.batch_execute("BEGIN")).map_err(pg_err)
+        let r = self
+            .rt
+            .block_on(self.client.borrow().batch_execute("BEGIN"))
+            .map_err(pg_err);
+        // Set only on success, so a failed BEGIN does not wedge the handle
+        // into "a transaction is open" and block every later recovery.
+        if r.is_ok() {
+            self.in_txn.set(true);
+        } else {
+            self.recover(r.as_ref().unwrap_err(), false);
+        }
+        r
     }
 
     fn commit(&self) -> Result<()> {
-        self.rt.block_on(self.client.batch_execute("COMMIT")).map_err(pg_err)
+        let r = self
+            .rt
+            .block_on(self.client.borrow().batch_execute("COMMIT"))
+            .map_err(pg_err);
+        // Cleared either way: a failed COMMIT ends the transaction just as
+        // surely as a successful one, and leaving the flag set would suppress
+        // reconnects forever after a single outage mid-transaction.
+        self.in_txn.set(false);
+        if let Err(ref e) = r {
+            self.recover(e, false);
+        }
+        r
     }
 
     fn rollback(&self) -> Result<()> {
-        self.rt.block_on(self.client.batch_execute("ROLLBACK")).map_err(pg_err)
+        let r = self
+            .rt
+            .block_on(self.client.borrow().batch_execute("ROLLBACK"))
+            .map_err(pg_err);
+        self.in_txn.set(false);
+        if let Err(ref e) = r {
+            self.recover(e, false);
+        }
+        r
     }
 
     fn prefers_batched_reads(&self) -> bool {
@@ -416,9 +574,11 @@ impl Db for PgDb {
             // erasure.
             let _ = self
                 .client
+                .borrow()
                 .batch_execute("CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public")
                 .await;
             self.client
+                .borrow()
                 .batch_execute(&format!(
                     "ALTER TABLE embeddings ADD COLUMN IF NOT EXISTS vec vector({dim})"
                 ))
@@ -432,6 +592,7 @@ impl Db for PgDb {
             // fail mid-transaction — refuse the embedder up front instead.
             let row = self
                 .client
+                .borrow()
                 .query_one(
                     "SELECT a.atttypmod FROM pg_attribute a
                       JOIN pg_class c ON a.attrelid = c.oid

--- a/crates/areev-store/src/pg.rs
+++ b/crates/areev-store/src/pg.rs
@@ -315,7 +315,19 @@ impl PgDb {
     /// for NEXT time and this error now, which is the honest outcome: the host
     /// learns its unit of work did not complete.
     fn recover(&self, e: &AreevError, replayable: bool) -> bool {
-        if !Self::is_connection_dead(e) || self.in_txn.get() {
+        if self.in_txn.get() {
+            return false;
+        }
+        // Two independent signals, because neither alone is complete. The
+        // SQLSTATE match reads the message `pg_err` formatted, which only
+        // exists when the SERVER got far enough to send an error; when the
+        // socket simply vanished there is no SQLSTATE to match and the client
+        // is the only witness. Asking the client directly also means a change
+        // to `pg_err`'s wording degrades recovery rather than silently
+        // disabling it. The borrow is dropped before `reconnect` takes its
+        // `borrow_mut`.
+        let socket_gone = self.client.borrow().is_closed();
+        if !socket_gone && !Self::is_connection_dead(e) {
             return false;
         }
         // A failed reconnect leaves the handle dead-but-retryable rather than

--- a/crates/areev-store/src/pg.rs
+++ b/crates/areev-store/src/pg.rs
@@ -149,7 +149,14 @@ pub(crate) struct PgDb {
     /// until the process was recycled.
     url: String,
     schema: String,
-    client: RefCell<tokio_postgres::Client>,
+    // `Arc` so a caller can clone the handle out of the cell and drop the
+    // borrow BEFORE awaiting on it. Holding a `Ref` across an await is the
+    // shape that would deadlock against `reconnect`'s `borrow_mut`; taking the
+    // clone first makes that impossible by construction rather than by
+    // reasoning about which futures run when. `Arc` rather than `Rc` because
+    // `Db` is `Send` — the handle moves between threads even though only one
+    // uses it at a time.
+    client: RefCell<std::sync::Arc<tokio_postgres::Client>>,
     /// Prepared statements keyed by the ORIGINAL (untranslated) SQL, so hot
     /// callers hit the cache without re-translating.
     ///
@@ -241,7 +248,7 @@ impl PgDb {
             rt,
             url: url.to_string(),
             schema: schema.to_string(),
-            client: RefCell::new(client),
+            client: RefCell::new(std::sync::Arc::new(client)),
             cache: RefCell::new(HashMap::new()),
             in_txn: std::cell::Cell::new(false),
             stats: RefCell::new(None),
@@ -293,7 +300,7 @@ impl PgDb {
         // stats were cached against a connection that can no longer confirm them.
         self.cache.borrow_mut().clear();
         *self.stats.borrow_mut() = None;
-        *self.client.borrow_mut() = client;
+        *self.client.borrow_mut() = std::sync::Arc::new(client);
         Ok(())
     }
 
@@ -330,7 +337,8 @@ impl PgDb {
             return Ok(st.clone());
         }
         let translated = translate(sql)?;
-        let st = self.rt.block_on(self.client.borrow().prepare(&translated)).map_err(|e| {
+        let client = self.client.borrow().clone();
+        let st = self.rt.block_on(client.prepare(&translated)).map_err(|e| {
             AreevError::Storage(format!("prepare failed: {e} — translated SQL: {translated}"))
         })?;
         self.cache.borrow_mut().insert(sql.to_string(), st.clone());
@@ -343,12 +351,14 @@ impl PgDb {
             vals.iter().map(|v| v as &(dyn ToSql + Sync)).collect();
         let rows = if hot {
             let st = self.prepared(sql)?;
-            self.rt.block_on(self.client.borrow().query(&st, &refs))
+            let client = self.client.borrow().clone();
+            self.rt.block_on(client.query(&st, &refs))
         } else {
             // Uncached path: the temporary statement is closed on drop, so
             // dynamic SQL leaves nothing behind on either side.
             let translated = translate(sql)?;
-            self.rt.block_on(self.client.borrow().query(translated.as_str(), &refs))
+            let client = self.client.borrow().clone();
+            self.rt.block_on(client.query(translated.as_str(), &refs))
         }
         .map_err(pg_err)?;
         rows.iter().map(row_to_row).collect()
@@ -391,11 +401,13 @@ impl PgDb {
             vals.iter().map(|v| v as &(dyn ToSql + Sync)).collect();
         if hot {
             let st = self.prepared(sql)?;
-            self.rt.block_on(self.client.borrow().execute(&st, &refs)).map_err(pg_err)
+            let client = self.client.borrow().clone();
+            self.rt.block_on(client.execute(&st, &refs)).map_err(pg_err)
         } else {
             let translated = translate(sql)?;
+            let client = self.client.borrow().clone();
             self.rt
-                .block_on(self.client.borrow().execute(translated.as_str(), &refs))
+                .block_on(client.execute(translated.as_str(), &refs))
                 .map_err(pg_err)
         }
     }
@@ -419,25 +431,22 @@ impl Db for PgDb {
     }
 
     fn begin(&self) -> Result<()> {
-        let r = self
-            .rt
-            .block_on(self.client.borrow().batch_execute("BEGIN"))
-            .map_err(pg_err);
+        let client = self.client.borrow().clone();
+        let r = self.rt.block_on(client.batch_execute("BEGIN")).map_err(pg_err);
         // Set only on success, so a failed BEGIN does not wedge the handle
         // into "a transaction is open" and block every later recovery.
-        if r.is_ok() {
-            self.in_txn.set(true);
-        } else {
-            self.recover(r.as_ref().unwrap_err(), false);
+        match &r {
+            Ok(_) => self.in_txn.set(true),
+            Err(e) => {
+                self.recover(e, false);
+            }
         }
         r
     }
 
     fn commit(&self) -> Result<()> {
-        let r = self
-            .rt
-            .block_on(self.client.borrow().batch_execute("COMMIT"))
-            .map_err(pg_err);
+        let client = self.client.borrow().clone();
+        let r = self.rt.block_on(client.batch_execute("COMMIT")).map_err(pg_err);
         // Cleared either way: a failed COMMIT ends the transaction just as
         // surely as a successful one, and leaving the flag set would suppress
         // reconnects forever after a single outage mid-transaction.
@@ -449,10 +458,8 @@ impl Db for PgDb {
     }
 
     fn rollback(&self) -> Result<()> {
-        let r = self
-            .rt
-            .block_on(self.client.borrow().batch_execute("ROLLBACK"))
-            .map_err(pg_err);
+        let client = self.client.borrow().clone();
+        let r = self.rt.block_on(client.batch_execute("ROLLBACK")).map_err(pg_err);
         self.in_txn.set(false);
         if let Err(ref e) = r {
             self.recover(e, false);
@@ -572,13 +579,13 @@ impl Db for PgDb {
             // install into that schema — invisible to sibling memories, and
             // destroyed database-wide by that one memory's DROP SCHEMA
             // erasure.
-            let _ = self
-                .client
-                .borrow()
+            // Cloned out of the cell up front, so no borrow is held across an
+            // await (see the `client` field).
+            let client = self.client.borrow().clone();
+            let _ = client
                 .batch_execute("CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA public")
                 .await;
-            self.client
-                .borrow()
+            client
                 .batch_execute(&format!(
                     "ALTER TABLE embeddings ADD COLUMN IF NOT EXISTS vec vector({dim})"
                 ))
@@ -590,9 +597,7 @@ impl Db for PgDb {
                 })?;
             // A pre-existing column with a different dim would make every add
             // fail mid-transaction — refuse the embedder up front instead.
-            let row = self
-                .client
-                .borrow()
+            let row = client
                 .query_one(
                     "SELECT a.atttypmod FROM pg_attribute a
                       JOIN pg_class c ON a.attrelid = c.oid

--- a/crates/areev-store/tests/store_tests.rs
+++ b/crates/areev-store/tests/store_tests.rs
@@ -4,7 +4,7 @@
 //! (create memory, structural recall, batch-add, supersede, forget)
 //! running in-process.
 
-use areev_core::types::{Event, Fact, Grain};
+use areev_core::types::{Event, Fact, Grain, GrainType};
 use areev_store::{Axis, Direction, Areev, OP_ADD, OP_FORGET, OP_SUPERSEDE};
 use tempfile::TempDir;
 
@@ -151,6 +151,68 @@ fn thread_tail_returns_transcript_order() {
     assert_eq!(tail.len(), 20);
     assert_eq!(tail[0].get_str("content"), Some("turn 10"));
     assert_eq!(tail[19].get_str("content"), Some("turn 29"));
+}
+
+#[test]
+fn recent_in_session_beats_the_truncated_window() {
+    // The defect this read exists to fix (#49): the session's turns are OLDER
+    // than the page a namespace scan returns, so a post-filter over `recent`
+    // finds none of them while the index-backed read finds all of them.
+    let (mut m, _d) = open_mem();
+    for i in 0..5 {
+        let mut e = Event::new(&format!("call-7 turn {i}"));
+        e.session_id = Some("call-7".to_string());
+        e.common.namespace = Some("caller".to_string());
+        m.add(&e).unwrap();
+    }
+    // 200 newer events on other sessions bury it.
+    for i in 0..200 {
+        let mut e = Event::new(&format!("noise {i}"));
+        e.session_id = Some(format!("other-{i}"));
+        e.common.namespace = Some("caller".to_string());
+        m.add(&e).unwrap();
+    }
+
+    // What a post-filter over a 50-row page would have seen: nothing.
+    let page = m.recent("caller", Some(GrainType::Event), 50).unwrap();
+    let in_page = page
+        .iter()
+        .filter(|g| g.get_str("session_id") == Some("call-7"))
+        .count();
+    assert_eq!(in_page, 0, "the session must be outside the page for this test to mean anything");
+
+    // The index-backed read returns the whole session regardless of page.
+    let got = m
+        .recent_in_session("caller", "call-7", Some(GrainType::Event), 20, true)
+        .unwrap();
+    assert_eq!(got.len(), 5);
+    // Newest first, matching `recent`'s contract (thread_tail is the
+    // oldest-first transcript view).
+    assert_eq!(got[0].get_str("content"), Some("call-7 turn 4"));
+    assert_eq!(got[4].get_str("content"), Some("call-7 turn 0"));
+}
+
+#[test]
+fn recent_in_session_filters_type_and_unknown_session_is_empty() {
+    let (mut m, _d) = open_mem();
+    let mut e = Event::new("an event");
+    e.session_id = Some("s1".to_string());
+    e.common.namespace = Some("caller".to_string());
+    m.add(&e).unwrap();
+
+    // Narrowing to a type the session has none of returns empty, not the event.
+    let none = m
+        .recent_in_session("caller", "s1", Some(GrainType::Fact), 10, true)
+        .unwrap();
+    assert!(none.is_empty());
+    // No type filter: the event comes back.
+    let all = m.recent_in_session("caller", "s1", None, 10, true).unwrap();
+    assert_eq!(all.len(), 1);
+    // A session term nothing ever carried is an empty answer, not an error.
+    let unknown = m
+        .recent_in_session("caller", "never-used", None, 10, true)
+        .unwrap();
+    assert!(unknown.is_empty());
 }
 
 #[test]

--- a/docs/areev-adaptive-agents-proposal.md
+++ b/docs/areev-adaptive-agents-proposal.md
@@ -1,6 +1,9 @@
 # Areev for adaptive agents — the runtime, the governance plane, and the distillation path
 
-**Status:** proposal, 2026-08-11. Nothing built. Supersedes and absorbs
+**Status:** proposal, 2026-08-11. **Partially built:** the runtime and the
+governance plane shipped (`areev-run-core`/`areev-run`, the loop's gates and
+recommendation lifecycle). The distillation / small-language-model path in §5
+onward remains unbuilt. Supersedes and absorbs
 [`areev-run-proposal.md`](areev-run-proposal.md) (2026-08-07), whose §4 replay
 recommendation survives and whose §2 cost estimate does not. Sits alongside
 [`areev-enterprise-proposal.md`](areev-enterprise-proposal.md), whose adoption

--- a/docs/areev-run-proposal.md
+++ b/docs/areev-run-proposal.md
@@ -1,8 +1,12 @@
 # `areev run` — an agent runtime whose execution history is memory
 
-**Status:** proposal, **partially superseded**. Nothing built. Written
+**Status:** proposal, **partially superseded — and now BUILT**. Written
 2026-08-07, after the graph-engineering audit (PR #56) landed the substrate this
-would sit on. **2026-08-14:** the phasing here (§7) and the two open decisions
+would sit on. **2026-08-19:** the runtime shipped — `areev-run-core` (the pure
+scheduler) and `areev-run` (the driver) are in the workspace, with the CLI
+`areev run …` verbs, the six MCP `areev_run_*` tools, and the console Runs tab.
+`docs/run.md` is the reference; this file is kept for the design rationale, not
+as a statement of what exists. **2026-08-14:** the phasing here (§7) and the two open decisions
 (§10) are superseded by
 [`areev-governed-agents-proposal.md`](areev-governed-agents-proposal.md), which
 records the decided answers (LangGraph-parity bar; Bet B on Hermes; the §8

--- a/docs/cal-reference.md
+++ b/docs/cal-reference.md
@@ -221,14 +221,49 @@ ASSEMBLE "<topic>" [FOR "<audience>"] FROM <sources> [WHERE ...]
          [BUDGET <n> [tokens|grains]]
          [PRIORITY label: weight, ... | PRIORITY a > b > c]
          [FORMAT <spec>] [WITH dedup(<field>)]
+
+<sources> = label: [PIN] (<sub-query>)
+          | label: [PIN] LITERAL "<text>"
 ```
 
 Clause order is fixed (it is the OMS §8.2 order): `FOR` directly after the topic,
-`BUDGET` before `PRIORITY`, and `FORMAT` before `WITH dedup`. A clause written out
-of order is not attached to the statement (e.g. `BUDGET` after `FORMAT` is
-silently dropped — see the golden-test notes). `WHERE` applies to the
-single-source form only. `PRIORITY` accepts weighted labels (`a: 0.5, b: 0.3`) or
-an ordering chain (`a > b > c`, mapped to evenly spaced weights).
+`BUDGET` before `PRIORITY`, and `FORMAT` before `WITH dedup`. **A clause written
+out of order is a parse error** naming the clause and the canonical order. It
+used to be silently dropped — `… FORMAT markdown BUDGET 900` ran at the
+4000-token default, so the guard you wrote was not the guard that ran.
+`WHERE` applies to the single-source form only. `PRIORITY` accepts weighted
+labels (`a: 0.5, b: 0.3`) or an ordering chain (`a > b > c`, mapped to evenly
+spaced weights).
+
+**Render order is FROM-clause order, and nothing else changes it.** Sections
+appear in the order their labels are written. `PRIORITY` weights how the token
+budget is *shared*; it does not reorder. A pipeline `ORDER BY` on an assembly
+cannot reorder sections either and emits `CAL-W016` rather than silently doing
+nothing — to order *within* a section, put the stage on that source's
+sub-query.
+
+**`LITERAL` — host text at an authored position.** A production system prompt
+is grains interleaved with fixed text, some of it contractually mandatory. A
+`LITERAL` source renders exactly the text given, at its authored index, and
+counts against the budget like any other section — so a compliance-critical
+instruction can live in the statement (i.e. in code) rather than as a mutable
+grain.
+
+**`PIN` — non-degradable.** The budget allocator satisfies pinned sources
+first, at their full cost, and never trims them; `PRIORITY` then shares what is
+left among the rest. If the pins alone exceed `BUDGET`, the statement fails
+with `CAL-E122` instead of summarising the one section that had to survive
+verbatim. `PIN` works on query sources too, not just literals.
+
+```sql
+ASSEMBLE "turn" FROM
+  guardrail: PIN LITERAL "Never diagnose. Route clinical questions to staff.",
+  turns:     PIN (RECALL events RECENT 3),
+  history:   (RECALL events RECENT 200)
+BUDGET 900 tokens
+PRIORITY history: 1.0
+FORMAT markdown
+```
 
 Single-source:
 
@@ -475,6 +510,18 @@ Saved-query limits: 100 per namespace, 8 KiB body, 10 parameters. Saved-query
 bodies get an extra read-only verification pass, so a saved query can never
 smuggle in a write or a blocked keyword.
 
+**Does `RUN` reuse a compiled plan?** Yes, per distinct *argument set*. The
+executor caches parsed statements keyed by exact text, and `RUN` substitutes
+parameters into the body **before** parsing — so a zero-parameter saved query
+hits the cache on every call after the first, and a parameterized one hits per
+distinct set of bindings. The same cache serves plain statement text from every
+surface (CLI, MCP, the server, both bindings), which is what keeps a real-time
+turn from re-lexing and re-parsing its statement each time. The Node and
+Python bindings additionally expose `calPrepare` / `cal_prepare`, which parses
+and validates a statement at startup and keeps the plan — turning a bad
+statement into a startup error instead of a first-turn error. The handle is the
+statement text itself; there is no opaque handle object to leak.
+
 `DEFINE` also **parses** the body, so a query that could never run is refused
 where it is written rather than stored as a landmine for its first caller —
 which is typically an unattended agent, long after whoever wrote the query has
@@ -604,6 +651,39 @@ RECALL facts WHERE namespace = "caller" | COUNT
 RECALL facts WHERE relation = "knows" | OBJECTS
 ```
 
+`WHERE session_id = "…"` is **pushed into the thread index**
+(`idx_thread(ns, session, seq)`) rather than applied as a post-filter, so
+`RECALL events WHERE session_id = "call-42" RECENT 20` is bounded by 20 turns
+*of that conversation* — not by the newest 20 rows of the namespace, which on a
+busy namespace could contain none of it. A session is an anchor, so the bare
+`RECALL WHERE session_id = "…"` form (no grain type) is accepted too. The Rust,
+Node and Python bindings also expose `thread_tail(session, n)` for the same
+read in transcript order.
+
+**Stages that rank, filter or count see the whole matching set, not a page of
+it.** A pipeline stage runs over the grains the statement returned, and that
+is `default_limit` (50) rows unless the statement said otherwise — so
+`ORDER BY priority DESC | LIMIT 5` used to return the top 5 *of the newest 50*
+and was indistinguishable from the top 5 overall. When an `ORDER BY`, a
+type-specific `WHERE` post-filter, or a `COUNT` is present, the scan widens to
+`max_limit` (1000) and the caller's bound is re-applied afterwards: **LIMIT
+bounds the answer, not the search for it.** If even the widened scan comes back
+full, the result carries `CAL-W015` — past that point the answer is the top-k
+of a window rather than of the memory, and nothing else would distinguish the
+two. Narrow with `WHERE`/`ABOUT`/`SINCE`, or raise `max_limit`.
+
+`ORDER BY created_at` is the one ordering pushed into the scan itself, so it is
+exact at any corpus size: `created_at` is a column on the `grains` table.
+Every other sort key (`priority`, `status`, `confidence`, and all
+type-specific fields) lives inside the immutable, content-addressed blob, where
+SQL cannot reach it without materializing a column per field — those are ranked
+in the executor over the widened scan.
+
+A stage attached to a payload it cannot act on — most usefully `ORDER BY` on a
+multi-source `ASSEMBLE`, which returns an assembled section list rather than a
+flat grain list — is skipped with `CAL-W016`. It used to vanish with no error
+and no warning.
+
 There is **no `| WHERE` stage** — filtering is a statement clause, not a
 pipeline stage. Write `RECALL … WHERE a = … AND b = …` instead. The parser
 rejects `| WHERE` with `CAL-E002` and lists the stages it does accept, which is
@@ -635,7 +715,7 @@ representative selection:
 | `WITH rerank` / `WITH rerank("model")` | Cross-encoder reranking (feature-gated) |
 | `WITH query_expansion` / `WITH query_decompose` / `WITH hyde` | Query rewriting strategies |
 | `WITH multi_hop(2)` | Entity-graph expansion (1–3 hops): follows the entities named by the first-pass results and adds what they anchor to the candidate pool, competing within `LIMIT` |
-| `WITH recency_weight(0.3)` / `WITH min_score(0.6)` | Scoring controls |
+| `WITH recency_weight(0.3)` / `WITH min_score(0.6)` | Scoring controls. `recency_weight(w)` scores `final = (1-w)·relevance + w·freshness`, `freshness = 1/(1 + age_hours)`, where relevance is the candidate's rank in fusion order; **state facts are exempt** (a current fact should not sink below a stale event just for being older). It re-ranks the retrieved candidates *before* the result is bounded. |
 | `WITH conflict_resolution` | Keep only the newest grain per `(subject, relation)` |
 | `WITH contradiction_detection` | Keep everything, but stamp `contested_by` on grains that are live tips of an open fork |
 | `WITH annotate_relative_time` | Add "2 weeks ago"-style labels |

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -842,6 +842,69 @@ mapping = json.loads(m.anon_mappings())[0]["mapping"]
 final = json.loads(m.rehydrate_text(reply, json.dumps(mapping)))["text"]
 ```
 
+### Gate the policy in CI
+
+An egress control you cannot test is close to one you cannot use, and a
+fixture file is the first artifact an auditor asks for. Write down what the
+policy **must** redact and what it **must not**, and fail the build on either
+direction:
+
+```json
+{
+  "policy": {
+    "mode": "egress",
+    "default_action": "allow",
+    "categories": { "sg_nric": "redact", "mrn": "redact", "email": "redact" }
+  },
+  "must_redact": [
+    "NRIC S1234567D on file",
+    "MRN 00456123 admitted",
+    "contact jane@example.com"
+  ],
+  "must_not_redact": [
+    "invoice total 4471820 aed",
+    "S1234567A is not a valid NRIC",
+    "the ward saw 12345678 visitors"
+  ]
+}
+```
+
+```bash
+areev anonymize test --fixtures policy-fixtures.json
+# → 6 fixtures: 6 passed, 0 failed (0 missed, 0 false positive)
+# exits non-zero on any miss or false positive
+```
+
+The `must_not_redact` half is the load-bearing one: a policy that redacts
+everything passes `must_redact` trivially. Note what the negatives above pin —
+`S1234567A` has a valid NRIC *shape* but a wrong check digit, and the bare
+digit runs are quantities, not identifiers. The national-ID detectors are
+checksum-gated (Singapore NRIC/FIN weighted mod-11, UAE Emirates ID Luhn +
+`784` prefix), and MRN is cue-gated on a nearby `MRN` / `medical record
+number`, because matching bare digit runs would redact every quantity in a
+clinical note.
+
+### Redact on context, not just on category
+
+A name alone may be fine in a prompt; a name **beside a condition** is health
+data. That is a property of the pair, so no per-category action can express it:
+
+```json
+{
+  "mode": "egress",
+  "default_action": "allow",
+  "categories": { "person": "allow", "condition": "allow", "phi": "pseudonym" },
+  "term_sets": { "condition": ["type 2 diabetes", "hypertension"] },
+  "co_occurrence": [
+    { "when": "person", "near": "condition", "within_chars": 120, "as_category": "phi" }
+  ]
+}
+```
+
+"Jane Doe called about the invoice" keeps the name; "Jane Doe was diagnosed
+with type 2 diabetes" comes back as `[PHI_1]` — and the placeholder says *why*
+it was escalated rather than reading like an ordinary `[PERSON_1]`.
+
 `scope: "session"` keeps tokens stable across calls in one process. MCP and
 CAL payloads carry an `anonymized` report with mapping **ids** only — the
 mapping itself never rides a payload; the host process rehydrates.

--- a/docs/deployment-profile.md
+++ b/docs/deployment-profile.md
@@ -22,7 +22,7 @@ partner requires it.
 │  single-tenant: per-team memory FILES (encrypted at rest,        │
 │      open_encrypted / AREEV_PASSPHRASE)                            │
 │  multi-tenant:  PostgreSQL backend — one memory = one schema,    │
-│      advisory-locked single writer, pgvector                     │
+│      CONCURRENT writers per schema, pgvector                     │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
@@ -46,9 +46,14 @@ partner requires it.
    verbs) — provisioning is `areev`-CLI statements, auditable in the file
    itself.
 4. **Postgres for multi-tenant.** One memory = one schema keeps tenant
-   isolation at the storage boundary; the advisory lock keeps the single
-   writer honest; pgvector serves recall. Connection credentials are the
-   platform's secret-manager problem (env vars in the service unit).
+   isolation at the storage boundary; pgvector serves recall. Unlike the
+   embedded backend, this one admits **multiple concurrent writers per
+   memory** — `STO-E002` is never raised here, and the advisory lock covers
+   *schema bootstrap only*, not writes. Concurrent writers block and
+   serialise at `reserve_write` rather than erroring. Connection credentials
+   are the platform's secret-manager problem (env vars in the service unit);
+   the connection lifecycle, per-handle cost, and reconnect contract are in
+   [Postgres connection contract](#postgres-connection-contract) below.
 5. **Retention + holds, declared.** `areev retention set` (with
    `--min-days` floors) and `areev hold set` are file-truths that travel
    with the memory; `areev audit export` produces the hash-chain-verified

--- a/docs/deployment-profile.md
+++ b/docs/deployment-profile.md
@@ -59,6 +59,53 @@ partner requires it.
    with the memory; `areev audit export` produces the hash-chain-verified
    accountability evidence a reviewer asks for first.
 
+## Postgres connection contract
+
+The numbers below are measured against `pgvector/pgvector:pg16` on loopback
+Docker (Apple M4 Max). Treat them as shape, not as managed-database figures.
+
+**Connections per handle: 1, or 2 with telemetry.** One `tokio_postgres`
+client per `Areev` handle, plus a second for the recall-telemetry sidecar. The
+**bindings default telemetry to `aggregate`**, so a stock Node or Python handle
+opens **two**. Pass `telemetry="off"` when you do not want the sidecar. A
+multi-tenant host with one memory per tenant multiplies this by tenants *and*
+by instances against the server's `max_connections` — cache handles per tenant
+with an LRU and close idle ones (`close()` in Node; drop in Rust/Python), or
+put a pooler (PgBouncer in transaction mode, Cloud SQL Auth Proxy) in front.
+There is no built-in pool.
+
+**Open cost: provision schemas ahead of the request path.** First open of a
+NEW schema runs the full DDL bootstrap under an advisory lock — hundreds of
+milliseconds, fine as a provisioning step and unacceptable inside a request.
+Steady-state open of an existing, populated schema is tens of milliseconds.
+Create the tenant's schema when the tenant is created, not on their first turn.
+
+**Outage recovery: automatic for reads, explicit for writes.** A managed
+Postgres restarts, fails over, and drops connections as routine maintenance.
+The handle now replaces a dead session in place — clearing the
+prepared-statement cache and the BM25 stats cache, both of which belonged to
+the dead session — and:
+
+- a **read** is replayed transparently: it had no effect, so running it twice
+  is running it once;
+- a **write** is **not** replayed. The connection may have died *after* the
+  server committed it, and nothing client-side can tell the difference, so
+  replaying risks applying it twice. The call returns its error (`STO-E001`,
+  carrying the Postgres SQLSTATE — `57P01` for an administrator restart) and
+  the handle is usable again on the next call. **Your host must treat a failed
+  write as a unit of work to redo**, exactly as it would any other transaction
+  failure.
+- nothing is replayed **inside an open transaction**: the transaction died
+  with the connection, so the whole unit has to be re-run.
+
+Conformance: `a_handle_recovers_from_a_database_outage` in
+`areev-conformance`, run against a real server with a real
+`pg_terminate_backend`.
+
+**Writers: concurrent, not single.** See control 4 above — `STO-E002` is never
+raised on this backend, and concurrent writers block and serialise at
+`reserve_write` rather than erroring.
+
 ## SSO note (trusted-header mode)
 
 The proxy shared secret (`--sso-secret-env`) is an **impersonation-grade

--- a/docs/facts/context-assembly.md
+++ b/docs/facts/context-assembly.md
@@ -233,11 +233,11 @@ without `FORMAT`, the same statement returns the `assembled` token ledger
 Syntax facts this exercise pinned down (all against the parser):
 
 - **Clause order is fixed and matches OMS §8.2**: topic, `FOR`, `FROM`, `BUDGET`,
-  `PRIORITY`, `FORMAT`, `WITH dedup` — `parse_assemble` at
-  `crates/areev-cal/src/parser.rs:3147` (FOR at `:3186`, BUDGET `:3248`,
-  PRIORITY `:3307`, FORMAT `:3395`, WITH-dedup `:3406`). Out-of-order clauses
-  detach silently — `BUDGET` after `FORMAT` is dropped, a **known bug**
-  (`crates/areev-cli/tests/golden/CLAUDE.md`, Suite 9 #2).
+  `PRIORITY`, `FORMAT`, `WITH dedup` — `parse_assemble` in
+  `crates/areev-cal/src/parser.rs`. **Fixed 2026-08-19 (issue #42):**
+  out-of-order clauses used to detach silently — `BUDGET` after `FORMAT` was
+  dropped and the assembly ran at the 4000-token default. They are now a parse
+  error naming the clause and the canonical order.
 - **Source labels are plain identifiers** — dotted labels (`org.policies:`) are a
   parse error (`CAL-E002`); mounts are addressed by the namespace *string* inside
   the source (`WHERE namespace = "org.policies"`), per the §8 acceptance test

--- a/docs/loop.md
+++ b/docs/loop.md
@@ -91,6 +91,32 @@ up front); every decision carries a written reason.
 4. **Verify** — outcome review re-runs the stored metric after `review_after`
    and proposes a revert on regression.
 
+### Definition rewrites (`DEFINE QUERY` / `DEFINE TEMPLATE`)
+
+A proposal may rewrite a saved query or template — which is where a
+self-improving agent's *prompt-assembly* lives, so without it the loop could
+evolve an agent's memories but never the CAL that turns them into a prompt.
+Two rules make it safe, both enforced in the engine rather than by convention:
+
+- **Never auto-applied, regardless of policy.** The `query` target class is
+  excluded from `grants_auto_apply` by name, exactly as `code` and `evalset`
+  are. A grain edit changes one remembered value; a definition rewrite changes
+  what **every future context** contains, so it always requires a human
+  `APPROVE` + `APPLY` with `BECAUSE`.
+- **The inverse is recorded at apply, or the apply is refused.** A `DEFINE`
+  writes a `qry:`/`tpl:` registry row, not a grain, so the ordinary rollback
+  (retract `created_hashes`) would undo nothing while reporting success. The
+  substrate supplies `definition_inverse` — the statement restoring the
+  previous definition, or a `DROP` when there was none — and `ROLLBACK` runs
+  it. A substrate that cannot produce one (the default) refuses the apply:
+  a definition change `ROLLBACK` could not undo must not be applied at all.
+  Built-in definitions are immutable and therefore yield no inverse, so a
+  proposal to redefine one is refused.
+
+`DROP` is never proposable, and saved-query bodies keep their read-only
+verification pass, so a definition rewrite can no more smuggle in a write than
+a hand-written one can.
+
 The **audit trail is grains**: one immutable Observation per transition,
 hash-chained per recommendation, carrying the actor label and the reason. It
 syncs with the file and is queryable.

--- a/docs/memory-tool.md
+++ b/docs/memory-tool.md
@@ -55,7 +55,7 @@ while True:
 ### Node
 
 ```js
-const { Areev } = require('areev')
+const { Areev } = require('@areev/areev')
 const m = new Areev('agent.db', 'assistant')
 
 // inside your tool loop (every method returns a promise):

--- a/docs/postgres-backend-proposal.md
+++ b/docs/postgres-backend-proposal.md
@@ -1,6 +1,11 @@
 # Postgres Storage Backend — Proposal
 
-**Status: proposal (2026-08-07). Decision pending.**
+**Status: proposal (2026-08-07) — DECIDED AND BUILT.** The backend shipped as
+`crates/areev-store/src/pg.rs` behind `feature = "postgres"`, one memory = one
+schema, exercised on both backends by `areev-conformance`. Note the decision
+recorded here was later revised: this document's single-writer framing was
+superseded by multi-writer (see `docs/deployment-profile.md`). Kept for the
+latency analysis and the options that were weighed, not as current status.
 
 Driver: enterprise deployments — concretely Atmatic (healthcare front-desk,
 GCP Cloud Run + Cloud SQL Postgres 16) — need Areev's memory model without a

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -49,18 +49,38 @@ top of that.
 
 ### Anonymization keys and the sealed vault
 
-- **Three subkeys derive from the page-cipher key** via HKDF with distinct
-  domain-separation strings: `areev.blobs.v1` (the CAS sidecar, above),
-  `areev.anon.memory.v1` (value-derived pseudonym tokens — ingress mode and
-  `memory` scope), and `areev.vault.v1` (the sealed placeholder→value vault:
-  AES-256-GCM per row, the `vault:<ns>:<placeholder>` row key bound in as
-  associated data). Destroying the page key destroys all three —
-  **crypto-erasure reaches the vault by construction**.
-- **No page key, no value-derived features.** On a plaintext file — or any
-  Postgres schema, where the page cipher does not exist — ingress modes,
-  `memory` scope, and the vault refuse loudly at policy `set` rather than
-  degrade to unkeyed derivation (conformance-pinned on both backends). The
-  egress session's `mapping_id` key falls back to a per-handle random key
+- **Subkeys derive from ONE root** via HKDF with distinct domain-separation
+  strings: `areev.blobs.v1` (the CAS sidecar, above), `areev.anon.memory.v1`
+  (value-derived pseudonym tokens — ingress mode and `memory` scope), and
+  `areev.vault.v1` (the sealed placeholder→value vault: AES-256-GCM per row,
+  the `vault:<ns>:<placeholder>` row key bound in as associated data).
+- **The root is `AreevOptions::anon_key` when the host supplies one, else the
+  page-cipher key.** With the page key as root, destroying it destroys all
+  three subkeys — **crypto-erasure reaches the vault by construction**. With a
+  host-supplied root the same property holds against *that* key instead: the
+  vault rows are unreadable without it.
+- **Trust model for a host-supplied `anon_key`.** It is a 32-byte secret that
+  belongs in a KMS or secret manager (Cloud KMS, AWS KMS, Vault) and is
+  supplied per process. **Whoever holds it can re-identify every pseudonym in
+  the vault** — it is exactly as sensitive as the plaintext it protects. It is
+  **never persisted**: not in `meta`, not in a bundle, not in the file, so it
+  cannot leak through sync or export. **Rotating it is destructive**: existing
+  vault rows become permanently unreadable and every value-derived token
+  changes, so a rotation is a crypto-erasure of the mapping table and a break
+  in pseudonym continuity, not a routine hygiene step. Rotate deliberately —
+  to revoke re-identification — and re-derive nothing.
+- **Why it exists.** The Postgres backend refuses `encryption_key` outright (it
+  is a page-cipher capability), so when the page key was the only possible root
+  the mapping vault and deterministic tokens were unavailable on exactly the
+  backend built for stateless hosts — Cloud Run, ECS, Kubernetes. Separating
+  the anonymization root from encryption-at-rest fixes that, and lets a file be
+  encrypted under one key and pseudonymised under another, which is what
+  separating the two roles is for.
+- **No root, no value-derived features.** With neither an `anon_key` nor a page
+  key, ingress modes, `memory` scope, and the vault refuse loudly at policy
+  `set` rather than degrade to unkeyed derivation (conformance-pinned on both
+  backends), and the refusal names `anon_key` as the fix that works everywhere.
+  The egress session's `mapping_id` key falls back to a per-handle random key
   held only in memory.
 - **The vault never replicates.** `vault:` rows are excluded from bundle
   export, and the import allowlist refuses them from a crafted bundle — the


### PR DESCRIPTION
Closes #42, #43, #44, #45, #46, #47, #48, #49, #50, #28.

All nine evaluation findings (#42–#50) reproduced against the code before
being fixed. Two had a **wrong diagnosis**, which changed the fix — see below.

## The two corrected diagnoses

**#50 — the Windows leg builds fine.** The issue inferred "the Windows build
evidently failed". It doesn't: `needs: build` gates publish, so a failed leg
would have blocked the whole release. What failed was the **publish**, on
npm's spam filter rejecting the *name* `areev-win32-x64-msvc` — the same
filter that already blocks unscoped `areev`. The workflow caught that 403 by
name and shipped anyway, leaving a manifest promising an optionalDependency
npm had refused; npm skips a missing optional dep silently, and napi then
fails at `require()` with its misleading "Cannot find native binding" message.

So rather than dropping the target (the issue's suggestion), **scoping the
package** makes `napi create-npm-dirs` derive `@areev/areev-win32-x64-msvc`,
which the filter does not reject. Windows *works* instead of being documented
as unsupported. Verified locally: the regenerated loader requires the scoped
names. `prepare-npm.mjs` now hard-fails a release when a declared target
produced no artifact.

**#43 — true sort pushdown is possible for exactly one field.** The issue's
first option was "a sort key on `RecallParams`, pushed into the store query".
That works for `created_at`, which is a column on `grains` — and for nothing
else. `priority`, `status`, `confidence` and every type-specific field live
**inside the content-addressed blob**, so ordering on them in SQL would mean
materializing a column per field. That's a consequence of content addressing,
not an oversight.

So: `created_at` is pushed down and exact at any corpus size; everything else
widens to `max_limit` and **says so** via the new `CAL-W015` when even the
widened scan fills. Moving the boundary silently would have been the same
class of bug the issue reported.

## What changed, by issue

| # | Fix | Proof |
|---|---|---|
| **43** | `CONTRADICTIONS`' widening generalized to every post-retrieval stage (`ORDER BY`, type-specific `WHERE`, `COUNT`); `created_at` pushdown; `CAL-W016` replaces the silent `(other, _)` passthrough; **`WITH recency_weight` implemented** (parsed and read by nothing since 1.0, while ten built-in saved queries passed it) | 5 CAL integration tests, incl. top-k over a 200-grain corpus returning the true top-5 |
| **49** | `Areev::recent_in_session` over `idx_thread(ns, session, seq)`; `WHERE session_id` pushes down (**no new syntax**); `thread_tail` on both bindings | store + CAL + node + pytest tests, each burying a session under 200 newer events |
| **48** | Dead Postgres sessions replaced in place, clearing the statement and stats caches that belonged to them; **reads replay, writes don't** | conformance case against real Postgres with real `pg_terminate_backend` — verified to **fail without the fix** |
| **46** | `AreevOptions::anon_key` — one anonymization root, independent of the page cipher | conformance case on **both** backends, pinning cross-process token stability |
| **42** | `LITERAL` sources + `PIN`; pins costed off the top, never trimmed, `CAL-E122` when they can't fit; out-of-order clauses are now a parse error | 7 tests incl. a pin surviving a budget far below the assembled size |
| **47** | NRIC/FIN + Emirates ID (checksum-gated), MRN (cue-gated), `co_occurrence`, `areev anonymize test --fixtures` | 6 unit tests + a CLI smoke test asserting both directions |
| **45** | `cred::Credential` minted per request; `vertex:` under ADC against the **regional** endpoint; per-provider features, OpenRouter off by default | 4 tests; `--no-default-features` build verified |
| **44** | Parsed-statement cache; the bindings built a **fresh executor per `cal()` call** so no cache could ever hit — one now lives on the handle | measured numbers below |
| **50** | Scoped npm packages; release guard; 3 stale proposal headers | loader regenerated and inspected |
| **28** | `definition_inverse` + `AppliedRecord::inverse_cal`; definition targets excluded from auto-apply by name | adapter round-trip test |

## Measured (#44)

Node binding, release addon, 2,200 grains, 300 iterations. Now in
`RESULTS.md` §1b.

| statement (from Node) | backend | p50 | p95 | p99 |
|---|---|---|---|---|
| `RECALL events RECENT 20` | embedded | 0.17 ms | 0.48 ms | 0.86 ms |
| `ASSEMBLE` (3 sources) | embedded | 0.20 ms | 0.65 ms | 0.93 ms |
| `thread_tail` 20 | embedded | 0.08 ms | 0.28 ms | 0.58 ms |
| `RECALL events RECENT 20` | Postgres (loopback Docker) | 1.06 ms | 1.82 ms | 3.39 ms |
| `ASSEMBLE` (3 sources) | Postgres (loopback Docker) | 4.29 ms | 13.72 ms | 32.55 ms |
| `thread_tail` 20 | Postgres (loopback Docker) | 1.68 ms | 3.35 ms | 6.36 ms |

**Can Postgres meet a ~100 ms turn budget?** On loopback, comfortably. Off it,
the answer is round-trips × added RTT — a same-region managed instance adds
tens of ms to the assembly and gets tight at p99; cross-region does not fit.

## Verified

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets` clean at **`-D warnings`** across
  default, `postgres`, and `vertex,openrouter` feature sets
- Conformance **63 Postgres + 55 Turso** against a real pgvector 16 container
- Node **51/51**, pytest **78/78**, both with new tests for the new methods
- `docs_examples` passes, so the new ```sql fences in `cal-reference.md`
  actually parse

## Not verified here, and why

Stated plainly rather than implied:

- **Vertex/ADC against real GCP.** The credential paths (metadata server,
  gcloud well-known file) and the endpoint construction are unit-tested; no
  GCP project was reachable from this machine. Service-account key JSON is
  refused **by name** — signing its JWT needs an RSA dependency this tree
  deliberately doesn't carry, and the deployments ADC exists for typically
  forbid creating such keys anyway.
- **Managed Cloud SQL latency.** The Postgres rows are loopback-Docker on one
  machine and labelled as such in `RESULTS.md`.
- **#47's published precision/recall.** The fixture harness ships; inventing
  precision figures without a labelled corpus would be worse than omitting
  them.
- **The Windows npm publish.** The scoped name can only be proven on a real
  release run.

## Deliberately out of scope

`thread_tail` is on the bindings, as #49 asked. It is **not** a new MCP tool
or CLI verb — that would change `docs/mcp-reference.md`'s pinned tool count
for a surface nobody asked for. Say the word and I'll add it.

## Behaviour changes worth a release note

1. **Out-of-order `ASSEMBLE` clauses now error.** They used to detach
   silently, so a statement that "worked" may now be refused — which is the
   point: `… FORMAT markdown BUDGET 900` was running at the 4000-token
   default.
2. **`ORDER BY` returns different (correct) results** on corpora larger than
   `default_limit`.
3. **OpenRouter needs `--features openrouter`.** Default features shrink.
4. **`grants_auto_apply` no longer accepts the `query` class** — a definition
   rewrite always needs a human `APPROVE` + `APPLY`.

New CAL syntax (`LITERAL`, `PIN`) is ahead of the OMS spec, recorded as a
named decision in `ARCHITECTURE.md` §10 — the same posture `DEFINE QUERY`
already has. Upstreaming it is a separate OMS issue.
