### PR TITLE
Give the code-review job the tools its plugin actually needs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write, not read: the /code-review plugin posts its verdict with
+      # `gh pr comment`, which is an issue-comment write.
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -38,8 +40,13 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # `--allowedTools` REPLACES the session allowlist — it does not add to
+          # a default set. Restricted to the inline-comment MCP tool alone, the
+          # plugin could not run at all: it fetches the PR with `gh pr diff` /
+          # `gh pr view`, fans out to Haiku/Sonnet sub-agents (Task), and posts
+          # its verdict with `gh pr comment`. Every one of those was denied.
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment,Task,Read,Grep,Glob,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(gh api:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git rev-parse:*)"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The Claude Code Review job has never posted a review on any PR.

## Root cause

`--allowedTools` **replaces** the session allowlist rather than adding to a default set. Restricting it to `mcp__github_inline_comment__create_inline_comment` alone left the `/code-review` plugin unable to do anything — it fetches the PR with `gh pr diff` / `gh pr view`, fans out to Haiku/Sonnet sub-agents (`Task`), and posts its verdict with **`gh pr comment`**, not the inline-comment tool.

Evidence from PR #54:

| run | duration | turns | permission denials | comments posted |
|---|---|---|---|---|
| `32256527722` | 19s | 5 | 1 | 0 |
| same, re-run with debug | 155s | 11 | **26** | 0 |

Both ended with `No buffered inline comments`, because the plugin never buffers any — it is not the tool it uses.

## Changes

- Widened `--allowedTools` to the tools the plugin's own command frontmatter declares (`Bash(gh pr view:*)`, `Bash(gh pr diff:*)`, `Bash(gh pr comment:*)`, …) plus `Task`/`Read`/`Grep`/`Glob` and the `git` reads its history-context agent needs.
- Dropped `--comment <repo>/pull/N`. That flag belongs to Claude Code's **built-in** `/code-review` skill, not to this marketplace plugin, so it was being appended to the prompt as prose.
- Raised `pull-requests` and `issues` to `write` — `gh pr comment` is an issue-comment write.

## Why this is a separate PR

The action refuses to run when a PR modifies the review workflow itself:

> Skipping action due to workflow validation: Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch.

That is an anti-tampering guard and it is correct. It also means the fix cannot be validated from a feature branch — it takes effect only once it is on `main`. Merging this and then re-running the job on an open PR is the test.