### PR TITLE
Fix the SBOM step that withheld the 1.5.2 release from npm, PyPI and the binaries

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -112,6 +112,12 @@ jobs:
   sbom:
     name: SBOM
     runs-on: ubuntu-latest
+    # A bill of materials is documentation about a build, not the build. It
+    # must never be able to withhold a shipped binary from users — which is
+    # exactly what it did on the 1.5.2 tag, where a wrong flag in this job
+    # left five green platform builds unattached to the release. `publish`
+    # no longer waits on it either; both halves of that lesson matter.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -123,11 +129,15 @@ jobs:
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           [ "$GITHUB_EVENT_NAME" = "release" ] || VERSION="dev"
-          cargo cyclonedx --format json --spec-version 1.5 --locked -p areev
+          # cargo-cyclonedx takes NEITHER `--locked` nor `-p`, and it ignores
+          # `--override-filename`: it writes `<package>.cdx.json` next to each
+          # manifest it describes. `--top-level` is also deliberately absent —
+          # it truncates the document to DIRECT dependencies (17 of 341 here),
+          # which is not a bill of materials.
+          cargo cyclonedx --manifest-path crates/areev-cli/Cargo.toml \
+            --format json --spec-version 1.5
           mkdir -p dist
-          # cargo-cyclonedx writes next to the manifest it described.
-          find . -name '*.cdx.json' -not -path './dist/*' -print \
-            -exec cp {} "dist/areev-${VERSION}-cargo.cdx.json" \;
+          cp crates/areev-cli/areev.cdx.json "dist/areev-${VERSION}-cargo.cdx.json"
           test -s "dist/areev-${VERSION}-cargo.cdx.json"
       - uses: actions/upload-artifact@v4
         with:
@@ -137,6 +147,10 @@ jobs:
 
   publish:
     name: attach to the release
+    # `needs: sbom` for ORDERING only — the job is `continue-on-error`, and a
+    # continue-on-error job that fails still satisfies `needs`. So the SBOM is
+    # attached alongside the binaries when it works, and cannot hold them
+    # hostage when it does not.
     needs: [build, sbom]
     # Only a real release has something to attach to; a manual run stops after
     # build, which makes `workflow_dispatch` a usable dry run.

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -171,35 +171,14 @@ jobs:
       - name: Collect per-platform binaries into npm/ dirs
         run: npx napi artifacts
 
-      # Two SBOMs, because the package has two dependency graphs and only one
-      # of them is visible to npm: `npm sbom` describes the JS tree, while
-      # everything the addon actually links is Cargo's. Publishing only the
-      # npm one would describe a package with almost no dependencies.
-      - name: Generate SBOMs
-        working-directory: ${{ github.workspace }}
-        run: |
-          set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
-          mkdir -p sbom
-          (cd crates/areev-js && npm sbom --sbom-format cyclonedx --omit dev) \
-            > "sbom/areev-${VERSION}-npm.cdx.json"
-          rustup update stable
-          cargo install cargo-cyclonedx --version 0.5.7 --locked
-          # areev-js is NOT a workspace member, so it carries its own lockfile
-          # and has to be described from its own manifest.
-          (cd crates/areev-js && cargo cyclonedx --format json --spec-version 1.5 --locked)
-          find crates/areev-js -name '*.cdx.json' \
-            -exec cp {} "sbom/areev-${VERSION}-node-cargo.cdx.json" \;
-          test -s "sbom/areev-${VERSION}-node-cargo.cdx.json"
+      # Attest before publishing: an artifact on the registry that no
+      # attestation covers is worse than one with none, because the security
+      # model claims every artifact is attested. This one DOES gate the
+      # publish — it is a security claim, not paperwork.
       - name: Attest build provenance for the native addons
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: crates/areev-js/npm/*/*.node
-      - name: Attach the SBOMs to the GitHub Release
-        working-directory: ${{ github.workspace }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" sbom/*.cdx.json --clobber --repo "$GITHUB_REPOSITORY"
       - name: Publish platform packages + main to npm
         # We do NOT use `napi prepublish` here: it publishes every platform
         # package in one shot, and we want the main package to go out LAST so
@@ -246,3 +225,36 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Two SBOMs, because the package has two dependency graphs and only one
+      # of them is visible to npm: `npm sbom` describes the JS tree, while
+      # everything the addon actually links is Cargo's. Publishing only the
+      # npm one would describe a package with almost no dependencies.
+      #
+      # AFTER the publish, and `continue-on-error`: a bill of materials is
+      # documentation about a build, not the build, and it must never be able
+      # to withhold a release from users. On the 1.5.2 tag it did exactly that
+      # — a wrong flag here meant npm never got the packages at all.
+      - name: Generate and attach the SBOMs
+        continue-on-error: true
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          mkdir -p sbom
+          (cd crates/areev-js && npm sbom --sbom-format cyclonedx --omit dev) \
+            > "sbom/areev-${VERSION}-npm.cdx.json"
+          rustup update stable
+          cargo install cargo-cyclonedx --version 0.5.7 --locked
+          # areev-js is NOT a workspace member, so it carries its own lockfile
+          # and is described from its own manifest. cargo-cyclonedx takes
+          # NEITHER `--locked` nor `-p`, ignores `--override-filename`, and
+          # writes `<package>.cdx.json` beside the manifest; `--top-level` is
+          # deliberately absent because it truncates to DIRECT dependencies.
+          cargo cyclonedx --manifest-path crates/areev-js/Cargo.toml \
+            --format json --spec-version 1.5
+          cp crates/areev-js/areev-js.cdx.json "sbom/areev-${VERSION}-node-cargo.cdx.json"
+          test -s "sbom/areev-${VERSION}-node-cargo.cdx.json"
+          gh release upload "$GITHUB_REF_NAME" sbom/*.cdx.json --clobber --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -112,31 +112,16 @@ jobs:
           pattern: wheels-*
           merge-multiple: true
           path: dist
-      # The wheel is a compiled Rust extension, so its real dependency graph
-      # is Cargo's, not pip's — `pip-audit` over the wheel would report a
-      # package with no dependencies, which is true and useless. Describe the
-      # graph that actually ships inside the binary.
-      - name: Generate CycloneDX SBOM
-        run: |
-          set -euo pipefail
-          rustup update stable
-          cargo install cargo-cyclonedx --version 0.5.7 --locked
-          cargo cyclonedx --format json --spec-version 1.5 --locked -p areev-py
-          VERSION="${GITHUB_REF_NAME#v}"
-          find . -name '*.cdx.json' -not -path './dist/*' \
-            -exec cp {} "dist/areev-${VERSION}-python.cdx.json" \;
-          test -s "dist/areev-${VERSION}-python.cdx.json"
-      # Attest before publishing, for the same reason release-cli.yml does.
+      # Attest before publishing: an artifact on the registry that no
+      # attestation covers is worse than one with none, because the security
+      # model claims every artifact is attested. This one DOES gate the
+      # publish — it is a security claim, not paperwork.
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: "dist/*.whl"
-      - name: Attach the SBOM to the GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" dist/*.cdx.json --clobber --repo "$GITHUB_REPOSITORY"
-      # `maturin upload dist/*` would now also try to upload the SBOM, which
-      # PyPI rejects. Publish exactly the distributions.
+      # `maturin upload dist/*` would also try to upload the SBOM, which PyPI
+      # rejects. Publish exactly the distributions.
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
@@ -144,3 +129,30 @@ jobs:
         with:
           command: upload
           args: --non-interactive --skip-existing dist/*.whl dist/*.tar.gz
+
+      # The wheel is a compiled Rust extension, so its real dependency graph
+      # is Cargo's, not pip's — `pip-audit` over the wheel would report a
+      # package with no dependencies, which is true and useless. Describe the
+      # graph that actually ships inside the binary.
+      #
+      # AFTER the publish, and `continue-on-error`: a bill of materials is
+      # documentation about a build, not the build, and it must never be able
+      # to withhold a release from users. On the 1.5.2 tag it did exactly that
+      # — a wrong flag here meant PyPI never got the wheels at all.
+      - name: Generate and attach the CycloneDX SBOM
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          rustup update stable
+          cargo install cargo-cyclonedx --version 0.5.7 --locked
+          # Takes NEITHER `--locked` nor `-p`, ignores `--override-filename`,
+          # and writes `<package>.cdx.json` beside the manifest. `--top-level`
+          # is deliberately absent: it truncates to DIRECT dependencies.
+          cargo cyclonedx --manifest-path crates/areev-py/Cargo.toml \
+            --format json --spec-version 1.5
+          VERSION="${GITHUB_REF_NAME#v}"
+          cp crates/areev-py/areev-py.cdx.json "dist/areev-${VERSION}-python.cdx.json"
+          test -s "dist/areev-${VERSION}-python.cdx.json"
+          gh release upload "$GITHUB_REF_NAME" dist/*.cdx.json --clobber --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
`cargo cyclonedx` takes neither `--locked` nor `-p`, so every SBOM step added in #81 died with `error: unexpected argument '--locked' found` on the v1.5.2 tag.

**Blast radius:** `release-cli` built all five platforms green and then skipped `attach to the release`; `release-npm` and `release-pypi` never reached their publish steps, because the SBOM ran *before* them. Only crates.io shipped 1.5.2.

## Two fixes, and the second is the one that matters

**1. The invocation.** cargo-cyclonedx writes `<package>.cdx.json` beside each manifest it describes, ignores `--override-filename`, and takes `--manifest-path` rather than `-p`. `--top-level` is deliberately absent too: it truncates the document to *direct* dependencies — 17 components of 341 for the CLI — which is not a bill of materials.

**2. An SBOM can no longer withhold a release.** It is documentation *about* a build, not the build, and it must never stand between users and a shipped binary. Every SBOM step is now `continue-on-error`, and the two binding pipelines generate theirs **after** publishing. `release-cli`'s `publish` still `needs: sbom` for ordering only — a `continue-on-error` job that fails still satisfies `needs`, so the SBOM rides along when it works and cannot block when it does not.

**Attestations keep gating the publish, on purpose.** They are a security claim about the artifact, not paperwork about it: an artifact on a registry that no attestation covers is worse than one with none, because `docs/security-model.md` claims every artifact is attested.

## Verification

Ran locally against cargo-cyclonedx 0.5.7 — the exact pinned version CI installs:

```
specVersion 1.5 | components 341
subject areev 1.5.2
```

(vs. 17 components with `--top-level`, which is what made it worth removing.)

## After merge

The v1.5.2 tag has to move to this commit and the Release be re-cut, because the workflows run from the tag's checkout. That is safe here: nothing has shipped for 1.5.2 except crates.io, and crate packages do not contain `.github/`, so the published crate contents are byte-identical either way.