### PR TITLE
Fix the egress broker's early-refusal reset race, and the release dry-run ordering

### DIFF
--- a/.claude/skills/areev-release/SKILL.md
+++ b/.claude/skills/areev-release/SKILL.md
@@ -16,10 +16,6 @@ must publish bottom-up.
   this too, as the `versions` job).
 - `python3 scripts/repo_stats.py --check` — the quality figures in README.md
   still match the tree; regenerate and commit if not.
-- `cargo publish --workspace --dry-run` — catches the failures that actually
-  happen (a bumped crate whose internal dependency requirement still permits
-  the old version, a missing `include`) BEFORE anything is tagged. This is
-  what makes the publish order below safe to parallelise.
 - `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean.
 - `cargo deny check` passes (advisories, licenses, sources, bans).
 - Fuzz smoke: `cargo +nightly fuzz build`.
@@ -58,7 +54,33 @@ must publish bottom-up.
   ```
 - Move the `[Unreleased]` section of `CHANGELOG.md` under a new dated version
   heading; add a fresh empty `[Unreleased]`.
-- Commit: `Release vX.Y.Z`. Tag: `git tag vX.Y.Z`.
+- Commit: `Release vX.Y.Z`. **Do not tag here** — step 3 tags the merge
+  commit on `main`, not this branch tip, and tagging twice on two different
+  commits is how a release ships from the wrong SHA.
+
+**Dry-run now, on this commit — not in pre-flight, before the bump.**
+`cargo publish --workspace --dry-run` verifies each crate's package by
+resolving its dependencies against a local staging registry keyed on
+`(name, version)`. Before this commit, every crate's manifest `version` still
+matches what's already on crates.io, so cargo treats local content as
+identical to the published copy and links the **stale registry version**
+instead of your source — even though the two now disagree. 1.3.1 hit exactly
+this: `areev-trigger`'s Cargo.toml still said `1.3.0` when a pre-bump dry-run
+ran, so `areev-cli`'s verification build linked the OLD `areev-trigger` and
+failed with `unknown field` errors on code that had, in fact, already shipped
+— a false failure pointing at nothing wrong. The check only means anything
+once the version genuinely diverges from the registry, which starts here:
+
+```bash
+cargo publish --workspace --dry-run
+```
+
+This is what actually catches the failures that happen for real (a bumped
+crate whose internal dependency requirement still permits the old version, a
+missing `include`) BEFORE anything is tagged or pushed — the whole reason to
+run it at all — and what makes the publish order in step 4 safe to
+parallelise. `cargo publish` refuses a dirty tree, which is exactly why this
+runs after the commit above rather than before it.
 
 ## 3. Tag and publish the GitHub Release FIRST
 
@@ -109,16 +131,18 @@ Cargo resolves the dependency order itself — the hand-maintained tier list
 this runbook used to carry went stale twice and failed mid-publish:
 
 ```bash
-cargo publish --workspace          # --dry-run already run in pre-flight
+cargo publish --workspace          # --dry-run already run in step 2, on this exact commit
 ```
 
-**Bump the internal dependency requirements too.** Crates declare each other
-as `version = "1.0.0"`; on a minor/major release that requirement still
-permits the OLD version, so cargo can resolve new-crate + old-dep from a
-lockfile and fail to compile while the manifest claims the pair is supported.
-1.1.0 hit exactly this (`areev-cal` used `GrainType::Recommendation`, absent
-from `areev-core` 1.0.5). `cargo publish --workspace --dry-run` in pre-flight
-is what catches it now.
+**Bump the internal dependency requirements too — on a minor/major only.**
+Crates declare each other as `version = "1.0.0"`; on a minor/major release
+that requirement still permits the OLD version, so cargo can resolve
+new-crate + old-dep from a lockfile and fail to compile while the manifest
+claims the pair is supported. 1.1.0 hit exactly this (`areev-cal` used
+`GrainType::Recommendation`, absent from `areev-core` 1.0.5). A patch release
+doesn't have this problem — `^1.3.0` already permits `1.3.1` — which is why
+1.3.1 needed no change here; the dry-run in step 2 is what tells you which
+case you're in.
 
 If `--workspace` is unavailable or a leg fails partway, fall back to
 publishing bottom-up, recomputing the order from the manifests rather than
@@ -182,10 +206,9 @@ EOF
 - **The ordering trade-off, stated plainly**: cutting the Release before
   crates.io means a crates.io failure lands *after* npm and PyPI have already
   shipped. That is the right trade because the failure modes are not
-  symmetric — `cargo publish --workspace --dry-run` in pre-flight catches
-  essentially every real crates.io failure while nothing tags yet, whereas the
-  cost of the old ordering was paid on every single release. If crates.io does
-  fail, fix forward: the registries are independent and a patch release is
-  cheap.
+  symmetric — the dry-run in step 2 catches essentially every real crates.io
+  failure while nothing is tagged yet, whereas the cost of the old ordering
+  was paid on every single release. If crates.io does fail, fix forward: the
+  registries are independent and a patch release is cheap.
 - The three release workflows carry `concurrency` groups keyed on the tag, so
   a re-run cannot race a manual dispatch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A refused egress-broker call could reset the caller's own connection
+  instead of delivering its 401/403 JSON body.** `serve_one` read the
+  request's token, decided to refuse it (unknown token, or a caller with no
+  grant), wrote the response and dropped the connection — all without
+  reading the request body the caller had already started sending. Closing a
+  socket with unread data queued sends an RST rather than a clean FIN, so
+  under enough scheduling delay the caller's own `write` could fail with a
+  raw `ConnectionReset` and never see the refusal at all — a security-
+  relevant "why was I denied" path degrading to an opaque I/O error under
+  load. Found as a one-off `ConnectionReset` in the test suite during the
+  1.3.1 release, confirmed as a real, reproducible defect (not test
+  flakiness) by isolating it: 5/60 failures on the pre-fix code under
+  verified CPU load, 0/60 after. The two refusal paths whose bodies are
+  always small and legitimate (bad token, no grant) now drain the request
+  body before responding; the "body too large" refusal deliberately does
+  not, since draining an oversized claimed body is the resource-exhaustion
+  risk that refusal exists to avoid. A regression test forces the same race
+  deterministically, without needing artificial system load, by making the
+  body large enough to force real TCP backpressure rather than fit entirely
+  inside OS socket buffers — verified to fail on the very first run against
+  the pre-fix code.
+
 ## [1.3.1] — 2026-08-20
 
 ### Added

--- a/crates/areev-run/src/broker.rs
+++ b/crates/areev-run/src/broker.rs
@@ -376,6 +376,11 @@ fn serve_one(
     let caller = match presented.and_then(|t| by_token.get(&t).cloned()) {
         Some(c) => c,
         None => {
+            // The caller may still be mid-write on a body we are about to
+            // refuse to read for its own sake; drain it so closing the
+            // connection sends a clean FIN, not an RST that could clobber
+            // their view of this very response.
+            drain_body(&mut reader, content_length);
             return respond(
                 &mut stream,
                 401,
@@ -388,6 +393,7 @@ fn serve_one(
         }
     };
     let Some(grant) = grants.for_caller(&caller) else {
+        drain_body(&mut reader, content_length);
         return respond(
             &mut stream,
             403,
@@ -399,6 +405,11 @@ fn serve_one(
         );
     };
     if content_length > MAX_BODY {
+        // Deliberately NOT drained: the whole point of this refusal is that
+        // the caller claims a body large enough that reading it is the
+        // resource-exhaustion risk. An abrupt reset here is the acceptable
+        // side of that trade, unlike the two refusals above where the body is
+        // always small and legitimate.
         return respond(&mut stream, 413, r#"{"error":"body too large"}"#);
     }
     let mut body = vec![0u8; content_length];
@@ -564,6 +575,23 @@ fn serve_one(
     }
 }
 
+/// Best-effort: read and discard up to `content_length` bytes (capped at
+/// [`MAX_BODY`]) still pending on the socket.
+///
+/// A refusal that writes its response and drops the connection WITHOUT
+/// reading a body the caller already started sending leaves those bytes
+/// queued in the kernel receive buffer. Closing a socket over unread data
+/// sends an RST instead of a clean FIN — which can surface to the caller as a
+/// raw `ConnectionReset` on their own write, burying the 401/403 JSON body
+/// under an opaque I/O error instead of a readable refusal. Draining first
+/// turns that into an ordinary, parseable response every time. The cap
+/// matters even here: a caller presenting a bad token gets no free pass to
+/// make us read an unbounded body.
+fn drain_body(reader: &mut BufReader<TcpStream>, content_length: usize) {
+    let mut discard = vec![0u8; content_length.min(MAX_BODY)];
+    let _ = reader.read_exact(&mut discard);
+}
+
 fn respond(stream: &mut TcpStream, status: u16, body: &str) -> std::io::Result<()> {
     let head = format!(
         "HTTP/1.1 {status} \r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -716,6 +744,34 @@ mod tests {
         let b = Broker::start(policy(&[]), BTreeMap::new(), grants(&[]), "TRG-E009").unwrap();
         let (status, _) =
             call_with_token(&b, "0".repeat(48).as_str(), serde_json::json!({ "url": "https://x/" }));
+        assert_eq!(status, 401);
+    }
+
+    /// A refusal must not corrupt the caller's own write with an RST (found
+    /// while releasing 1.3.1: a `ConnectionReset` here once, under heavy
+    /// concurrent-build load).
+    ///
+    /// The tiny bodies elsewhere in this file fit entirely inside the OS
+    /// socket buffers, so `write_all` never blocks and completes before the
+    /// server has a chance to close — the race that causes an RST only shows
+    /// up under enough scheduling delay to matter, which is exactly why it
+    /// took heavy system load to surface and why a normal CI run would not
+    /// reliably catch a regression here. A body large enough to force real
+    /// TCP backpressure reproduces the same race on every run, load or not:
+    /// with the server closing before draining, this `write_all` fails with
+    /// `ConnectionReset`; with it draining first, the write always completes
+    /// and the 401 is always readable. Verified: this test fails
+    /// deterministically (no stress needed) against the code before the
+    /// `drain_body` fix, on the very first run.
+    #[test]
+    fn a_refusal_drains_the_body_so_a_large_write_never_resets() {
+        let b = Broker::start(policy(&[]), BTreeMap::new(), grants(&[]), "TRG-E009").unwrap();
+        // Comfortably under MAX_BODY (drain_body covers the whole thing) and
+        // comfortably over typical default OS socket buffer sizes, so the
+        // write backpressures for real rather than completing instantly.
+        let pad = "a".repeat(900_000);
+        let (status, _) =
+            call_with_token(&b, "0".repeat(48).as_str(), serde_json::json!({ "pad": pad }));
         assert_eq!(status, 401);
     }
 


### PR DESCRIPTION
Two follow-ups from the 1.3.1 release, both caught reviewing that release rather than before it shipped — the user asked directly why, so both are fixed here with a full explanation of what was missed and why.

## The broker bug (real, not test flakiness)

`serve_one` refused a call with an unknown token (401) or no grant (403) by writing the response and dropping the connection — **without reading the request body the caller had already started sending.** Closing a socket with unread data queued sends an RST instead of a clean FIN, so under scheduling delay the caller's own `write` could fail with a raw `ConnectionReset` and never see the refusal body at all. That's a security-relevant "why was I denied" path degrading to an opaque I/O error under load, for a component the docs describe as a real production credential broker, not test-only scaffolding.

This first surfaced as a one-off flaky test during 1.3.1's release, and was initially treated as noise: isolated, confirmed a clean re-run, shipped. It isn't noise — proven with a controlled before/after:

| | Failures / 60 runs, verified CPU stress |
|---|---|
| Before | **5 / 60** |
| After | **0 / 60** |

Fix: the two refusal paths whose bodies are always small and legitimate (bad token, no grant) drain the body before responding. The "body too large" refusal deliberately stays undrained — reading an oversized *claimed* body is the resource-exhaustion risk that refusal exists to avoid.

**The regression test doesn't need stress at all.** Every existing test body is a few bytes — small enough to fit entirely inside OS socket buffers, so `write_all` never blocks and the race needs real scheduling delay to matter, which is exactly why it took heavy concurrent-build load to surface in the first place and why a normal CI run wouldn't reliably catch a regression here. A body large enough to force actual TCP backpressure reproduces the identical race **deterministically** — verified to fail on the very first run against the pre-fix code, zero artificial load:

```
thread '...' panicked: Os { code: 54, kind: ConnectionReset, ... }
```

## The release runbook

`cargo publish --workspace --dry-run` sat in "pre-flight," before the version bump. It resolves each crate's dependencies against a local staging registry keyed on `(name, version)` — before the bump, a changed crate's manifest version still matches what's on crates.io, so cargo treats local content as identical to the published copy and silently links the **stale registry version**. 1.3.1 hit this directly: `areev-trigger`'s Cargo.toml still said `1.3.0` when the pre-flight dry-run ran, so `areev-cli`'s verification build linked the old `areev-trigger` and failed with `unknown field` errors on code that had already shipped — a false failure pointing at nothing wrong.

Moved the dry-run to right after the version-bump commit, before anything is tagged or pushed — both where it needs to sit to mean anything, and (by necessity, mid-release) where it was actually run to ship 1.3.1. Also fixed an inconsistency the move surfaced: step 2 told you to tag the branch-tip commit, step 3 correctly tags the merge commit on `main` — two different SHAs. Removed the premature tag instruction.

## Why these weren't caught before shipping 1.3.1

Asked directly, so stated plainly:

- **Runbook gap**: followed the doc's literal step order without reasoning forward from what I already knew (cargo resolves by version-equality, 1.3.0 was already published) — found it only by hitting the error, not by anticipating it.
- **Flaky test**: diagnosed correctly in the moment for *shipping purposes* (isolated it, confirmed it wasn't a regression from my own diff, didn't paper over a real failure) — but stopped at "not mine, not a regression" instead of asking whether the test's own fragility indicated a real defect underneath. It did.

## Gate

`cargo test --workspace` exit 0, **2,177 passed**, 119 targets. `cargo clippy --workspace --all-targets -- -D warnings` clean. `areev-run`'s full suite green independently.

## Scope note

No version bump / no new release in this PR — `CHANGELOG.md` entry sits under `[Unreleased]`. This is a fix to already-released code (the broker bug predates 1.3.0's egress-broker feature); whether it warrants a 1.3.2 patch is a separate call.
