### PR TITLE
Give a firing the same run budgets `run start` takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A trigger-started run now carries the budgets it was given.**
+  `run start` has taken `--max-tokens`/`--max-usd`/`--max-wall-ms`/`--ask-ttl`
+  on every surface since the runtime shipped; the trigger path took none of
+  them and built `RunOptions::default()`, in the CLI and both bindings alike.
+  Moving a workflow behind a trigger therefore dropped every ceiling silently —
+  on the one path that fires unattended, where an unbounded run has nobody
+  watching it and an ask with no TTL parks forever. `trigger run` and
+  `trigger deliver` now take the same budgets as `run start`, optional and
+  adding no implicit limit when omitted. Node refuses a negative budget rather
+  than reading it as unlimited, as it already did for `runStart`.
+- **`docs/triggers.md` now states what a run started by a trigger receives.**
+  The connector contract was documented; the run input was not. A trigger wraps
+  the item as `{trigger, connector, scope, item}` while `run start` passes its
+  input through unchanged, so one plan started both ways sees two shapes — and
+  a tool reading a top-level key dies on the trigger path only, while the pass
+  still reports `runs_started: 1` with no errors, because the firing did
+  succeed and the run is what failed.
+
 ## [1.4.0] — 2026-08-21
 
 ### Added

--- a/crates/areev-cli/src/main.rs
+++ b/crates/areev-cli/src/main.rs
@@ -96,6 +96,7 @@ COMMANDS:
                                       `composite` one
   trigger  run [--id T] [--connector-cmd CMD] [--tool-cmd CMD] [--dry-run]
            [--lease SECS] [--max-items N] [--credential NAME=ENV_VAR]
+           [--max-tokens N] [--max-usd USD] [--max-wall-ms MS] [--ask-ttl SECS]
                                       evaluate once and exit — the cadence is
                                       data in the memory, so the heartbeat can
                                       be coarse. Safe to invoke concurrently.
@@ -103,14 +104,17 @@ COMMANDS:
                                       executing; --dry-run touches nothing.
                                       --credential names an env var whose value
                                       the egress broker attaches on the way out,
-                                      so the connector never holds the token
+                                      so the connector never holds the token.
+                                      The budget flags are the ones `run start`
+                                      takes, and bound the runs a firing starts
   trigger  render --target cron|launchd|systemd|k8s-cronjob
                                       emit heartbeat config for infrastructure
                                       you already run; never creates anything
-  trigger  deliver --id T [< payload.json]
+  trigger  deliver --id T [< payload.json] [--tool-cmd CMD] [budget flags]
                                       hand a webhook/manual payload to Areev.
                                       The host owns the listener — Areev never
-                                      opens a port. Idempotent on the dedup key
+                                      opens a port. Idempotent on the dedup key.
+                                      Takes the same budget flags as `run`
   trigger  list | show <T> | status   what is declared, and what has actually
                                       fired (a trigger that never fired is
                                       reported, not silent)

--- a/crates/areev-cli/src/trigger_cli.rs
+++ b/crates/areev-cli/src/trigger_cli.rs
@@ -84,6 +84,26 @@ impl RunStarter for RunnerStarter {
     }
 }
 
+/// The run ceilings a firing passes on, from the same flags `run start` takes.
+fn run_budgets(flags: &HashMap<String, String>) -> areev_run::RunOptions {
+    areev_run::RunOptions {
+        budgets: areev_run::BudgetsSpec {
+            max_supersteps: flag(flags, "max-supersteps").and_then(|v| v.parse().ok()),
+            max_tokens: flag(flags, "max-tokens").and_then(|v| v.parse().ok()),
+            max_usd_micros: flag(flags, "max-usd")
+                .and_then(|v| v.parse::<f64>().ok())
+                .map(|usd| (usd * 1_000_000.0) as u64),
+            max_wall_ms: flag(flags, "max-wall-ms").and_then(|v| v.parse().ok()),
+            max_storage_bytes: flag(flags, "max-storage").and_then(|v| v.parse().ok()),
+        },
+        ask_ttl_sec: flag(flags, "ask-ttl").and_then(|v| v.parse().ok()),
+        workers: flag(flags, "workers").and_then(|v| v.parse().ok()).unwrap_or(4),
+        on_dangling: Default::default(),
+        llm_max_tokens: flag(flags, "llm-max-tokens").and_then(|v| v.parse().ok()),
+        inject_crash: None,
+    }
+}
+
 pub fn run_trigger(
     m: Areev,
     ns: &str,
@@ -133,8 +153,7 @@ fn evaluator(facade: Arc<AreevFacade>, ns: &str, flags: &HashMap<String, String>
             ns: ns.to_string(),
             principal: flag(flags, "as").unwrap_or_else(|| "user:local".into()),
         };
-        Arc::new(RunnerStarter { runner, opts: areev_run::RunOptions::default() })
-            as Arc<dyn RunStarter>
+        Arc::new(RunnerStarter { runner, opts: run_budgets(flags) }) as Arc<dyn RunStarter>
     });
 
     // Credentials are named on the command line and READ here, so a value
@@ -582,4 +601,38 @@ fn set_paused(
         println!("{verb}d trigger {}", short(&target, 12));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod budget_tests {
+    use super::*;
+
+    fn flags(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+    }
+
+    #[test]
+    fn budget_flags_reach_the_run_a_firing_starts() {
+        // `trigger run` built RunOptions::default(), so moving a workflow
+        // behind a trigger silently dropped every ceiling.
+        let o = run_budgets(&flags(&[
+            ("max-tokens", "5000"),
+            ("max-usd", "0.25"),
+            ("max-wall-ms", "60000"),
+            ("ask-ttl", "3600"),
+        ]));
+        assert_eq!(o.budgets.max_tokens, Some(5000));
+        assert_eq!(o.budgets.max_usd_micros, Some(250_000), "--max-usd is dollars, stored as micros");
+        assert_eq!(o.budgets.max_wall_ms, Some(60_000));
+        assert_eq!(o.ask_ttl_sec, Some(3600));
+    }
+
+    #[test]
+    fn no_budget_flags_means_no_ceiling_not_a_surprise_one() {
+        let o = run_budgets(&flags(&[]));
+        assert_eq!(o.budgets.max_tokens, None);
+        assert_eq!(o.budgets.max_usd_micros, None);
+        assert_eq!(o.ask_ttl_sec, None);
+        assert_eq!(o.workers, 4, "the documented default");
+    }
 }

--- a/crates/areev-js/__test__/smoke.mjs
+++ b/crates/areev-js/__test__/smoke.mjs
@@ -1119,6 +1119,44 @@ test('triggerRun evaluates, and dryRun touches nothing', async () => {
   m.close()
 })
 
+test('a trigger-started run carries the budgets it was given', async () => {
+  // The bridge built RunOptions::default(), so every ceiling a host set was
+  // dropped on the one path that fires unattended.
+  const dir = mkdtempSync(join(tmpdir(), 'areev-trig-budget-'))
+  const m = new Areev(join(dir, 'b.db'), 'ops')
+
+  // An unbound node is abstract and refuses at load (RUN-E006), so bind one.
+  const tool = await m.add('tool', JSON.stringify({ tool_name: 'noop', kind: 'definition' }))
+  const wf = await m.add('workflow', JSON.stringify({
+    name: 'budgeted', nodes: ['only'], edges: [], bindings: { only: tool },
+  }))
+  const trig = await m.triggerAdd(
+    JSON.stringify({ kind: 'webhook', workflow: wf, connector: 'c', dedup_key: ['/id'] }),
+    'budgets must survive the trigger path',
+  )
+
+  const toolCmd = `${process.execPath} -e "process.stdout.write('{}')"`
+  const report = JSON.parse(await m.triggerDeliver(
+    trig, JSON.stringify({ id: 'item-1' }), null, toolCmd, null, null, null, null,
+    5000, 250000, 60000, 3600,
+  ))
+  assert.equal(report.runs_started, 1, JSON.stringify(report))
+
+  const runId = JSON.parse(await m.runList(10))[0]
+  const budgets = JSON.parse(await m.runInspect(runId)).budgets
+  assert.equal(budgets.max_tokens, 5000)
+  assert.equal(budgets.max_usd_micros, 250000)
+  assert.equal(budgets.max_wall_ms, 60000)
+
+  // A negative budget is a caller bug, not "unlimited".
+  await assert.rejects(
+    () => m.triggerDeliver(trig, JSON.stringify({ id: 'i2' }), null, toolCmd,
+      null, null, null, null, -1),
+    /maxTokens must be >= 0/,
+  )
+  m.close()
+})
+
 test('triggerRender emits heartbeat config and creates nothing', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'areev-trig-render-'))
   const m = new Areev(join(dir, 'r.db'), 'ops')

--- a/crates/areev-js/index.d.ts
+++ b/crates/areev-js/index.d.ts
@@ -533,12 +533,12 @@ export declare class Areev {
    * never the secret. An unset variable is refused here rather than leaving
    * the connector to make an unauthenticated call.
    */
-  triggerRun(only?: string | undefined | null, dryRun?: boolean | undefined | null, leaseSecs?: number | undefined | null, maxItems?: number | undefined | null, connectorCmd?: string | undefined | null, toolCmd?: string | undefined | null, credentialsJson?: string | undefined | null, node?: string | undefined | null, model?: string | undefined | null, baseUrl?: string | undefined | null, keyEnv?: string | undefined | null): Promise<string>
+  triggerRun(only?: string | undefined | null, dryRun?: boolean | undefined | null, leaseSecs?: number | undefined | null, maxItems?: number | undefined | null, connectorCmd?: string | undefined | null, toolCmd?: string | undefined | null, credentialsJson?: string | undefined | null, node?: string | undefined | null, model?: string | undefined | null, baseUrl?: string | undefined | null, keyEnv?: string | undefined | null, maxTokens?: number | undefined | null, maxUsdMicros?: number | undefined | null, maxWallMs?: number | undefined | null, askTtlSec?: number | undefined | null, llmMaxTokens?: number | undefined | null): Promise<string>
   /**
    * Hand a webhook or manual payload to a trigger. Areev never opens a
    * port: the host owns the listener and hands the payload over.
    */
-  triggerDeliver(trigger: string, payloadJson: string, connectorCmd?: string | undefined | null, toolCmd?: string | undefined | null, credentialsJson?: string | undefined | null, model?: string | undefined | null, baseUrl?: string | undefined | null, keyEnv?: string | undefined | null): Promise<string>
+  triggerDeliver(trigger: string, payloadJson: string, connectorCmd?: string | undefined | null, toolCmd?: string | undefined | null, credentialsJson?: string | undefined | null, model?: string | undefined | null, baseUrl?: string | undefined | null, keyEnv?: string | undefined | null, maxTokens?: number | undefined | null, maxUsdMicros?: number | undefined | null, maxWallMs?: number | undefined | null, askTtlSec?: number | undefined | null, llmMaxTokens?: number | undefined | null): Promise<string>
   /** Stop a trigger firing without deleting it. Mandatory reason. */
   triggerPause(trigger: string, because: string): Promise<string>
   /** Let a paused trigger fire again. Mandatory reason. */

--- a/crates/areev-js/src/lib.rs
+++ b/crates/areev-js/src/lib.rs
@@ -198,6 +198,7 @@ fn js_read_only_evaluator(
 /// deliberate `None`s: without a connector a due polling trigger fails loudly
 /// (`TRG-E003`) rather than looking healthy while doing nothing, and without a
 /// `toolCmd` the pass ingests items and records firings but starts nothing.
+#[allow(clippy::too_many_arguments)]
 fn js_evaluator(
     facade: std::sync::Arc<AreevFacade>,
     ns: String,
@@ -206,6 +207,7 @@ fn js_evaluator(
     tool_cmd: Option<String>,
     credentials_json: Option<String>,
     llm: Option<std::sync::Arc<dyn areev_llm::ToolCallLlm>>,
+    opts: areev_run::RunOptions,
 ) -> napi::Result<areev_trigger::Evaluator> {
     // A connector IS a tool — JSON in, JSON out, one process per invocation —
     // so there is one subprocess contract to learn and connectors inherit its
@@ -227,7 +229,7 @@ fn js_evaluator(
                 Some(cmd),
                 llm,
             ),
-            opts: areev_run::RunOptions::default(),
+            opts,
         }) as std::sync::Arc<dyn areev_trigger::RunStarter>
     });
 
@@ -2792,6 +2794,11 @@ impl Areev {
         model: Option<String>,
         base_url: Option<String>,
         key_env: Option<String>,
+        max_tokens: Option<i64>,
+        max_usd_micros: Option<i64>,
+        max_wall_ms: Option<i64>,
+        ask_ttl_sec: Option<i64>,
+        llm_max_tokens: Option<u32>,
     ) -> napi::bindgen_prelude::AsyncTask<StringJob> {
         let slot = self.facade.clone();
         let ns = self.ns.clone();
@@ -2807,6 +2814,8 @@ impl Areev {
                 tool_cmd,
                 credentials_json,
                 llm,
+                js_run_options_full(max_tokens, max_usd_micros, max_wall_ms,
+                                    ask_ttl_sec, llm_max_tokens)?,
             )?;
             let mut opts = areev_trigger::EvalOptions {
                 dry_run: dry_run.unwrap_or(false),
@@ -2841,6 +2850,11 @@ impl Areev {
         model: Option<String>,
         base_url: Option<String>,
         key_env: Option<String>,
+        max_tokens: Option<i64>,
+        max_usd_micros: Option<i64>,
+        max_wall_ms: Option<i64>,
+        ask_ttl_sec: Option<i64>,
+        llm_max_tokens: Option<u32>,
     ) -> napi::bindgen_prelude::AsyncTask<StringJob> {
         let slot = self.facade.clone();
         let ns = self.ns.clone();
@@ -2858,6 +2872,8 @@ impl Areev {
                 tool_cmd,
                 credentials_json,
                 llm,
+                js_run_options_full(max_tokens, max_usd_micros, max_wall_ms,
+                                    ask_ttl_sec, llm_max_tokens)?,
             )?;
             let report = ev.deliver(&trigger, payload).map_err(err)?;
             serde_json::to_string(&report).map_err(err)

--- a/crates/areev-py/src/lib.rs
+++ b/crates/areev-py/src/lib.rs
@@ -2341,9 +2341,13 @@ impl Areev {
     /// to the value itself: the connector is handed the broker's address and
     /// never the secret. An unset variable is refused here rather than
     /// leaving the connector to make an unauthenticated call.
+    ///
+    /// Budgets bound the runs a firing starts, exactly as on `run_start`.
     #[pyo3(signature = (only = None, dry_run = false, lease_secs = None, max_items = None,
                         connector_cmd = None, tool_cmd = None, credentials_json = None,
-                        node = None, model = None, base_url = None, key_env = None))]
+                        node = None, model = None, base_url = None, key_env = None,
+                        max_tokens = None, max_usd_micros = None, max_wall_ms = None,
+                        ask_ttl_sec = None, llm_max_tokens = None))]
     #[allow(clippy::too_many_arguments)]
     fn trigger_run(
         &self,
@@ -2359,8 +2363,16 @@ impl Areev {
         model: Option<String>,
         base_url: Option<String>,
         key_env: Option<String>,
+        max_tokens: Option<u64>,
+        max_usd_micros: Option<u64>,
+        max_wall_ms: Option<u64>,
+        ask_ttl_sec: Option<i64>,
+        llm_max_tokens: Option<u32>,
     ) -> PyResult<String> {
-        let ev = self.evaluator(connector_cmd, tool_cmd, credentials_json, model, base_url, key_env)?;
+        let ev = self.evaluator(
+            connector_cmd, tool_cmd, credentials_json, model, base_url, key_env,
+            run_options(max_tokens, max_usd_micros, max_wall_ms, ask_ttl_sec, llm_max_tokens),
+        )?;
         let mut opts = areev_trigger::EvalOptions { dry_run, only, ..Default::default() };
         if let Some(secs) = lease_secs {
             opts.lease = std::time::Duration::from_secs(secs);
@@ -2377,8 +2389,12 @@ impl Areev {
 
     /// Hand a webhook or manual payload to a trigger. Areev never opens a
     /// port: the host owns the listener and hands the payload over.
+    ///
+    /// Takes the same budgets as `trigger_run`: a delivery starts a real run.
     #[pyo3(signature = (trigger, payload_json, connector_cmd = None, tool_cmd = None,
-                        credentials_json = None, model = None, base_url = None, key_env = None))]
+                        credentials_json = None, model = None, base_url = None, key_env = None,
+                        max_tokens = None, max_usd_micros = None, max_wall_ms = None,
+                        ask_ttl_sec = None, llm_max_tokens = None))]
     #[allow(clippy::too_many_arguments)]
     fn trigger_deliver(
         &self,
@@ -2391,10 +2407,18 @@ impl Areev {
         model: Option<String>,
         base_url: Option<String>,
         key_env: Option<String>,
+        max_tokens: Option<u64>,
+        max_usd_micros: Option<u64>,
+        max_wall_ms: Option<u64>,
+        ask_ttl_sec: Option<i64>,
+        llm_max_tokens: Option<u32>,
     ) -> PyResult<String> {
         let payload: serde_json::Value = serde_json::from_str(&payload_json)
             .map_err(|e| err(format!("payload_json is not JSON: {e}")))?;
-        let ev = self.evaluator(connector_cmd, tool_cmd, credentials_json, model, base_url, key_env)?;
+        let ev = self.evaluator(
+            connector_cmd, tool_cmd, credentials_json, model, base_url, key_env,
+            run_options(max_tokens, max_usd_micros, max_wall_ms, ask_ttl_sec, llm_max_tokens),
+        )?;
         let report = py.detach(|| ev.deliver(&trigger, payload)).map_err(err)?;
         serde_json::to_string(&report).map_err(err)
     }
@@ -2494,6 +2518,7 @@ impl Areev {
 
     /// The acting evaluator. Mirrors the CLI's construction, including the two
     /// deliberate `None`s documented on [`Areev::trigger_run`].
+    #[allow(clippy::too_many_arguments)]
     fn evaluator(
         &self,
         connector_cmd: Option<String>,
@@ -2502,6 +2527,7 @@ impl Areev {
         model: Option<String>,
         base_url: Option<String>,
         key_env: Option<String>,
+        opts: areev_run::RunOptions,
     ) -> PyResult<areev_trigger::Evaluator> {
         // A connector IS a tool — JSON in, JSON out, one process per
         // invocation — so there is one subprocess contract to learn and
@@ -2519,7 +2545,7 @@ impl Areev {
             tool_cmd.map(|cmd| {
                 std::sync::Arc::new(RunnerStarter {
                     runner: self.runner(Some(cmd), llm),
-                    opts: areev_run::RunOptions::default(),
+                    opts,
                 }) as std::sync::Arc<dyn areev_trigger::RunStarter>
             });
 

--- a/crates/areev-py/tests/test_triggers.py
+++ b/crates/areev-py/tests/test_triggers.py
@@ -263,3 +263,52 @@ def test_trigger_status_reports_unusable_for_declarations_it_did_not_write(tmp_p
     # …and a healthy one carries no `unusable` key at all.
     assert "unusable" not in rows[0]
     assert rows[0]["due"] is True
+
+
+def test_a_trigger_started_run_carries_the_budgets_it_was_given(tmp_path):
+    """The bridge built `RunOptions::default()`, so every budget a host passed
+    to `run_start` was dropped on the trigger path — the worst place to drop
+    one, since a standing rule fires unattended."""
+    import sys
+
+    m = areev.Areev(str(tmp_path / "b.db"), ns="ops")
+    # An unbound node is abstract and refuses at load (RUN-E006).
+    tool = m.add("tool", json.dumps({"tool_name": "noop", "kind": "definition"}))
+    wf = m.add("workflow", json.dumps({
+        "name": "budgeted", "nodes": ["only"], "edges": [], "bindings": {"only": tool},
+    }))
+    trig = m.trigger_add(json.dumps({
+        "kind": "webhook", "workflow": wf, "connector": "c",
+        "dedup_key": ["/id"]}), "budgets must survive the trigger path")
+
+    tool = f"{sys.executable} -c \"import sys,json;sys.stdout.write(json.dumps({{}}))\""
+    report = json.loads(m.trigger_deliver(
+        trig, json.dumps({"id": "item-1"}), tool_cmd=tool,
+        max_tokens=5000, max_usd_micros=250_000, max_wall_ms=60_000, ask_ttl_sec=3600))
+    assert report["runs_started"] == 1, report
+
+    run_id = json.loads(m.run_list(10))[0]
+    budgets = json.loads(m.run_inspect(run_id))["budgets"]
+    assert budgets["max_tokens"] == 5000, budgets
+    assert budgets["max_usd_micros"] == 250_000, budgets
+    assert budgets["max_wall_ms"] == 60_000, budgets
+
+
+def test_trigger_budgets_default_to_unset_when_not_given(tmp_path):
+    """Optional, and adds no implicit ceiling when omitted."""
+    import sys
+
+    m = areev.Areev(str(tmp_path / "b2.db"), ns="ops")
+    tool = m.add("tool", json.dumps({"tool_name": "noop", "kind": "definition"}))
+    wf = m.add("workflow", json.dumps({
+        "name": "unbudgeted", "nodes": ["only"], "edges": [], "bindings": {"only": tool},
+    }))
+    trig = m.trigger_add(json.dumps({
+        "kind": "webhook", "workflow": wf, "connector": "c",
+        "dedup_key": ["/id"]}), "no budgets given")
+    tool = f"{sys.executable} -c \"import sys,json;sys.stdout.write(json.dumps({{}}))\""
+    m.trigger_deliver(trig, json.dumps({"id": "i"}), tool_cmd=tool)
+
+    budgets = json.loads(m.run_inspect(json.loads(m.run_list(10))[0]))["budgets"]
+    assert budgets["max_tokens"] is None and budgets["max_usd_micros"] is None
+

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -109,6 +109,43 @@ ceiling, an output cap, and the withholding of any variable named by
   declared interval, and the failure is visible in `trigger status`. A broken
   connector backs off; it never hot-loops.
 
+## What the run receives
+
+A trigger does not pass the item through as the run input. It wraps it, so a
+run can always say what fired it:
+
+```json
+{ "trigger": "<hash>", "connector": "gmail", "scope": "mailbox:…",
+  "item": { … the connector's or delivery's payload … } }
+```
+
+`run start` passes its `--input` through unchanged, so **one plan started both
+ways sees two shapes**. Tools that must work either way should resolve it once:
+
+```python
+payload = payload.get("item", payload)
+```
+
+A tool that reads a top-level key without this dies on the trigger path only,
+is retried per the node's `retries`, and the pass still reports
+`runs_started: 1` with an empty `errors` list — the firing genuinely succeeded;
+the run is what failed.
+
+## Budgets
+
+A firing starts a real run, so it takes the same ceilings `run start` does —
+`max_tokens`, `max_usd_micros`, `max_wall_ms`, `ask_ttl_sec` and
+`llm_max_tokens`, on both `trigger run` and `trigger deliver`. They are
+optional and add no implicit limit when omitted.
+
+```python
+db.trigger_run(tool_cmd="./tools.sh", max_usd_micros=250_000, ask_ttl_sec=3600)
+```
+
+Budgets matter more here than anywhere else: a standing rule fires unattended,
+so an unbounded run has nobody watching it, and an ask with no TTL parks
+forever.
+
 ## Idempotency
 
 The run id is derived from `(trigger, connector, dedup value)`, so the same item


### PR DESCRIPTION
`run start` has accepted `--max-tokens`/`--max-usd`/`--max-wall-ms`/`--ask-ttl` on every surface since the runtime shipped. The trigger path accepted none of them and built `RunOptions::default()` — in the CLI and in both bindings — so moving a workflow behind a trigger dropped every ceiling silently, on the one path that fires unattended. An unbounded run has nobody watching it; an ask with no TTL parks forever.

Found while migrating a first-party agent from a host-side poller to a trigger. Parity review would not have caught it: `trigger run` and `run start` were each internally consistent, and the gap only appears when you move a workflow from one to the other.

## The change

Nothing new is invented. `BudgetsSpec` already carries these fields, and no file under `areev-run`, `areev-run-core` or `areev-core` changes here. Three call sites stop discarding the caller's options, each reusing the helper its own surface already had for `run start` rather than duplicating budget construction.

| Surface | Was | Now |
|---|---|---|
| `areev-cli` — `trigger run` / `trigger deliver` | `RunOptions::default()` | `run_budgets(flags)` |
| `areev-py` — `trigger_run` / `trigger_deliver` | `RunOptions::default()` | `run_options(...)` |
| `areev-js` — `triggerRun` / `triggerDeliver` | `RunOptions::default()` | `js_run_options_full(...)` |

Budgets stay optional and add no implicit limit when omitted. Node refuses a negative budget rather than reading it as unlimited, as it already did for `runStart`.

## Docs

`docs/triggers.md` gains **What the run receives**. The connector contract was documented; the run input was not. A trigger wraps the item as `{trigger, connector, scope, item}` while `run start` passes its input through unchanged, so one plan started both ways sees two shapes. A tool reading a top-level key fails on the trigger path only — and the pass still reports `runs_started: 1` with an empty `errors` list, because the firing did succeed and the run is what failed. That combination is very hard to diagnose without the shape written down.

## Tests

- **`areev-py`** — a delivered run carries the budgets it was given; omitting them leaves them unset. The first of these fails against released 1.4.0 and passes here, which is the check that it is testing the fix rather than the plumbing.
- **`areev-js`** — the same pair, plus a negative budget is refused.
- **`areev-cli`** — unit tests over `run_budgets`, including that `--max-usd` is dollars stored as micros. An end-to-end CLI test is not possible here: the CLI has no verb to author a Workflow grain, which is why no existing CLI test creates one either.

## Gate

| Check | Result |
|---|---|
| `cargo test --workspace` | 2,192 passed, 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `cargo clippy` inside `areev-js` (outside the workspace) | clean — and it caught a `too_many_arguments` the workspace run cannot see |
| `pytest crates/areev-py/tests/` | 108 passed, 5 skipped |
| `node --test` | 60 passed, 0 failed |
| `scripts/check_versions.py` | all sites agree on 1.4.0 |

No version bump; `CHANGELOG.md` entries sit under `[Unreleased]`.