### PR TITLE
npm: publish 1.6.0 under @areev/areev — the unscoped name still 403s

### DIFF
--- a/.claude/skills/areev-release/SKILL.md
+++ b/.claude/skills/areev-release/SKILL.md
@@ -201,12 +201,15 @@ EOF
 
 ## Notes
 
-- Registry names: `areev` on crates.io, PyPI, and npm (unscoped, since
-  1.5.1 — npm support granted the similarity-filter exception and released
-  the `areev-win32-x64-msvc` security hold on 2026-08-22). The scoped
-  `@areev/*` twins (1.2.3–1.5.1) are **deprecated pointers**: never publish
-  new versions to them, and never "un-deprecate" — existing installs keep
-  resolving them forever.
+- Registry names: `areev` on crates.io and PyPI. On npm, the *unscoped*
+  `areev` name is still blocked by npm's similarity filter (403 against
+  `argv`) — a support ticket is open, but as of the 1.6.0 release npm still
+  publishes under the pre-1.5.1 scoped names, `@areev/areev` +
+  `@areev/areev-<platform>`. Check `crates/areev-js/package.json`'s `name`
+  field for which is currently live before assuming either — CLAUDE.md's
+  Status section is the source of truth. `areev-win32-x64-msvc`'s SEPARATE
+  security hold (unrelated to the similarity filter) was released
+  2026-08-22; don't conflate the two the way an earlier pass here did.
 - crates.io rate-limits NEW crate names hard (burst ~5, slow refill, 429
   with retry-after); existing-crate version publishes are much milder.
   Retry on 429 AND on upload timeouts — a timed-out upload may still have

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,14 +1,16 @@
-# Publish the Node bindings (crates/areev-js) to npm as `areev`.
+# Publish the Node bindings (crates/areev-js) to npm. Reads its target name
+# from package.json — currently `@areev/areev` (unscoped `areev` is pending
+# an npm similarity-filter exception; see CLAUDE.md's Status section).
 #
 # napi-rs ships a native addon per platform. This builds the `.node` for each
 # target, then publishes one small platform package per target
-# (`areev-<platform>`) plus the thin main package that loads the right one at
+# (`<name>-<platform>`) plus the thin main package that loads the right one at
 # runtime via optionalDependencies (the layout the review flagged as missing).
 #
 # Trigger: on a published GitHub Release (tag `vX.Y.Z`) or manual dispatch.
 # Prerequisite secret: `NPM_TOKEN` (an npm automation token for the account
-# that owns the `areev` packages — it must have publish rights on the
-# unscoped names, not just the `@areev` scope).
+# that owns the `areev` packages — it must have publish rights on whichever
+# names package.json currently declares, scoped or not).
 #
 # NOTE: native cross-platform CI is finicky — watch the first release run and
 # adjust the target matrix / napi flags to your installed @napi-rs/cli (v3) if a
@@ -190,14 +192,13 @@ jobs:
         # publish. Publishes skip anything already on the registry, so re-runs
         # are idempotent.
         #
-        # Both the main package and the per-platform packages are UNSCOPED
-        # (`areev`, `areev-win32-x64-msvc`, …) since 1.5.1 — npm support
-        # granted the similarity-filter exception and released the Windows
-        # name's security hold on 2026-08-22. Any 403 here is a real failure
-        # (auth/2FA/ownership), never the filter; do NOT warn past it — a
-        # manifest that promises a package npm refused breaks `require()` on
-        # that platform (the pre-1.2.3 Windows incident). The scoped
-        # `@areev/*` twins are deprecated pointers; they get no new versions.
+        # The main package and per-platform packages publish under whatever
+        # name is currently in package.json (`@areev/areev` + scoped platform
+        # names as of 1.6.0 — unscoped `areev` still 403s npm's similarity
+        # filter; see CLAUDE.md's Status section for where that stands). Any
+        # OTHER 403 here is a real failure (auth/2FA/ownership); do NOT warn
+        # past it — a manifest that promises a package npm refused breaks
+        # `require()` on that platform (the pre-1.2.3 Windows incident).
         run: |
           set -euo pipefail
           publish_if_absent() { # $1 = package name, $2 = version, $3 = dir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   indistinguishable from the connection having failed. The broker's contract
   is to answer with the response, so it now does.
 
+- **The Node binding publishes as `@areev/areev` again, not `areev`.** npm's
+  similarity filter still 403s the unscoped name against `argv` — the
+  1.5.2 release attempted it twice (once before, once after an unrelated SBOM
+  fix) and both times the four platform packages published while the main
+  package failed, leaving a broken partial release on the registry. A
+  support ticket for the unscoped name is open; until it resolves, `npm
+  install @areev/areev` is correct and `npm install areev` is not. crates.io
+  and PyPI are unaffected.
+
 ### Not in this release
 
 Deliberately out of #101's first phase: verify-by-re-execution against the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,12 +9,17 @@ with CAL, and rendered into model-ready context in-process (no server in the
 recall path).
 
 **Status**: published — the library crates + the `areev` binary on crates.io,
-`areev` on PyPI, and **`areev`** on npm (unscoped, since 1.5.1 — npm support
-granted the exception and released the `areev-win32-x64-msvc` security hold
-on 2026-08-22, so the main package *and* every per-platform addon
-(`areev-win32-x64-msvc`, …) publish unscoped). The former scoped packages
-(`@areev/areev` + platforms) are deprecated pointers, kept for existing
-installs; never publish new versions to them.
+`areev` on PyPI, and the Node binding on npm as **`@areev/areev`** (+ scoped
+per-platform addons). Unscoped `areev` on npm is still blocked: npm's
+similarity filter 403s it against `argv` (`Package name too similar to
+existing package argv`), unresolved as of the 1.5.2 release attempt
+(2026-08-22) despite an earlier belief the exception had been granted —
+`areev-win32-x64-msvc`'s separate *security hold* was released that day, but
+the *main package's* filter block was not, and the two got conflated here
+once already. A support ticket for the unscoped name is open; until it
+lands, npm releases publish under the pre-1.5.1 `@areev/*` scope (never the
+bare `areev-<platform>` names, which 403 the same way). crates.io and PyPI
+are unaffected — different registries, no naming block there.
 `areev-py`, `areev-bench`, and `areev-conformance` stay `publish = false`;
 `areev-js` ships to npm, not crates.io.
 The version lives in `[workspace.package]` in the root `Cargo.toml` (all crates
@@ -316,7 +321,9 @@ outputs), `name-reservation/` (registry placeholder stubs), `target/`.
 ## Naming
 
 Brand "Areev", CLI binary `areev` (package/crate `areev`), hub daemon
-"areevd", Python module `areev`, npm packages `areev` +
-`areev-<platform>` (unscoped since 1.5.1; the scoped `@areev/*` twins are
-deprecated pointers). The OMS spec itself is external (CC0); OMS
+"areevd", Python module `areev`, npm packages `@areev/areev` +
+`@areev/areev-<platform>` (unscoped `areev`/`areev-<platform>` is the intent
+once npm's similarity-filter exception lands — see Status above — not yet
+in effect; don't call the scoped names "deprecated" until it does). The OMS
+spec itself is external (CC0); OMS
 conformance is the compatibility mechanism with other implementations.

--- a/FAQ.md
+++ b/FAQ.md
@@ -26,7 +26,7 @@ edges.
 
 Areev is written in Rust and ships as a Rust library, the `areev` command-line
 binary, an MCP server, and Python (`import areev`) and Node
-(`require('areev')`) bindings. It runs anywhere Rust and Turso run — Linux,
+(`require('@areev/areev')`) bindings. It runs anywhere Rust and Turso run — Linux,
 macOS, and Windows on x86-64, plus **arm64** everywhere (Apple Silicon, arm64
 servers, and 64-bit Raspberry Pi OS).
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Measured on the devices themselves, clock-certified:
 ```bash
 cargo install areev          # the CLI    (prebuilt binaries: see the quickstart)
 pip install areev            # Python
-npm install areev     # Node
+npm install @areev/areev     # Node (unscoped `areev` is pending an npm exception)
 ```
 
 Store a fact, recall it, hand it to a model:

--- a/crates/areev-js/README.md
+++ b/crates/areev-js/README.md
@@ -2,16 +2,19 @@
 
 Node.js (napi-rs) bindings for Areev, the embedded memory engine for AI agents.
 
-`areev-js` is the napi-rs native addon that exposes Areev to Node.js as the
-`areev` package. It mirrors the Python binding with the same thin,
-version-stable FFI convention: scalar arguments in, JSON strings out for
-anything structured, and errors thrown as JavaScript `Error`s. Because the
-underlying engine is native, this is a compiled Node addon rather than WASM. One
-memory is one file, opened with a namespace, giving JavaScript agents durable
-add / recall / supersede / forget over content-addressed memory.
+`areev-js` is the napi-rs native addon that exposes Areev to Node.js, published
+as `@areev/areev` — the unscoped `areev` name is pending an npm similarity-filter
+exception (npm's spam filter reads it as too close to `argv`); the scoped
+package is not a fork, just the current install name. It mirrors the Python
+binding with the same thin, version-stable FFI convention: scalar arguments
+in, JSON strings out for anything structured, and errors thrown as JavaScript
+`Error`s. Because the underlying engine is native, this is a compiled Node
+addon rather than WASM. One memory is one file, opened with a namespace,
+giving JavaScript agents durable add / recall / supersede / forget over
+content-addressed memory.
 
 ```js
-const { Areev } = require('areev')
+const { Areev } = require('@areev/areev')
 
 const mem = new Areev('caller.db', 'caller') // 3rd arg: passphrase for AES-256 at rest
 const h = await mem.addFact('john', 'prefers', 'tea', 0.95)

--- a/crates/areev-js/index.js
+++ b/crates/areev-js/index.js
@@ -75,8 +75,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-android-arm64')
-        const bindingPackageVersion = require('areev-android-arm64/package.json').version
+        const binding = require('@areev/areev-android-arm64')
+        const bindingPackageVersion = require('@areev/areev-android-arm64/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -91,8 +91,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-android-arm-eabi')
-        const bindingPackageVersion = require('areev-android-arm-eabi/package.json').version
+        const binding = require('@areev/areev-android-arm-eabi')
+        const bindingPackageVersion = require('@areev/areev-android-arm-eabi/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -112,8 +112,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-x64-gnu')
-        const bindingPackageVersion = require('areev-win32-x64-gnu/package.json').version
+        const binding = require('@areev/areev-win32-x64-gnu')
+        const bindingPackageVersion = require('@areev/areev-win32-x64-gnu/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -128,8 +128,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-x64-msvc')
-        const bindingPackageVersion = require('areev-win32-x64-msvc/package.json').version
+        const binding = require('@areev/areev-win32-x64-msvc')
+        const bindingPackageVersion = require('@areev/areev-win32-x64-msvc/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -145,8 +145,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-ia32-msvc')
-        const bindingPackageVersion = require('areev-win32-ia32-msvc/package.json').version
+        const binding = require('@areev/areev-win32-ia32-msvc')
+        const bindingPackageVersion = require('@areev/areev-win32-ia32-msvc/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -161,8 +161,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-win32-arm64-msvc')
-        const bindingPackageVersion = require('areev-win32-arm64-msvc/package.json').version
+        const binding = require('@areev/areev-win32-arm64-msvc')
+        const bindingPackageVersion = require('@areev/areev-win32-arm64-msvc/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -180,8 +180,8 @@ function requireNative() {
       loadErrors.push(e)
     }
     try {
-      const binding = require('areev-darwin-universal')
-      const bindingPackageVersion = require('areev-darwin-universal/package.json').version
+      const binding = require('@areev/areev-darwin-universal')
+      const bindingPackageVersion = require('@areev/areev-darwin-universal/package.json').version
       if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
         throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
@@ -196,8 +196,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-darwin-x64')
-        const bindingPackageVersion = require('areev-darwin-x64/package.json').version
+        const binding = require('@areev/areev-darwin-x64')
+        const bindingPackageVersion = require('@areev/areev-darwin-x64/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -212,8 +212,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-darwin-arm64')
-        const bindingPackageVersion = require('areev-darwin-arm64/package.json').version
+        const binding = require('@areev/areev-darwin-arm64')
+        const bindingPackageVersion = require('@areev/areev-darwin-arm64/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -232,8 +232,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-freebsd-x64')
-        const bindingPackageVersion = require('areev-freebsd-x64/package.json').version
+        const binding = require('@areev/areev-freebsd-x64')
+        const bindingPackageVersion = require('@areev/areev-freebsd-x64/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -248,8 +248,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-freebsd-arm64')
-        const bindingPackageVersion = require('areev-freebsd-arm64/package.json').version
+        const binding = require('@areev/areev-freebsd-arm64')
+        const bindingPackageVersion = require('@areev/areev-freebsd-arm64/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -269,8 +269,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-x64-musl')
-          const bindingPackageVersion = require('areev-linux-x64-musl/package.json').version
+          const binding = require('@areev/areev-linux-x64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-x64-musl/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -285,8 +285,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-x64-gnu')
-          const bindingPackageVersion = require('areev-linux-x64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-x64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-x64-gnu/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -303,8 +303,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm64-musl')
-          const bindingPackageVersion = require('areev-linux-arm64-musl/package.json').version
+          const binding = require('@areev/areev-linux-arm64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-arm64-musl/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -319,8 +319,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm64-gnu')
-          const bindingPackageVersion = require('areev-linux-arm64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-arm64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-arm64-gnu/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -337,8 +337,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm-musleabihf')
-          const bindingPackageVersion = require('areev-linux-arm-musleabihf/package.json').version
+          const binding = require('@areev/areev-linux-arm-musleabihf')
+          const bindingPackageVersion = require('@areev/areev-linux-arm-musleabihf/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -353,8 +353,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-arm-gnueabihf')
-          const bindingPackageVersion = require('areev-linux-arm-gnueabihf/package.json').version
+          const binding = require('@areev/areev-linux-arm-gnueabihf')
+          const bindingPackageVersion = require('@areev/areev-linux-arm-gnueabihf/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -371,8 +371,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-loong64-musl')
-          const bindingPackageVersion = require('areev-linux-loong64-musl/package.json').version
+          const binding = require('@areev/areev-linux-loong64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-loong64-musl/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -387,8 +387,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-loong64-gnu')
-          const bindingPackageVersion = require('areev-linux-loong64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-loong64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-loong64-gnu/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -405,8 +405,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-riscv64-musl')
-          const bindingPackageVersion = require('areev-linux-riscv64-musl/package.json').version
+          const binding = require('@areev/areev-linux-riscv64-musl')
+          const bindingPackageVersion = require('@areev/areev-linux-riscv64-musl/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -421,8 +421,8 @@ function requireNative() {
           loadErrors.push(e)
         }
         try {
-          const binding = require('areev-linux-riscv64-gnu')
-          const bindingPackageVersion = require('areev-linux-riscv64-gnu/package.json').version
+          const binding = require('@areev/areev-linux-riscv64-gnu')
+          const bindingPackageVersion = require('@areev/areev-linux-riscv64-gnu/package.json').version
           if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
             throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
@@ -438,8 +438,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-linux-ppc64-gnu')
-        const bindingPackageVersion = require('areev-linux-ppc64-gnu/package.json').version
+        const binding = require('@areev/areev-linux-ppc64-gnu')
+        const bindingPackageVersion = require('@areev/areev-linux-ppc64-gnu/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -454,8 +454,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-linux-s390x-gnu')
-        const bindingPackageVersion = require('areev-linux-s390x-gnu/package.json').version
+        const binding = require('@areev/areev-linux-s390x-gnu')
+        const bindingPackageVersion = require('@areev/areev-linux-s390x-gnu/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -474,8 +474,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-openharmony-arm64')
-        const bindingPackageVersion = require('areev-openharmony-arm64/package.json').version
+        const binding = require('@areev/areev-openharmony-arm64')
+        const bindingPackageVersion = require('@areev/areev-openharmony-arm64/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -490,8 +490,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-openharmony-x64')
-        const bindingPackageVersion = require('areev-openharmony-x64/package.json').version
+        const binding = require('@areev/areev-openharmony-x64')
+        const bindingPackageVersion = require('@areev/areev-openharmony-x64/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -506,8 +506,8 @@ function requireNative() {
         loadErrors.push(e)
       }
       try {
-        const binding = require('areev-openharmony-arm')
-        const bindingPackageVersion = require('areev-openharmony-arm/package.json').version
+        const binding = require('@areev/areev-openharmony-arm')
+        const bindingPackageVersion = require('@areev/areev-openharmony-arm/package.json').version
         if (bindingPackageVersion !== '1.6.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           throw new Error(`Native binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
@@ -643,16 +643,16 @@ if (!nativeBinding || forceWasi) {
     let candidateError = null
     let candidateFailed = false
     try {
-      candidateError = __napiWasiResolveCandidate('areev-wasm32-wasi', true, undefined)
+      candidateError = __napiWasiResolveCandidate('@areev/areev-wasm32-wasi', true, undefined)
       candidateFailed = candidateError !== null
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          const bindingPackageVersion = require('areev-wasm32-wasi/package.json').version
+          const bindingPackageVersion = require('@areev/areev-wasm32-wasi/package.json').version
           if (bindingPackageVersion !== '1.6.0') {
             throw new Error(`WASI binding package version mismatch, expected 1.6.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
-        wasiBinding = require('areev-wasm32-wasi')
+        wasiBinding = require('@areev/areev-wasm32-wasi')
         nativeBinding = wasiBinding
         wasiBindingLoaded = true
       }

--- a/crates/areev-js/package.json
+++ b/crates/areev-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "areev",
+  "name": "@areev/areev",
   "version": "1.6.0",
   "description": "Node.js bindings for Areev, the embedded memory engine for AI agents.",
   "license": "MIT OR Apache-2.0",

--- a/crates/areev-js/scripts/prepare-npm.mjs
+++ b/crates/areev-js/scripts/prepare-npm.mjs
@@ -9,18 +9,20 @@
 //   3. wires the main package's `optionalDependencies` to all platform packages, and
 //   4. prints — one per line on stdout — the platform package dirs to publish.
 //
-// The packages are UNSCOPED (`areev`, `areev-win32-x64-msvc`, …) since
-// 1.5.1: npm support granted the similarity-filter exception and released
-// the `areev-win32-x64-msvc` security hold on 2026-08-22. History that must
-// not repeat: while the filter 403'd only the Windows platform name, the
-// main package shipped declaring an optionalDependency that did not exist —
-// npm silently skips a missing optional dep at install and napi then fails
-// at `require()` with its misleading "npm optional dependencies bug" text,
-// so Windows was broken by a registry-name problem reported as a build
+// The packages are back on the SCOPED names (`@areev/areev`,
+// `@areev/areev-win32-x64-msvc`, …) as of 1.6.0: npm's similarity filter
+// still 403s the unscoped `areev` main package against `argv`
+// (`areev-win32-x64-msvc`'s separate SECURITY HOLD was released on
+// 2026-08-22, which is not the same block and does not clear it) — a support
+// ticket for the unscoped name is open, and CLAUDE.md's Status section is
+// the source of truth for where that stands. History that must not repeat:
+// releases before 1.2.3 warned past a 403 on one platform name and shipped a
+// main package declaring an optionalDependency that did not exist — npm
+// silently skips a missing optional dep at install and napi then fails at
+// `require()` with its misleading "npm optional dependencies bug" text, so
+// Windows was broken by a registry-name problem reported as a build
 // problem. That is why this script HARD-FAILS when any declared target has
-// no artifact, and why the workflow publishes the main package last. The
-// scoped `@areev/*` twins (releases 1.2.3–1.5.1) are deprecated pointers;
-// never publish new versions to them.
+// no artifact, and why the workflow publishes the main package last.
 import { readFileSync, writeFileSync, readdirSync, existsSync } from 'node:fs';
 
 const mainPath = 'package.json';

--- a/docs/loop-proposal.md
+++ b/docs/loop-proposal.md
@@ -247,7 +247,7 @@ Areev 1.0.1 is published (crates.io, PyPI, npm) and public at
 ### 4.1 Claude Code agent (ten minutes)
 
 ```bash
-cargo install areev            # or: pip install areev / npm install areev
+cargo install areev            # or: pip install areev / npm install @areev/areev
 
 areev init --db agent.db --template coding-agent --framework claude-code
 #   (new verb) seeds namespaces, an instruction doc, starter saved queries,

--- a/docs/memory-tool.md
+++ b/docs/memory-tool.md
@@ -55,7 +55,7 @@ while True:
 ### Node
 
 ```js
-const { Areev } = require('areev')
+const { Areev } = require('@areev/areev')
 const m = new Areev('agent.db', 'assistant')
 
 // inside your tool loop (every method returns a promise):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ Areev ships on all three registries — install the surface you need:
 ```bash
 cargo install areev          # the `areev` CLI
 pip install areev            # Python bindings
-npm install areev     # Node bindings
+npm install @areev/areev     # Node bindings (unscoped `areev` is pending an npm exception)
 ```
 
 No Rust toolchain? Every release also carries prebuilt `areev` binaries for
@@ -226,7 +226,7 @@ transaction; to load another system's export, prefer `migrate()`
 ## Node
 
 ```js
-const { Areev } = require('areev')
+const { Areev } = require('@areev/areev')
 
 const mem = new Areev('john.db', 'caller')                  // 3rd arg: passphrase for AES-256 at rest
 await mem.addFact('john', 'prefers', 'tea', 0.95)


### PR DESCRIPTION
The 1.5.2 release attempted the unscoped `areev` npm name twice (the original
run and the retry after #98's SBOM fix) and both times hit npm's similarity
filter (403 against `argv`), leaving a broken partial release on the
registry — 4 platform packages published, the main package didn't. CLAUDE.md's
claim that the exception was granted on 2026-08-22 conflated it with the
separate `areev-win32-x64-msvc` security hold, which *was* released that day.

Publishes 1.6.0's Node binding under the pre-1.5.1 scoped name
(`@areev/areev` + `@areev/areev-<platform>`) instead, and corrects every place
the "unscoped since 1.5.1" claim had already propagated (README, docs,
CLAUDE.md, the release skill, workflow/script comments) so nothing tells a
user to run an install command that 404s. A support ticket for the unscoped
name is open with npm.

Verified: \`check_versions.py\` / \`repo_stats.py --check\` pass, \`node --test\`
65/65 green, no Rust source touched.