### PR TITLE
Capability tools: non-credential request headers (#105) and CAS blob reads (#106)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -980,6 +980,45 @@ redirects with the allowlist checked only on the initial URL, and the
 `--credential` variable had never been added to the withhold list every other
 secret flag is on.
 
+**Decision (2026-08-23, issue #106):** the guest gets neither a socket **nor a
+file descriptor** — a capability tool reads the memory's stored bytes through
+the same broker, never from the filesystem.
+
+The gap this closes is narrow and sharp. A trigger's connector files an email
+attachment as a CAS blob; the tool that should parse it is the one most worth
+sandboxing, because its input is untrusted by construction — and it was the
+one tool that structurally could not be, because `wasm32-areev-io` could reach
+the network but not the bytes the memory already held. So `{"blob": {"read":
+true}}` declares a second capability and `areev::blob_get` reads one blob by
+content address: no enumeration, no write, no namespace access, so a module
+reaches bytes it was handed a reference to and cannot browse the memory.
+
+The implementation choice is the interesting part, because the obvious one is
+wrong in a way that only shows up at the audit trail. Reading the `.blobs`
+sidecar directly from the sandbox subprocess *looks* free — the read is
+lock-free by design, which is what already lets a `--tool-cmd` subprocess run
+`areev blob get` mid-run. But the subprocess is handed no memory path, cannot
+take a dependency on `areev-store` without giving up the five-dependency
+standalone posture that makes it a credible boundary, reads nothing at all on
+the Postgres backend where blobs live in-schema, and — decisively — has **no
+channel back to the driver**: stdout is contractually the guest's own result,
+and the fuel line on stderr is prose for a human. A read performed there could
+not be journaled, which would put the hole in the evidence exactly where the
+untrusted bytes are.
+
+Routing it through the broker answers all four at once, because the broker
+already runs in the engine's process, already authenticates per-caller tokens,
+and already exists to turn "the module has no socket" into "every byte is
+mediated and recorded". Blob reads journal as `blob_read` Observations naming
+the address and byte count, drained on the same superstep boundary as
+`egress_call` — and the address *is* the content hash, so the record names
+exactly which bytes were opened without putting an attachment into an
+immutable, replicating grain. The two capabilities are gated independently, and
+asymmetrically on purpose: `--allow-fetch` derives from the pinned runtime
+because a host-side grant narrows it afterwards, while `--allow-blob` derives
+from the pinned *declaration*, because nothing narrows a blob read after the
+fact and every capability module would otherwise acquire it silently.
+
 ### Cadence is data; evaluation is a command
 
 A trigger is a standing rule that starts a workflow, declared as a `Trigger`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Capability tools can set non-credential request headers** (#105). A
+  brokered `areev::fetch` request takes an optional `headers` map, and a Tool
+  grain declares which names it may use as `capabilities.http.headers`. This
+  was the last thing between capability tools and the APIs they are pitched at:
+  every Google API called with user credentials requires `X-Goog-User-Project`
+  or answers `403 … requires a quota project`, and that header is not a
+  credential, so neither the broker nor the guest could set it. The same gap
+  blocked `anthropic-version`, `x-ms-version`, and every tenant header.
+
+  The credential channel stays closed. `Authorization`, `Proxy-Authorization`,
+  `Cookie`, `Host` — and any header a configured `Credential::Header` rides in,
+  which is known only after resolution — are refused at any casing: declaring
+  one is refused at **write** time, sending one at call time. That refusal is
+  deliberately free rather than costing a call from the budget: the
+  spend-before-checking rule exists so a module cannot probe *per-caller*
+  policy for nothing, and "may I write the Authorization header?" has one
+  answer for everyone. Malformed names and values carrying CR/LF are a `400`,
+  because header injection is malformed rather than merely denied, and it must
+  die at the parse instead of at the socket where it would split one request
+  into two.
+
+  Declared headers are deny-by-default like credentials, matched
+  case-insensitively, checked on every redirect hop, and travel exactly as far
+  as the credential does — a cross-origin hop drops both, since a quota project
+  or tenant id was meant for the host the caller named and not for one an
+  intermediary chose. They are journaled on the `egress_call` Observation
+  **with their values**, the deliberate asymmetry against the credential's
+  name-only record: the caller supplied them, so recording them discloses
+  nothing it did not already hold, and turns "it was allowed to reach Google"
+  into "it billed this quota project on these four requests".
+
+  The sandbox needed no change — it forwards the guest's JSON verbatim, so the
+  guest ABI is the broker ABI.
+
 ### Changed
 
 - **The framework adapters moved out of this repo.** `areev-langgraph` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,46 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The sandbox needed no change — it forwards the guest's JSON verbatim, so the
   guest ABI is the broker ABI.
 
+- **Capability tools can read CAS blobs** (#106). A Tool grain declares
+  `{"blob": {"read": true}}` and its module gains `areev::blob_get`, reading
+  one stored blob by content address. This closes the gap that left a whole
+  class of tool stuck outside Tier C: a trigger's connector already files email
+  attachments as CAS blobs, and the tool that parses them is the one that most
+  wants sandboxing — its input is untrusted by construction — yet it was the
+  one tool that structurally could not be, because `wasm32-areev-io` could
+  reach the network but not the bytes the memory already held.
+
+  Read-only, and by address only: no enumeration, no write, no namespace
+  access, so a module fetches bytes it was handed a `cas://` reference to and
+  cannot browse the memory. The two capabilities are independent — a module
+  that parses attachments and calls nothing declares only `blob` — and gated
+  asymmetrically on purpose: `--allow-fetch` derives from the pinned runtime,
+  because a host-side grant narrows it afterwards, while `--allow-blob` derives
+  from the pinned *declaration*, because nothing narrows a blob read after the
+  fact.
+
+  **The read goes through the broker, not the sandbox**, and that is the
+  design's substance rather than a detail. Reading the `.blobs` sidecar
+  directly from the subprocess looks free — the read is lock-free, which is
+  what already lets `areev blob get` work mid-run — but the subprocess is
+  handed no memory path, cannot take `areev-store` without giving up the
+  five-dependency standalone posture that makes it a credible boundary, reads
+  nothing on the Postgres backend, and has **no channel back to the driver**:
+  stdout is the guest's result and the stderr fuel line is prose. A read
+  performed there could not be journaled, putting the hole in the evidence
+  exactly where the untrusted bytes are. Through the broker, every read lands
+  as a `blob_read` Observation naming the address and byte count, drained on
+  the same superstep boundary as `egress_call` — and the guarantee becomes one
+  sentence: **the guest gets neither a socket nor a file descriptor.**
+
+  Success answers raw bytes rather than JSON, since a blob is binary and
+  base64 would tax every guest with a decoder to read its own attachment;
+  errors stay JSON and are told apart by status, never by sniffing a payload
+  that may legitimately begin with `{`. Ceiling is `runtime_limits.max_blob_bytes`
+  (default 8 MiB, the payload cap). Embedded backend only — on PostgreSQL a
+  blob lives in-schema, so the call returns a `501` naming the limitation
+  rather than reporting the attachment as missing.
+
 ### Changed
 
 - **The framework adapters moved out of this repo.** `areev-langgraph` and

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -140,7 +140,7 @@ in source.
 | `RUN-E020` | `Storage` | The store failed underneath the driver |
 | `RUN-E021` | `LeaseLost` | Another driver took this run over mid-flight; this driver's writes are refused |
 | `RUN-E023` | `AnonReplayUnsafe` | An anonymization policy covers the run's namespace with a scope whose placeholders are not value-derived, so an abstract node's model boundary would make `verify` diverge |
-| `RUN-E022` | `EgressRefused` | A host command's outbound call was refused: destination outside the run's allowlist, a method its grant does not permit, a credential it may not spend, or a request header it may not set — undeclared, or one the broker owns (the trigger evaluator reports the same condition as `TRG-E009`) |
+| `RUN-E022` | `EgressRefused` | A host command's mediated I/O was refused: destination outside the run's allowlist, a method its grant does not permit, a credential it may not spend, a request header it may not set — undeclared, or one the broker owns — or a CAS blob read without the `blob` capability (the trigger evaluator reports the same condition as `TRG-E009`) |
 
 ### `TRG` — triggers (`areev-trigger/src/error.rs`)
 

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -140,7 +140,7 @@ in source.
 | `RUN-E020` | `Storage` | The store failed underneath the driver |
 | `RUN-E021` | `LeaseLost` | Another driver took this run over mid-flight; this driver's writes are refused |
 | `RUN-E023` | `AnonReplayUnsafe` | An anonymization policy covers the run's namespace with a scope whose placeholders are not value-derived, so an abstract node's model boundary would make `verify` diverge |
-| `RUN-E022` | `EgressRefused` | A host command's outbound call was refused: destination outside the run's allowlist, a method its grant does not permit, or a credential it may not spend (the trigger evaluator reports the same condition as `TRG-E009`) |
+| `RUN-E022` | `EgressRefused` | A host command's outbound call was refused: destination outside the run's allowlist, a method its grant does not permit, a credential it may not spend, or a request header it may not set — undeclared, or one the broker owns (the trigger evaluator reports the same condition as `TRG-E009`) |
 
 ### `TRG` — triggers (`areev-trigger/src/error.rs`)
 

--- a/areev-sandbox/README.md
+++ b/areev-sandbox/README.md
@@ -78,11 +78,20 @@ bug:
 
 ```json
 { "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages",
-  "method": "GET", "credential": "gmail", "body": null }
+  "method": "GET", "credential": "gmail", "body": null,
+  "headers": { "X-Goog-User-Project": "my-project" } }
 ```
 
 The guest names *which* credential; it can never name a value it was not given,
 and no value ever crosses back.
+
+`headers` (optional) carries non-credential request headers the module
+declared in `capabilities.http.headers` — the quota-project, API-version, and
+tenant headers enterprise APIs require. The broker refuses `Authorization`,
+`Proxy-Authorization`, `Cookie`, `Host`, and any header a configured
+credential rides in: those are its to set, and a guest that could write them
+would hold the credential channel this whole boundary exists to keep it out
+of.
 
 **Out**: a non-negative return is a pointer to `[u32 little-endian length][JSON
 bytes]` in guest memory, allocated through the guest's own `alloc` export. One

--- a/areev-sandbox/README.md
+++ b/areev-sandbox/README.md
@@ -5,7 +5,8 @@ set. Invoked as a subprocess.
 
 ```bash
 areev-sandbox --module extract.wasm [--fuel N] [--max-pages N] \
-              [--allow-fetch] [--max-response-bytes N] < input.json
+              [--allow-fetch] [--max-response-bytes N] \
+              [--allow-blob] [--max-blob-bytes N] < input.json
 ```
 
 JSON on stdin, JSON on stdout, one process per invocation — the same contract as
@@ -35,7 +36,10 @@ content-addressed tool, and it forbade exactly the I/O real agents need.
 | Engine runtime | Import set | Determinism |
 |---|---|---|
 | `wasm32-areev` | `areev::emit` | pure — **re-execution-provable** |
-| `wasm32-areev-io` | `+ areev::fetch` | deterministic **modulo journaled effects** |
+| `wasm32-areev-io` | `+ areev::fetch`, `+ areev::blob_get` | deterministic **modulo journaled effects** |
+
+`--allow-blob` links the second one, and is derived from the module's
+declaration rather than its runtime — see `areev::blob_get` below.
 
 The guest still gets no socket. It gets one unforgeable capability to **ask the
 host**, and this binary forwards to the engine's credential broker over
@@ -112,6 +116,39 @@ nondeterminism is what durable-execution engines spend enormous machinery
 taming, and it would add an ordering side channel to a boundary whose whole
 point is that it leaks nothing.
 
+### `areev::blob_get(ptr, len) -> i32`
+
+**In**: a UTF-8 JSON request naming ONE content address. There is no
+enumeration and no name lookup, so a module reads bytes it was handed a
+reference to and cannot go looking for others:
+
+```json
+{ "uri": "cas://sha256:<64 hex>" }
+```
+
+**Out**: the same `[u32 little-endian length][bytes]` framing `fetch` uses —
+one more function, not one more pattern — except the bytes are the **blob
+itself** rather than JSON wrapping it. A blob is arbitrary binary; putting it
+through JSON would mean base64, which costs a third of the size and obliges
+every guest to carry a decoder to read its own attachment. On failure the
+payload is `{"error": "…"}` instead, and this binary tells the two apart by the
+broker's HTTP status rather than by sniffing a payload that might legitimately
+begin with `{`. A **negative** return still means the host could not place a
+response at all.
+
+The read goes through the same broker on the same token, for the same reason
+the network does: a module that could read the `.blobs` sidecar itself would be
+a module with a file descriptor, and — decisively — a read performed in this
+process has no way back to the engine to be journaled. The tool this exists for
+parses untrusted attachments, which is exactly where a hole in the audit trail
+is least affordable. Every read lands in the memory as a `blob_read`
+Observation naming the address and the byte count.
+
+`--allow-blob` is derived from the module's **declaration**
+(`{"blob": {"read": true}}`), not from its runtime, unlike `--allow-fetch`:
+egress has a host-side grant behind it that narrows the runtime's permission
+afterwards, and a blob read has no such second key.
+
 ## Limits
 
 | Limit | Default | Stops |
@@ -121,14 +158,16 @@ point is that it leaks nothing.
 | memory pages (declared max) | 256 (16 MiB) | a guest ballooning linear memory |
 | payload | 8 MiB | an oversized input or result |
 | response bytes (`--max-response-bytes`) | 1 MiB | an upstream ballooning the guest's memory |
+| blob bytes (`--max-blob-bytes`) | 8 MiB | one stored attachment ballooning the guest's memory |
 
 Overruns are typed errors, never truncation — a tool handed half a response
 computes a wrong answer with nothing to show for it.
 
 Fuel use is deterministic for a given module and input, which is what makes a
 **pure** Tier C tool re-execution-provable. A module that made brokered calls is
-deterministic only modulo those calls; the outcome's `fetches` count is how you
-tell the two apart.
+deterministic only modulo those calls; the outcome's `fetches` and `blob_reads`
+counts are how you tell the two apart. Both are omitted when zero, so a pure
+module's outcome stays byte-identical.
 
 ## Why this is a standalone package
 

--- a/areev-sandbox/src/http.rs
+++ b/areev-sandbox/src/http.rs
@@ -37,6 +37,23 @@ const TIMEOUT: Duration = Duration::from_secs(90);
 /// there is no place here for a translation bug, and the guest ABI stays
 /// exactly the broker ABI.
 pub fn post_json(url: &str, token: &str, body: &[u8], max_response_bytes: usize) -> Result<Vec<u8>, String> {
+    post(url, "/", token, body, max_response_bytes).map(|(_, b)| b)
+}
+
+/// Post to one of the broker's paths, returning `(status, body)`.
+///
+/// `areev::fetch` ignores the status — the broker answers it with JSON either
+/// way, and forwarding verbatim is that hop's whole contract. `areev::blob_get`
+/// needs it: its success answer is raw bytes and its failures are JSON, so the
+/// status is what tells them apart. Sniffing the payload to guess which one
+/// arrived would misread a PDF that happens to start with `{`.
+pub fn post(
+    url: &str,
+    path: &str,
+    token: &str,
+    body: &[u8],
+    max_response_bytes: usize,
+) -> Result<(u16, Vec<u8>), String> {
     let addr = authority(url)?;
     let stream = TcpStream::connect(&addr).map_err(|e| format!("connecting to the broker at {addr}: {e}"))?;
     stream.set_read_timeout(Some(TIMEOUT)).ok();
@@ -50,8 +67,14 @@ pub fn post_json(url: &str, token: &str, body: &[u8], max_response_bytes: usize)
         return Err("broker token contains a control character".into());
     }
 
+    // Same argument as the token, one line down: the path is ours, never the
+    // guest's, but a request line it could break is worth one `if`.
+    if path.chars().any(|c| c.is_control() || c == ' ') {
+        return Err("broker path contains a control character".into());
+    }
+
     let head = format!(
-        "POST / HTTP/1.1\r\nHost: {addr}\r\nX-Areev-Egress-Token: {token}\r\n\
+        "POST {path} HTTP/1.1\r\nHost: {addr}\r\nX-Areev-Egress-Token: {token}\r\n\
          Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
         body.len()
     );
@@ -66,6 +89,7 @@ pub fn post_json(url: &str, token: &str, body: &[u8], max_response_bytes: usize)
     if !line.starts_with("HTTP/1.") {
         return Err("the broker did not answer with HTTP".into());
     }
+    let status: u16 = line.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
 
     let mut content_length: Option<usize> = None;
     loop {
@@ -94,7 +118,7 @@ pub fn post_json(url: &str, token: &str, body: &[u8], max_response_bytes: usize)
             reader
                 .read_exact(&mut buf)
                 .map_err(|e| format!("reading the broker's response body: {e}"))?;
-            Ok(buf)
+            Ok((status, buf))
         }
         None => {
             // The broker always sends a Content-Length; read to EOF under the
@@ -111,7 +135,7 @@ pub fn post_json(url: &str, token: &str, body: &[u8], max_response_bytes: usize)
                      refused rather than truncated"
                 ));
             }
-            Ok(buf)
+            Ok((status, buf))
         }
     }
 }

--- a/areev-sandbox/src/lib.rs
+++ b/areev-sandbox/src/lib.rs
@@ -413,11 +413,16 @@ pub fn run(
 ///
 /// ```json
 /// { "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages",
-///   "method": "GET", "credential": "gmail", "body": null }
+///   "method": "GET", "credential": "gmail", "body": null,
+///   "headers": { "X-Goog-User-Project": "my-project" } }
 /// ```
 ///
 /// The guest names a credential; it can never name a *value* it was not given,
-/// and no value ever crosses back.
+/// and no value ever crosses back. `headers` (#105) carries non-credential
+/// request headers only — the broker refuses `Authorization`, `Cookie`,
+/// `Host`, `Proxy-Authorization`, and any header a configured credential
+/// rides in. Because this binary forwards rather than translates, that field
+/// needed no change here: the guest ABI is the broker ABI.
 ///
 /// **Out**: a non-negative return is a pointer into guest memory to
 /// `[u32 little-endian length][JSON bytes]`. One `i32` cannot carry both a

--- a/areev-sandbox/src/lib.rs
+++ b/areev-sandbox/src/lib.rs
@@ -28,7 +28,7 @@
 //! | Runtime | Imports | Determinism |
 //! |---|---|---|
 //! | `wasm32-areev` | `areev::emit` | pure — **re-execution-provable** |
-//! | `wasm32-areev-io` | `+ areev::fetch` | deterministic **modulo journaled effects** |
+//! | `wasm32-areev-io` | `+ areev::fetch`, `+ areev::blob_get` | deterministic **modulo journaled effects** |
 //!
 //! The isolation claim is *strengthened*, not weakened. The guest still has no
 //! socket, no credential, no clock, no environment: it gets one more
@@ -65,6 +65,10 @@
 //! - `areev.fetch(ptr: i32, len: i32) -> i32` — **only** under
 //!   [`Limits::allow_fetch`]. A module that imports it without a capability
 //!   declaration is refused by name before one instruction runs.
+//! - `areev.blob_get(ptr: i32, len: i32) -> i32` — **only** under
+//!   [`Limits::allow_blob`] (#106): read one CAS blob by content address,
+//!   through the same broker. Gated independently of `fetch`, so a module
+//!   that parses attachments and touches no network declares exactly that.
 //! - `alloc(len: i32) -> i32` is a guest **export** (with `run` and
 //!   `memory`), not an import: the guest allocates a buffer in its own
 //!   linear memory and the host calls it to place input — and, for `fetch`,
@@ -87,6 +91,7 @@
 //! | frozen imports | reaching anything not on the list |
 //! | no WASI | filesystem, network, clock, environment, randomness |
 //! | response byte cap | an upstream ballooning the guest's memory |
+//! | blob byte cap | one stored attachment ballooning the guest's memory |
 
 use serde::{Deserialize, Serialize};
 use wasmi::{Config, Engine, Linker, Module, Store};
@@ -126,9 +131,23 @@ pub struct Limits {
     /// MANIFEST-pinned runtime (`wasm32-areev-io`), never from the module —
     /// a blob cannot talk its way into a gate.
     pub allow_fetch: bool,
+    /// Link `areev::blob_get` into the guest's import set (#106).
+    ///
+    /// Same posture as [`Self::allow_fetch`], and separate from it on purpose:
+    /// the two capabilities are independent, and the tool this exists for —
+    /// parsing an attachment that arrived from outside — is precisely the one
+    /// that should be reading bytes with no network at all. The engine derives
+    /// this from the manifest-pinned DECLARATION (`{"blob": {"read": true}}`),
+    /// not merely from the runtime string, because unlike `fetch` there is no
+    /// host-side grant that could narrow it afterwards.
+    pub allow_blob: bool,
     /// Largest single brokered response handed back to the guest. Overruns
     /// are errors, never truncation.
     pub max_response_bytes: usize,
+    /// Largest single blob handed back to the guest. Defaults to the payload
+    /// cap rather than the response cap: an attachment is a document, not an
+    /// API answer, and 1 MiB is a small PDF.
+    pub max_blob_bytes: usize,
 }
 
 impl Default for Limits {
@@ -138,7 +157,9 @@ impl Default for Limits {
             max_pages: DEFAULT_MAX_PAGES,
             max_module_bytes: MAX_MODULE_BYTES,
             allow_fetch: false,
+            allow_blob: false,
             max_response_bytes: DEFAULT_MAX_RESPONSE_BYTES,
+            max_blob_bytes: MAX_PAYLOAD_BYTES,
         }
     }
 }
@@ -213,6 +234,10 @@ pub struct Outcome {
     /// serializes identically to a pre-1.6 outcome.
     #[serde(default, skip_serializing_if = "is_zero")]
     pub fetches: u32,
+    /// CAS blobs the guest read (#106). Same omit-when-zero rule, for the same
+    /// reason: a pure module's outcome must not change shape.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub blob_reads: u32,
 }
 
 fn is_zero(n: &u32) -> bool {
@@ -237,7 +262,16 @@ struct HostState {
     /// so unchecked reentrancy is a stack-exhaustion primitive with I/O
     /// amplification. A reentrant call returns `-1` immediately, before any
     /// broker traffic and before any `alloc`.
+    ///
+    /// ONE flag for every host call, not one per import (#106): the hazard is
+    /// re-entering *any* host function from inside `alloc`, so a `blob_get`
+    /// nested in a `fetch`'s reply is the same stack-exhaustion primitive as a
+    /// nested `fetch`. A per-import flag would leave that door open.
     fetching: bool,
+    /// How many CAS blobs the guest has read, reported alongside fuel.
+    blob_reads: u32,
+    /// Largest single blob handed back.
+    max_blob_bytes: usize,
 }
 
 /// Run `wasm` against `input`.
@@ -279,7 +313,9 @@ pub fn run(
     for import in module.imports() {
         let (m, n) = (import.module(), import.name());
         let permitted = m == IMPORT_MODULE
-            && (n == "emit" || (n == "fetch" && limits.allow_fetch));
+            && (n == "emit"
+                || (n == "fetch" && limits.allow_fetch)
+                || (n == "blob_get" && limits.allow_blob));
         if !permitted {
             return Err(SandboxError::ForbiddenImport {
                 module: m.to_string(),
@@ -294,8 +330,17 @@ pub fn run(
             // Read once, here, so the guest's calls cannot observe a mutating
             // environment — and so a module with no `fetch` import never
             // touches these at all.
-            broker: if limits.allow_fetch { BrokerEnv::from_env() } else { None },
+            //
+            // Both gates read the same handshake: `blob_get` posts to the same
+            // broker on the same token, just a different path, so a module
+            // that declared only `blob` still needs the broker wired.
+            broker: if limits.allow_fetch || limits.allow_blob {
+                BrokerEnv::from_env()
+            } else {
+                None
+            },
             max_response_bytes: limits.max_response_bytes,
+            max_blob_bytes: limits.max_blob_bytes,
             ..HostState::default()
         },
     );
@@ -329,6 +374,18 @@ pub fn run(
     // makes the `ForbiddenImport` above the *only* way a pure module can be
     // told about `fetch` — there is no second path where it exists but is
     // inert.
+    if limits.allow_blob {
+        linker
+            .func_wrap(
+                IMPORT_MODULE,
+                "blob_get",
+                |caller: wasmi::Caller<'_, HostState>, ptr: i32, len: i32| -> i32 {
+                    host_blob_get(caller, ptr, len)
+                },
+            )
+            .map_err(|e| SandboxError::Module(format!("linker: {e}")))?;
+    }
+
     if limits.allow_fetch {
         linker
             .func_wrap(
@@ -399,7 +456,8 @@ pub fn run(
 
     let fuel_used = limits.fuel.saturating_sub(store.get_fuel().unwrap_or(0));
     let fetches = store.data().fetches;
-    Ok(Outcome { output, fuel_used, fetches })
+    let blob_reads = store.data().blob_reads;
+    Ok(Outcome { output, fuel_used, fetches, blob_reads })
 }
 
 /// `areev::fetch(ptr, len) -> i32` — the guest's one gate to the network.
@@ -462,6 +520,95 @@ fn host_fetch(mut caller: wasmi::Caller<'_, HostState>, ptr: i32, len: i32) -> i
     let code = host_fetch_inner(&mut caller, ptr, len);
     caller.data_mut().fetching = false;
     code
+}
+
+/// `areev::blob_get(ptr, len) -> i32` — the guest's one gate to stored bytes
+/// (#106).
+///
+/// ## The ABI
+///
+/// **In**: `[ptr, ptr+len)` is a UTF-8 JSON request naming ONE content
+/// address. There is no enumeration and no name lookup, so a module reads
+/// bytes it was handed a reference to and cannot go looking for others:
+///
+/// ```json
+/// { "uri": "cas://sha256:<64 hex>" }
+/// ```
+///
+/// **Out**: the same `[u32 little-endian length][bytes]` framing `fetch` uses,
+/// so the guest ABI grows by one function rather than one pattern — but the
+/// bytes are the **blob itself**, not JSON wrapping it. A blob is arbitrary
+/// binary; putting it through JSON would mean base64, which costs a third of
+/// the size and obliges every guest to carry a decoder to read its own
+/// attachment. On failure the payload is `{"error": "…"}` instead, and the
+/// host — not the guest — tells the two apart, by the broker's HTTP status
+/// rather than by sniffing a payload that might legitimately begin with `{`.
+///
+/// A **negative** return still means the host could not place a response at
+/// all, exactly as for `fetch`.
+///
+/// ## Why this goes through the broker
+///
+/// Reading the `.blobs` sidecar from inside this process looks free — the read
+/// is lock-free by design. It is not: this binary is handed no memory path,
+/// carries five dependencies and so cannot take `areev-store`'s `cas://`
+/// parser or its SHA-256, would silently read nothing on the Postgres backend,
+/// and — decisively — has no way to tell the driver what it read, so the
+/// audit trail Tier C is *for* would have a hole exactly where the untrusted
+/// bytes go. The broker already runs in the engine's process, already
+/// authenticates this token, and already records what it mediates.
+fn host_blob_get(mut caller: wasmi::Caller<'_, HostState>, ptr: i32, len: i32) -> i32 {
+    // The SAME gate `fetch` takes, and deliberately the same flag: `reply`
+    // runs the guest's `alloc`, so a guest whose allocator calls back into any
+    // host function would recurse this native frame with a broker round trip
+    // per level. Per-import flags would let `blob_get` nest inside `fetch`.
+    if caller.data().fetching {
+        return -1;
+    }
+    caller.data_mut().fetching = true;
+    let code = host_blob_get_inner(&mut caller, ptr, len);
+    caller.data_mut().fetching = false;
+    code
+}
+
+fn host_blob_get_inner(caller: &mut wasmi::Caller<'_, HostState>, ptr: i32, len: i32) -> i32 {
+    let Some(wasmi::Extern::Memory(mem)) = caller.get_export("memory") else {
+        return -1;
+    };
+    let len = len.max(0) as usize;
+    if len > MAX_PAYLOAD_BYTES {
+        return reply(
+            caller,
+            &json_error(&format!(
+                "request of {len} bytes exceeds the {MAX_PAYLOAD_BYTES}-byte payload cap"
+            )),
+        );
+    }
+    let mut request = vec![0u8; len];
+    if mem.read(&*caller, ptr.max(0) as usize, &mut request).is_err() {
+        return -1;
+    }
+
+    let (broker, max_blob_bytes) = {
+        let st = caller.data();
+        (st.broker.clone(), st.max_blob_bytes)
+    };
+    caller.data_mut().blob_reads = caller.data().blob_reads.saturating_add(1);
+
+    let body = match broker {
+        None => json_error(
+            "this module declares the blob capability, but the host wired no broker to read \
+             through",
+        ),
+        Some(b) => match http::post(&b.url, "/blob", &b.token, &request, max_blob_bytes) {
+            // 200 is the blob; anything else is the broker's JSON error, which
+            // already reads well enough to hand straight to the guest.
+            Ok((200, bytes)) => return reply(caller, &bytes),
+            Ok((_, bytes)) => bytes,
+            Err(e) => json_error(&e),
+        },
+    };
+    reply(caller, &body)
 }
 
 fn host_fetch_inner(caller: &mut wasmi::Caller<'_, HostState>, ptr: i32, len: i32) -> i32 {

--- a/areev-sandbox/src/main.rs
+++ b/areev-sandbox/src/main.rs
@@ -42,7 +42,7 @@ fn run() -> Result<String, String> {
 
     let path = flags.get("module").ok_or(
         "usage: areev-sandbox --module <FILE.wasm> [--fuel N] [--max-pages N] \
-         [--allow-fetch] [--max-response-bytes N]",
+         [--allow-fetch] [--max-response-bytes N] [--allow-blob] [--max-blob-bytes N]",
     )?;
     let wasm = std::fs::read(path).map_err(|e| format!("reading {path}: {e}"))?;
 
@@ -57,6 +57,11 @@ fn run() -> Result<String, String> {
     // Tier C and a module importing `areev::fetch` is refused by name. The
     // engine passes this only for a manifest-pinned `wasm32-areev-io` runtime.
     limits.allow_fetch = flags.contains_key("allow-fetch");
+    limits.allow_blob = flags.contains_key("allow-blob");
+    if let Some(n) = flags.get("max-blob-bytes") {
+        limits.max_blob_bytes =
+            n.parse().map_err(|_| format!("--max-blob-bytes: not a number: {n}"))?;
+    }
     if let Some(n) = flags.get("max-response-bytes") {
         limits.max_response_bytes =
             n.parse().map_err(|_| format!("--max-response-bytes: not a number: {n}"))?;
@@ -75,13 +80,16 @@ fn run() -> Result<String, String> {
     // must stay exactly what the guest emitted. The brokered-call count rides
     // alongside it and only when there were any, so a pure module's stderr is
     // byte-identical to what it printed before 1.6.
+    // Each clause appears only when it happened, so a pure module's stderr
+    // stays byte-identical to what it printed before 1.6 and an http-only
+    // module's stays identical to 1.6.
+    let mut line = format!("areev-sandbox: fuel used {}", outcome.fuel_used);
     if outcome.fetches > 0 {
-        eprintln!(
-            "areev-sandbox: fuel used {}, brokered calls {}",
-            outcome.fuel_used, outcome.fetches
-        );
-    } else {
-        eprintln!("areev-sandbox: fuel used {}", outcome.fuel_used);
+        line.push_str(&format!(", brokered calls {}", outcome.fetches));
     }
+    if outcome.blob_reads > 0 {
+        line.push_str(&format!(", blob reads {}", outcome.blob_reads));
+    }
+    eprintln!("{line}");
     serde_json::to_string(&outcome.output).map_err(|e| e.to_string())
 }

--- a/areev-sandbox/tests/sandbox_tests.rs
+++ b/areev-sandbox/tests/sandbox_tests.rs
@@ -216,6 +216,92 @@ const FETCHER: &str = r#"
       (i32.load (local.get $r)))))
 "#;
 
+/// A guest that asks the host for a stored blob, then emits what came back.
+///
+/// Same shape as [`FETCHER`] — the `blob_get` ABI is one more function, not
+/// one more pattern — so the reply framing here is identical.
+const BLOB_READER: &str = r#"
+(module
+  (import "areev" "emit" (func $emit (param i32 i32)))
+  (import "areev" "blob_get" (func $blob_get (param i32 i32) (result i32)))
+  (memory (export "memory") 1 4)
+  (global $bump (mut i32) (i32.const 2048))
+  (func (export "alloc") (param $n i32) (result i32)
+    (local $p i32)
+    (local.set $p (global.get $bump))
+    (global.set $bump (i32.add (global.get $bump) (local.get $n)))
+    (local.get $p))
+  ;; {"uri":"cas://sha256:00…00"}  — 8 + 13 + 64 + 2 = 87 bytes
+  (data (i32.const 16) "{\22uri\22:\22cas://sha256:0000000000000000000000000000000000000000000000000000000000000000\22}")
+  (func (export "run") (param $ptr i32) (param $len i32)
+    (local $r i32)
+    (local.set $r (call $blob_get (i32.const 16) (i32.const 87)))
+    (if (i32.lt_s (local.get $r) (i32.const 0))
+      (then
+        (call $emit (i32.const 16) (i32.const 0))
+        (return)))
+    (call $emit
+      (i32.add (local.get $r) (i32.const 4))
+      (i32.load (local.get $r)))))
+"#;
+
+/// The blob gate is linked, not guarded — the same treatment `fetch` gets.
+#[test]
+fn a_module_importing_blob_get_is_refused_unless_the_host_allowed_it() {
+    // Refused by NAME at instantiation, before one instruction. And note the
+    // gate is per-capability: allowing `fetch` does not allow `blob_get`, so
+    // the widest existing grant still does not open this door.
+    for limits in [Limits::default(), Limits { allow_fetch: true, ..Default::default() }] {
+        let e = run(&wasm(BLOB_READER), &serde_json::Value::Null, &limits).unwrap_err();
+        match e {
+            SandboxError::ForbiddenImport { ref module, ref name } => {
+                assert_eq!(module, "areev");
+                assert_eq!(name, "blob_get");
+            }
+            other => panic!("got {other}"),
+        }
+    }
+}
+
+/// And the converse: allowing blobs does not allow the network.
+#[test]
+fn allowing_blobs_does_not_link_fetch() {
+    let limits = Limits { allow_blob: true, ..Default::default() };
+    let e = run(&wasm(FETCHER), &serde_json::Value::Null, &limits).unwrap_err();
+    match e {
+        SandboxError::ForbiddenImport { ref name, .. } => assert_eq!(name, "fetch"),
+        other => panic!("got {other}"),
+    }
+}
+
+/// With the capability allowed but no broker wired, a blob read is a typed
+/// error the guest can read — never a silent success, and never a read from
+/// somewhere the host did not name.
+#[test]
+fn a_blob_module_with_no_broker_gets_an_error_it_can_read() {
+    let _guard = env_lock();
+    std::env::remove_var("AREEV_EGRESS_URL");
+    std::env::remove_var("AREEV_EGRESS_TOKEN");
+    let limits = Limits { allow_blob: true, ..Default::default() };
+    let out = run(&wasm(BLOB_READER), &serde_json::Value::Null, &limits).unwrap();
+    let err = out.output["error"].as_str().unwrap_or_default();
+    assert!(err.contains("no broker"), "got {}", out.output);
+    assert_eq!(out.blob_reads, 1, "the attempt is still counted");
+}
+
+/// A pure module is unaffected by the second gate existing, and its outcome
+/// stays byte-identical: `blob_reads` is omitted when zero.
+#[test]
+fn a_pure_module_is_unchanged_by_the_blob_gate() {
+    let limits = Limits { allow_blob: true, ..Default::default() };
+    let out = run(&wasm(ECHO), &serde_json::json!({ "x": 1 }), &limits).unwrap();
+    assert_eq!(out.output, serde_json::json!({ "ok": true }));
+    assert_eq!(out.blob_reads, 0);
+    let json = serde_json::to_value(&out).unwrap();
+    assert!(json.get("blob_reads").is_none(), "omitted when zero: {json}");
+    assert!(json.get("fetches").is_none(), "and so is the 1.6 field: {json}");
+}
+
 /// The same guest, but the host never opted in.
 #[test]
 fn a_module_importing_fetch_is_refused_unless_the_host_allowed_it() {

--- a/crates/areev-cal/src/json_build.rs
+++ b/crates/areev-cal/src/json_build.rs
@@ -1172,11 +1172,16 @@ pub fn build_grain_from_json<S: GrainSink>(
                     for (k, v) in obj {
                         if !matches!(
                             k.as_str(),
-                            "fuel" | "max_pages" | "max_calls" | "max_response_bytes"
+                            "fuel"
+                                | "max_pages"
+                                | "max_calls"
+                                | "max_response_bytes"
+                                | "max_blob_bytes"
                         ) {
                             return Err(AreevError::Validation(format!(
                                 "tool 'runtime_limits' key '{k}' is not recognized; \
-                                 accepted: fuel, max_pages, max_calls, max_response_bytes"
+                                 accepted: fuel, max_pages, max_calls, max_response_bytes, \
+                                 max_blob_bytes"
                             )));
                         }
                         if v.as_u64().is_none() {

--- a/crates/areev-cli/src/main.rs
+++ b/crates/areev-cli/src/main.rs
@@ -2891,7 +2891,7 @@ Nothing was written — apply the snippet yourself (or rerun with your own paths
         }
         // ── areev run: the governed workflow runtime (governed-agents §8) ──
         "run" => {
-            return run_run(m, &ns, &flags, &positional);
+            return run_run(m, &db, &ns, &flags, &positional);
         }
         // ── areev eval: evalsets + the §7.4 gating edge ──
         "eval" => {
@@ -3267,6 +3267,11 @@ fn run_retention(
 /// time-travel / in-flight migration.
 fn run_run(
     m: Areev,
+    // The memory's own path, threaded in so the broker can serve this run's
+    // CAS blobs to a declared capability tool (#106). Taken from the resolved
+    // `--db` rather than from the open handle, because the lock-free blob read
+    // deliberately works from the path and never the handle.
+    db: &str,
     ns: &str,
     flags: &HashMap<String, String>,
     positional: &[String],
@@ -3287,6 +3292,13 @@ fn run_run(
     let egress: Option<areev_run::EgressHandle> = match run_stack::build_egress(flags)? {
         None => None,
         Some(broker) => {
+            // The other mediated door (#106): a module that declared
+            // `{"blob": {"read": true}}` reads stored bytes through this same
+            // broker, on this same token. Wired from the run's own memory
+            // path, and by path rather than by handle — `read_blob_offline`
+            // takes no lock, so serving an attachment never contends with the
+            // driver's exclusive hold on the file it came from.
+            broker.serve_blobs(db);
             let broker = Arc::new(broker);
             broker_guard = Some(Arc::clone(&broker));
             Some(areev_run::EgressHandle::new(broker))

--- a/crates/areev-core/src/types/capability.rs
+++ b/crates/areev-core/src/types/capability.rs
@@ -302,10 +302,22 @@ pub struct HttpCapability {
     headers: BTreeSet<String>,
 }
 
+/// The `blob` capability: may a module read the memory's stored bytes (#106).
+///
+/// Read-only, and only by content address. There is no enumeration, no write,
+/// and no namespace access — a module can fetch bytes it was handed a `cas://`
+/// reference to and nothing more, so the guarantee that a module cannot browse
+/// the memory survives having this at all.
+#[derive(Debug, Clone, Default)]
+pub struct BlobCapability {
+    read: bool,
+}
+
 /// Everything one Definition declares.
 #[derive(Debug, Clone, Default)]
 pub struct Declaration {
     http: Option<HttpCapability>,
+    blob: Option<BlobCapability>,
 }
 
 impl Declaration {
@@ -339,9 +351,15 @@ impl Declaration {
                     }
                     out.http = Some(parse_http(body)?);
                 }
+                "blob" => {
+                    if out.blob.is_some() {
+                        return Err("'capabilities' declares 'blob' more than once".into());
+                    }
+                    out.blob = Some(parse_blob(body)?);
+                }
                 other => {
                     return Err(format!(
-                        "'capabilities' entry '{other}' is not recognized; accepted: http"
+                        "'capabilities' entry '{other}' is not recognized; accepted: http, blob"
                     ))
                 }
             }
@@ -352,6 +370,15 @@ impl Declaration {
     /// Does this declaration admit the `areev::fetch` import at all?
     pub fn declares_http(&self) -> bool {
         self.http.is_some()
+    }
+
+    /// Does this declaration admit the `areev::blob_get` import at all (#106)?
+    ///
+    /// `{"blob": {"read": false}}` declares the capability and then declines
+    /// it, which is a module saying it wants no blob access — the import is
+    /// not linked, exactly as if the entry were absent.
+    pub fn declares_blob_read(&self) -> bool {
+        self.blob.as_ref().is_some_and(|b| b.read)
     }
 
     /// May the module make this call?
@@ -493,6 +520,29 @@ fn parse_http(body: &serde_json::Value) -> Result<HttpCapability> {
     Ok(HttpCapability { hosts, methods, path_prefixes, credentials, headers })
 }
 
+fn parse_blob(body: &serde_json::Value) -> Result<BlobCapability> {
+    let obj = body
+        .as_object()
+        .ok_or("'capabilities' entry 'blob' must be an object")?;
+    for k in obj.keys() {
+        if k.as_str() != "read" {
+            return Err(format!(
+                "'capabilities.blob' key '{k}' is not recognized; accepted: read"
+            ));
+        }
+    }
+    // Spelled as an explicit `read: true` rather than an empty object, so the
+    // declaration says what it wants rather than implying it, and so a future
+    // `write` has an obvious place to go without changing this shape.
+    let read = match obj.get("read") {
+        None => return Err("'capabilities.blob' must name 'read'".into()),
+        Some(v) => v
+            .as_bool()
+            .ok_or("'capabilities.blob.read' must be a boolean")?,
+    };
+    Ok(BlobCapability { read })
+}
+
 fn string_list(v: Option<&serde_json::Value>, field: &str) -> Result<Vec<String>> {
     let Some(v) = v.filter(|v| !v.is_null()) else {
         return Ok(Vec::new());
@@ -630,6 +680,59 @@ mod tests {
                 "'{name}' is refused and the message points at credentials: {e}"
             );
         }
+    }
+
+    #[test]
+    fn the_blob_capability_is_declared_explicitly() {
+        let d = decl(json!([{"blob": {"read": true}}]));
+        assert!(d.declares_blob_read());
+        // …and declines just as explicitly. `read: false` is a module saying
+        // it wants none, which must not link the import.
+        assert!(!decl(json!([{"blob": {"read": false}}])).declares_blob_read());
+        // The absence of the capability is not permission, same as http.
+        assert!(!Declaration::default().declares_blob_read());
+        assert!(!gmail().declares_blob_read());
+    }
+
+    #[test]
+    fn the_two_capabilities_are_independent() {
+        // The tool #106 exists for — parsing an attachment that arrived from
+        // outside — wants stored bytes and NO network at all. Declaring blob
+        // must not imply http, or the safest module would get the widest gate.
+        let blob_only = decl(json!([{"blob": {"read": true}}]));
+        assert!(blob_only.declares_blob_read());
+        assert!(!blob_only.declares_http());
+        assert_eq!(
+            blob_only.permits("https://anywhere.example/", "GET", None, &[]),
+            Err(CapabilityDenied::Undeclared { kind: "http" })
+        );
+
+        let both = decl(json!([
+            {"http": {"hosts": ["https://api.example.com"], "methods": ["POST"]}},
+            {"blob": {"read": true}}
+        ]));
+        assert!(both.declares_http() && both.declares_blob_read());
+    }
+
+    #[test]
+    fn a_malformed_blob_capability_is_refused() {
+        for bad in [
+            json!([{"blob": {}}]),                       // says nothing
+            json!([{"blob": {"read": "yes"}}]),          // not a boolean
+            json!([{"blob": {"read": true, "write": true}}]), // no write, ever
+            json!([{"blob": true}]),                     // not an object
+        ] {
+            assert!(
+                Declaration::parse(&bad).is_err(),
+                "{bad} must be refused rather than read loosely"
+            );
+        }
+        // And declared twice is a contradiction, not a last-one-wins.
+        assert!(Declaration::parse(&json!([
+            {"blob": {"read": true}},
+            {"blob": {"read": false}}
+        ]))
+        .is_err());
     }
 
     #[test]

--- a/crates/areev-core/src/types/capability.rs
+++ b/crates/areev-core/src/types/capability.rs
@@ -179,6 +179,64 @@ pub fn url_path(url: &str) -> String {
     }
 }
 
+/// Header names the broker owns; a module may never set them (#105).
+///
+/// `Authorization` and `Proxy-Authorization` ARE the credential channel: the
+/// whole point of brokering is that the module names a credential and never
+/// holds one, so letting it write the header the credential arrives in hands
+/// back exactly the surface #101 closed on the response side. `Cookie` is
+/// ambient authority spelled differently. `Host` re-targets the request
+/// *after* the allowlist has already judged the URL, turning a permitted
+/// destination into a different one at the socket.
+///
+/// Lowercase, because HTTP field names are case-insensitive and a check that
+/// is not would be bypassed by `authorization`.
+pub const BROKER_OWNED_HEADERS: [&str; 4] =
+    ["authorization", "cookie", "host", "proxy-authorization"];
+
+/// Is this a header the broker reserves for itself? Case-insensitive.
+pub fn is_broker_owned_header(name: &str) -> bool {
+    let lower = name.trim().to_ascii_lowercase();
+    BROKER_OWNED_HEADERS.contains(&lower.as_str())
+}
+
+/// RFC 9110 `field-name` (a `token`). Refusing anything else at parse time is
+/// what keeps `\r\n` out of a header name — header injection is the failure
+/// this forecloses, and a legitimate API header has no business containing a
+/// separator, a space, or a control byte.
+pub fn is_valid_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+/// RFC 9110 `field-value`: visible ASCII, space and tab. The same injection
+/// argument as [`is_valid_header_name`] — a CR or LF here splits one header
+/// into two, and the second one is the attacker's.
+pub fn is_valid_header_value(value: &str) -> bool {
+    value
+        .bytes()
+        .all(|b| b == b'\t' || (0x20..=0x7e).contains(&b) || b >= 0x80)
+}
+
 /// Why a declared capability refused a call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CapabilityDenied {
@@ -192,6 +250,8 @@ pub enum CapabilityDenied {
     Method { method: String },
     /// The credential is outside the declared set.
     Credential { name: String },
+    /// The request header is outside the declared set (#105).
+    Header { name: String },
 }
 
 impl std::fmt::Display for CapabilityDenied {
@@ -217,6 +277,10 @@ impl std::fmt::Display for CapabilityDenied {
                 f,
                 "asked for credential '{name}', which its declared capability does not name"
             ),
+            CapabilityDenied::Header { name } => write!(
+                f,
+                "tried to set header '{name}', which its declared capability does not name"
+            ),
         }
     }
 }
@@ -232,6 +296,10 @@ pub struct HttpCapability {
     path_prefixes: Vec<String>,
     /// Credential names this module may ask for. Empty = none.
     credentials: BTreeSet<String>,
+    /// Request header names this module may set, lowercased (#105). Empty =
+    /// none, the same deny-by-default reading `credentials` gets. Never
+    /// contains a [`BROKER_OWNED_HEADERS`] name — that is refused at parse.
+    headers: BTreeSet<String>,
 }
 
 /// Everything one Definition declares.
@@ -290,11 +358,17 @@ impl Declaration {
     ///
     /// The DECLARED half of `declared ∩ host-granted`; the broker checks the
     /// host grant separately and both must pass.
+    /// Header names this declaration admits, lowercased. Empty = none.
+    pub fn permitted_headers(&self) -> impl Iterator<Item = &str> {
+        self.http.iter().flat_map(|h| h.headers.iter().map(String::as_str))
+    }
+
     pub fn permits(
         &self,
         url: &str,
         method: &str,
         credential: Option<&str>,
+        header_names: &[String],
     ) -> std::result::Result<(), CapabilityDenied> {
         let Some(http) = &self.http else {
             return Err(CapabilityDenied::Undeclared { kind: "http" });
@@ -330,6 +404,11 @@ impl Declaration {
                 return Err(CapabilityDenied::Credential { name: name.to_string() });
             }
         }
+        for name in header_names {
+            if !http.headers.contains(&name.trim().to_ascii_lowercase()) {
+                return Err(CapabilityDenied::Header { name: name.to_string() });
+            }
+        }
         Ok(())
     }
 }
@@ -339,10 +418,13 @@ fn parse_http(body: &serde_json::Value) -> Result<HttpCapability> {
         .as_object()
         .ok_or("'capabilities' entry 'http' must be an object")?;
     for k in obj.keys() {
-        if !matches!(k.as_str(), "hosts" | "methods" | "path_prefixes" | "credentials") {
+        if !matches!(
+            k.as_str(),
+            "hosts" | "methods" | "path_prefixes" | "credentials" | "headers"
+        ) {
             return Err(format!(
                 "'capabilities.http' key '{k}' is not recognized; \
-                 accepted: hosts, methods, path_prefixes, credentials"
+                 accepted: hosts, methods, path_prefixes, credentials, headers"
             ));
         }
     }
@@ -387,7 +469,28 @@ fn parse_http(body: &serde_json::Value) -> Result<HttpCapability> {
     let credentials: BTreeSet<String> =
         string_list(obj.get("credentials"), "credentials")?.into_iter().collect();
 
-    Ok(HttpCapability { hosts, methods, path_prefixes, credentials })
+    // Header names are declared, validated, and lowercased here so that every
+    // height reads them identically — and so a module that tries to declare
+    // the credential channel is refused at WRITE time rather than on the run
+    // someone needed it for.
+    let mut headers = BTreeSet::new();
+    for h in string_list(obj.get("headers"), "headers")? {
+        let name = h.trim();
+        if !is_valid_header_name(name) {
+            return Err(format!(
+                "'capabilities.http.headers' entry '{name}' is not a valid HTTP header name"
+            ));
+        }
+        if is_broker_owned_header(name) {
+            return Err(format!(
+                "'capabilities.http.headers' entry '{name}' is set by the broker and cannot be \
+                 declared; name a credential instead"
+            ));
+        }
+        headers.insert(name.to_ascii_lowercase());
+    }
+
+    Ok(HttpCapability { hosts, methods, path_prefixes, credentials, headers })
 }
 
 fn string_list(v: Option<&serde_json::Value>, field: &str) -> Result<Vec<String>> {
@@ -431,7 +534,7 @@ mod tests {
                 "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
                 "POST",
                 Some("gmail")
-            )
+            , &[])
             .is_ok());
     }
 
@@ -441,7 +544,7 @@ mod tests {
         let d = Declaration::default();
         assert!(!d.declares_http());
         assert_eq!(
-            d.permits("https://anywhere.example/", "GET", None),
+            d.permits("https://anywhere.example/", "GET", None, &[]),
             Err(CapabilityDenied::Undeclared { kind: "http" })
         );
     }
@@ -450,23 +553,99 @@ mod tests {
     fn the_host_the_path_the_method_and_the_credential_are_each_a_gate() {
         let d = gmail();
         assert!(matches!(
-            d.permits("https://evil.example/gmail/v1/users/me/x", "POST", Some("gmail")),
+            d.permits("https://evil.example/gmail/v1/users/me/x", "POST", Some("gmail"), &[]),
             Err(CapabilityDenied::Host { .. })
         ));
         // The exfiltration case a host-only grant cannot express: an ALLOWED
         // host, a POST it is allowed to make, at an endpoint it never declared.
         assert!(matches!(
-            d.permits("https://gmail.googleapis.com/upload/drive/v3/files", "POST", Some("gmail")),
+            d.permits("https://gmail.googleapis.com/upload/drive/v3/files", "POST", Some("gmail"), &[]),
             Err(CapabilityDenied::Path { .. })
         ));
         assert!(matches!(
-            d.permits("https://gmail.googleapis.com/gmail/v1/users/me/x", "DELETE", Some("gmail")),
+            d.permits("https://gmail.googleapis.com/gmail/v1/users/me/x", "DELETE", Some("gmail"), &[]),
             Err(CapabilityDenied::Method { .. })
         ));
         assert!(matches!(
-            d.permits("https://gmail.googleapis.com/gmail/v1/users/me/x", "POST", Some("sheets")),
+            d.permits("https://gmail.googleapis.com/gmail/v1/users/me/x", "POST", Some("sheets"), &[]),
             Err(CapabilityDenied::Credential { .. })
         ));
+        // And the fifth (#105): a header the declaration does not name.
+        assert!(matches!(
+            d.permits(
+                "https://gmail.googleapis.com/gmail/v1/users/me/x",
+                "POST",
+                Some("gmail"),
+                &["X-Goog-User-Project".to_string()]
+            ),
+            Err(CapabilityDenied::Header { .. })
+        ));
+    }
+
+    #[test]
+    fn declaring_no_headers_means_none() {
+        // Same deny-by-default reading `credentials` and `methods` get: the
+        // gate is "did you say so", not "is it harmless".
+        let d = gmail();
+        assert!(matches!(
+            d.permits("https://gmail.googleapis.com/gmail/v1/users/me/x", "POST", None, &["X-Any".into()]),
+            Err(CapabilityDenied::Header { .. })
+        ));
+    }
+
+    #[test]
+    fn a_declared_header_matches_case_insensitively() {
+        // HTTP field names are case-insensitive, so a declaration that only
+        // matched its own spelling would refuse the same header written
+        // differently — and, worse, a check built the other way round could be
+        // walked past with a re-cased name.
+        let d = decl(json!([{"http": {
+            "hosts": ["https://sheets.googleapis.com"],
+            "methods": ["POST"],
+            "headers": ["X-Goog-User-Project"]
+        }}]));
+        for spelling in ["X-Goog-User-Project", "x-goog-user-project", "X-GOOG-USER-PROJECT"] {
+            assert!(
+                d.permits("https://sheets.googleapis.com/v4/x", "POST", None, &[spelling.to_string()])
+                    .is_ok(),
+                "'{spelling}' names the same header"
+            );
+        }
+    }
+
+    #[test]
+    fn a_declaration_cannot_name_a_header_the_broker_owns() {
+        // Refused at PARSE, so a module that tries is unwritable rather than
+        // writable-and-refused-at-runtime. The credential channel is not
+        // something a declaration gets to reach into, and the error says what
+        // to do instead.
+        for name in ["Authorization", "authorization", "Cookie", "Host", "Proxy-Authorization"] {
+            let e = Declaration::parse(&json!([{"http": {
+                "hosts": ["https://api.example.com"],
+                "headers": [name]
+            }}]))
+            .unwrap_err();
+            assert!(
+                e.contains("set by the broker") && e.contains("credential"),
+                "'{name}' is refused and the message points at credentials: {e}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_malformed_header_name_is_refused_at_parse() {
+        // The injection shapes, killed where a declaration is first read rather
+        // than at the socket where a CR would split one request into two.
+        for bad in ["X-Bad Name", "X:Colon", "X\r\nInjected", "", "X\u{0}Null"] {
+            assert!(
+                Declaration::parse(&json!([{"http": {
+                    "hosts": ["https://api.example.com"],
+                    "headers": [bad]
+                }}]))
+                .is_err(),
+                "{bad:?} is not a valid header name"
+            );
+        }
     }
 
     #[test]
@@ -485,7 +664,7 @@ mod tests {
         ] {
             assert!(
                 matches!(
-                    d.permits(evasive, "POST", Some("gmail")),
+                    d.permits(evasive, "POST", Some("gmail"), &[]),
                     Err(CapabilityDenied::Path { .. })
                 ),
                 "{evasive} must not pass the prefix"
@@ -494,7 +673,7 @@ mod tests {
         // And a benign dotted filename is NOT collateral damage: only whole
         // dot-SEGMENTS and encoded dots are evasive.
         assert!(d
-            .permits("https://gmail.googleapis.com/gmail/v1/users/me/msg.2.json", "POST", Some("gmail"))
+            .permits("https://gmail.googleapis.com/gmail/v1/users/me/msg.2.json", "POST", Some("gmail"), &[])
             .is_ok());
     }
 
@@ -505,7 +684,7 @@ mod tests {
                 "https://gmail.googleapis.com/upload?x=/gmail/v1/users/me/",
                 "POST",
                 Some("gmail")
-            ),
+            , &[]),
             Err(CapabilityDenied::Path { .. })
         ));
     }
@@ -514,9 +693,9 @@ mod tests {
     fn declaring_no_methods_means_read_only() {
         // Same reading as a CallerGrant: naming nothing is not naming everything.
         let d = decl(json!([{"http": {"hosts": ["https://api.example.com"]}}]));
-        assert!(d.permits("https://api.example.com/x", "GET", None).is_ok());
+        assert!(d.permits("https://api.example.com/x", "GET", None, &[]).is_ok());
         assert!(matches!(
-            d.permits("https://api.example.com/x", "POST", None),
+            d.permits("https://api.example.com/x", "POST", None, &[]),
             Err(CapabilityDenied::Method { .. })
         ));
     }
@@ -525,7 +704,7 @@ mod tests {
     fn declaring_no_credentials_means_none() {
         let d = decl(json!([{"http": {"hosts": ["https://api.example.com"]}}]));
         assert!(matches!(
-            d.permits("https://api.example.com/x", "GET", Some("anything")),
+            d.permits("https://api.example.com/x", "GET", Some("anything"), &[]),
             Err(CapabilityDenied::Credential { .. })
         ));
     }
@@ -565,10 +744,10 @@ mod tests {
 
         // And the wildcard reads the same way it does in an allowlist.
         let d = decl(json!([{"http": {"hosts": ["https://*.example.com"]}}]));
-        assert!(d.permits("https://api.example.com/x", "GET", None).is_ok());
-        assert!(d.permits("https://example.com/x", "GET", None).is_err(), "the apex is not a subdomain");
-        assert!(d.permits("https://evil-example.com/x", "GET", None).is_err(), "lookalike");
-        assert!(d.permits("https://api.example.com@evil.com/x", "GET", None).is_err(), "userinfo");
+        assert!(d.permits("https://api.example.com/x", "GET", None, &[]).is_ok());
+        assert!(d.permits("https://example.com/x", "GET", None, &[]).is_err(), "the apex is not a subdomain");
+        assert!(d.permits("https://evil-example.com/x", "GET", None, &[]).is_err(), "lookalike");
+        assert!(d.permits("https://api.example.com@evil.com/x", "GET", None, &[]).is_err(), "userinfo");
     }
 
     #[test]

--- a/crates/areev-core/src/types/tool.rs
+++ b/crates/areev-core/src/types/tool.rs
@@ -226,8 +226,12 @@ pub struct Tool {
     /// [ { "http": { "hosts": ["https://gmail.googleapis.com"],
     ///               "methods": ["POST"],
     ///               "path_prefixes": ["/gmail/v1/users/me/"],
-    ///               "credentials": ["gmail"] } } ]
+    ///               "credentials": ["gmail"],
+    ///               "headers": ["X-Goog-User-Project"] } } ]
     /// ```
+    ///
+    /// `headers` (#105) names the non-credential request headers the module
+    /// may set; a name the broker owns is refused at write time.
     ///
     /// ## A declaration, never an authorization
     ///

--- a/crates/areev-run-core/src/error.rs
+++ b/crates/areev-run-core/src/error.rs
@@ -69,8 +69,10 @@ pub enum RunError {
     LeaseLost { run_id: String },
     /// RUN-E022 — a host command's outbound call was refused: a destination
     /// outside the run's allowlist, a method its grant does not permit, a
-    /// credential it may not spend, or a request header it may not set —
-    /// undeclared, or one the broker owns (#105).
+    /// credential it may not spend, a request header it may not set —
+    /// undeclared, or one the broker owns (#105) — or a CAS blob read without
+    /// the `blob` capability (#106). One code for "the broker said no",
+    /// whichever of its doors was knocked on.
     ///
     /// The trigger evaluator reports the same condition as `TRG-E009`, the way
     /// a storage failure is `TRG-E010` there and `RUN-E020` here. One

--- a/crates/areev-run-core/src/error.rs
+++ b/crates/areev-run-core/src/error.rs
@@ -68,8 +68,9 @@ pub enum RunError {
     /// `RetentionRefused` and codes are append-only.
     LeaseLost { run_id: String },
     /// RUN-E022 — a host command's outbound call was refused: a destination
-    /// outside the run's allowlist, a method its grant does not permit, or a
-    /// credential it may not spend.
+    /// outside the run's allowlist, a method its grant does not permit, a
+    /// credential it may not spend, or a request header it may not set —
+    /// undeclared, or one the broker owns (#105).
     ///
     /// The trigger evaluator reports the same condition as `TRG-E009`, the way
     /// a storage failure is `TRG-E010` there and `RUN-E020` here. One

--- a/crates/areev-run/CLAUDE.md
+++ b/crates/areev-run/CLAUDE.md
@@ -161,11 +161,31 @@ evidence. Responding and resuming are separate acts.
   `areev-cal`'s write path sits below this crate and must reach the same parser,
   or a tool becomes writable and then unrunnable. `egress::AllowedHost` is a
   re-export of core's for the same reason.
-- **Two audit kinds, different dedup.** `refusals()` dedups on
-  `(caller, destination, reason)` — a policy fact. `calls()` does not — an
-  effect, and forty are forty. Both journal at the superstep boundary
-  (`write_egress_refusal` / `write_egress_call`), neither is a journal entry, so
-  `verify` is byte-identical with or without a broker.
+- **Blob reads go through the broker, not the sandbox** (#106) — `POST /blob`
+  on the same port and token, gated on `Declaration::declares_blob_read()` plus
+  `Broker::serve_blobs(db_path)`. The obvious design (sandbox reads the
+  `.blobs` sidecar itself) fails four ways: the subprocess is handed no memory
+  path under `ClearExcept`; `areev-sandbox` cannot take `areev-store` (the
+  5-dep standalone decision) so it would need its own `cas://` parser and
+  SHA-256; the sidecar does not exist on Postgres; and — decisively — a read
+  done in the subprocess has NO channel back to the driver to be journaled
+  (stdout is the guest's result, the fuel line is prose). Routing it here makes
+  the guarantee "neither a socket nor a file descriptor" and gets journaling on
+  the existing superstep drain. Answers RAW BYTES on 200 (a blob is binary;
+  base64-in-JSON would tax every guest with a decoder) and JSON on every error,
+  told apart by status — never by sniffing a payload that may start with `{`.
+  Embedded-only: a Postgres path is a typed 501, not a misleading "missing".
+- **`--allow-blob` comes off the DECLARATION, `--allow-fetch` off the runtime.**
+  Deliberate asymmetry: egress has a host-side grant that narrows the runtime's
+  permission afterwards, so that flag can be broad. A blob read has no second
+  key, so the declaration must be what the flag derives from — otherwise every
+  capability module silently gains the import.
+- **Three audit kinds, two dedup rules.** `refusals()` dedups on
+  `(caller, destination, reason)` — a policy fact. `calls()` and `blob_reads()`
+  do not — effects, and forty are forty. All three journal at the superstep
+  boundary (`write_egress_refusal` / `write_egress_call` / `write_blob_read`),
+  none is a journal entry, so `verify` is byte-identical with or without a
+  broker.
 - **`PinnedTool.capabilities`** freezes the declaration beside `runtime`, so a
   mid-run supersession cannot widen reach. `runtime_allows_capabilities` gates
   the `--allow-fetch` flag off the MANIFEST, never off the module.

--- a/crates/areev-run/CLAUDE.md
+++ b/crates/areev-run/CLAUDE.md
@@ -141,6 +141,22 @@ evidence. Responding and resuming are separate acts.
   `--tool-cmd` tool, every connector) is unaffected. The call budget is spent
   BEFORE dispatch so a refused call still costs one — otherwise a module probes
   the policy for free.
+- **Guest request headers** (#105) — `EgressRequest.headers` carries the
+  non-credential headers enterprise APIs demand (`X-Goog-User-Project` and
+  friends). Three rules, each load-bearing: (1) broker-owned names
+  (`Authorization`/`Cookie`/`Host`/`Proxy-Authorization`, plus whatever header
+  a resolved `Credential::Header` rides in — known only AFTER resolution, so
+  that check lives there) are refused, and refused *free*, because the answer
+  is identical for every caller and so leaks no policy — the spend-first rule
+  exists for answers that differ; (2) malformed names and CR/LF values are
+  `400`, not `403` — injection is malformed, not merely denied; (3) guest
+  headers are a SEPARATE vec from `credential_headers` all the way into
+  `perform`, because the reflection scrub iterates the credential vec and
+  scrubbing a guest-supplied string out of a response body would corrupt it.
+  They ride exactly as far as the credential (one `send_credential` boolean
+  gates both), which is why `EgressCall.headers` can be journaled under
+  `credential_sent` — if that ever becomes two flags, this becomes two too.
+  Values ARE journaled, unlike the credential: the caller chose them.
 - **The vocabulary lives in `areev_core::types::capability`**, not here:
   `areev-cal`'s write path sits below this crate and must reach the same parser,
   or a tool becomes writable and then unrunnable. `egress::AllowedHost` is a

--- a/crates/areev-run/src/broker.rs
+++ b/crates/areev-run/src/broker.rs
@@ -18,7 +18,8 @@
 //!
 //! ```json
 //! { "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages",
-//!   "method": "GET", "credential": "gmail" }
+//!   "method": "GET", "credential": "gmail",
+//!   "headers": { "X-Goog-User-Project": "my-project" } }
 //! ```
 //!
 //! and we answer with the response. The cost is real and worth stating: a
@@ -270,6 +271,13 @@ pub struct EgressCall {
     pub response_bytes: usize,
     /// The credential NAME that was attached, never a value.
     pub credential: Option<String>,
+    /// Non-credential request headers the caller set (#105), name AND value.
+    ///
+    /// Recorded in full, unlike the credential and unlike bodies: the caller
+    /// supplied these, so they carry nothing the caller did not already know,
+    /// and "it sent these four requests with these headers" is strictly more
+    /// evidence than "it sent these four requests".
+    pub headers: BTreeMap<String, String>,
 }
 
 /// Per-caller ceilings on a capability tool's mediated egress.
@@ -532,6 +540,19 @@ struct EgressRequest {
     /// *what* — it cannot name a value it was not given.
     credential: Option<String>,
     body: Option<String>,
+    /// Non-credential request headers the caller wants set (#105).
+    ///
+    /// The enterprise APIs capability tools are pitched at need one:
+    /// `X-Goog-User-Project` on every Google call made with user credentials,
+    /// `anthropic-version`, `x-ms-version`, a tenant id. None of them is a
+    /// secret — the caller supplies the value, so it is guest-visible by
+    /// construction, which is why these may be journaled verbatim while a
+    /// credential may only ever be journaled by name.
+    ///
+    /// A `BTreeMap` deliberately: one value per name, ordered, so the journal
+    /// is deterministic and a caller cannot smuggle a second `X-Foo` past a
+    /// check that looked at the first.
+    headers: BTreeMap<String, String>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -638,6 +659,61 @@ fn serve_one(
         }
     };
 
+    // Guest headers, validated before anything else looks at them (#105).
+    //
+    // Two refusals with different characters. A malformed name or value is a
+    // CLIENT error — the same shape as unparseable JSON — and a value carrying
+    // CR/LF is header injection, which must die here rather than at the socket
+    // where it would split one request into two.
+    //
+    // A broker-owned name is a policy refusal, and deliberately a FREE one:
+    // the "probing is not free" rule that spends a call before the declaration
+    // check exists because those answers differ per caller and so leak the
+    // policy. "May I write the Authorization header?" has exactly one answer,
+    // no, for every caller that ever asks — so answering it without charge
+    // reveals nothing, and refusing early keeps the credential channel's
+    // guarantee independent of budgets, declarations, and grants.
+    for (name, value) in &req.headers {
+        if !areev_core::types::capability::is_valid_header_name(name)
+            || !areev_core::types::capability::is_valid_header_value(value)
+        {
+            return respond(
+                &mut stream,
+                400,
+                &serde_json::json!({
+                    "error": format!("header '{name}' is not a valid HTTP header name/value")
+                })
+                .to_string(),
+            );
+        }
+        if areev_core::types::capability::is_broker_owned_header(name) {
+            note_refusal(
+                refusals,
+                EgressRefusal {
+                    caller: caller.clone(),
+                    destination: req.url.clone(),
+                    reason: format!("tried to set the broker-owned header '{name}'"),
+                },
+            );
+            return respond(
+                &mut stream,
+                403,
+                &serde_json::json!({
+                    "error": format!(
+                        "caller '{caller}' tried to set header '{name}', which the broker owns — \
+                         name a credential instead; the broker attaches it and the caller never \
+                         holds one"
+                    ),
+                    "code": refusal_code
+                })
+                .to_string(),
+            );
+        }
+    }
+    let guest_headers: Vec<(String, String)> =
+        req.headers.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    let guest_header_names: Vec<String> = req.headers.keys().cloned().collect();
+
     if let Err(e) = policy.permits(&req.url) {
         note_refusal(
             refusals,
@@ -702,9 +778,12 @@ fn serve_one(
                     );
                 }
                 d.calls_made += 1;
-                if let Err(denied) =
-                    d.declaration.permits(&req.url, &method, req.credential.as_deref())
-                {
+                if let Err(denied) = d.declaration.permits(
+                    &req.url,
+                    &method,
+                    req.credential.as_deref(),
+                    &guest_header_names,
+                ) {
                     drop(guard);
                     note_refusal(
                         refusals,
@@ -882,6 +961,40 @@ fn serve_one(
         }
     }
 
+    // The static list of broker-owned names is not the whole credential
+    // channel: `Credential::Header` lets an operator carry a secret in ANY
+    // header — `X-Api-Key`, `apikey`, whatever the upstream wants — and that
+    // name is known only here, after resolution, because it is per-credential
+    // host configuration rather than a constant. A guest header colliding with
+    // it would be a guest writing a value into the exact slot the broker fills
+    // with a secret. Refused for the same reason and with the same words
+    // (#105).
+    for (guest_name, _) in &guest_headers {
+        let g = guest_name.trim().to_ascii_lowercase();
+        if headers.iter().any(|(k, _)| k.trim().to_ascii_lowercase() == g) {
+            note_refusal(
+                refusals,
+                EgressRefusal {
+                    caller: caller.clone(),
+                    destination: req.url.clone(),
+                    reason: format!("tried to set the broker-owned header '{guest_name}'"),
+                },
+            );
+            return respond(
+                &mut stream,
+                403,
+                &serde_json::json!({
+                    "error": format!(
+                        "caller '{caller}' tried to set header '{guest_name}', which carries a \
+                         configured credential on this host — name the credential instead"
+                    ),
+                    "code": refusal_code
+                })
+                .to_string(),
+            );
+        }
+    }
+
     if !matches!(method.as_str(), "GET" | "HEAD" | "DELETE" | "POST" | "PUT" | "PATCH") {
         return respond(
             &mut stream,
@@ -895,6 +1008,7 @@ fn serve_one(
         &method,
         req.body.as_deref(),
         &headers,
+        &guest_headers,
         policy,
         grant,
         capability.as_ref().map(|(_, d)| d),
@@ -936,6 +1050,16 @@ fn serve_one(
                     // destination it never touched is a false record a DSAR or
                     // reviewer would read as fact.
                     credential: if credential_sent { req.credential.clone() } else { None },
+                    // Recorded on the same "what actually rode the final
+                    // request" rule as the credential, and for the same
+                    // reason: guest headers travel exactly as far as the
+                    // credential does (see `dispatch`), so a chain that left
+                    // its origin sent neither.
+                    headers: if credential_sent {
+                        req.headers.clone()
+                    } else {
+                        BTreeMap::new()
+                    },
                 },
             );
             respond(
@@ -1023,6 +1147,13 @@ enum Dispatched {
     /// `credential_sent` is whether the credential actually rode the FINAL
     /// request: a cross-origin redirect drops it, so the audit must not claim a
     /// secret reached a destination it never did.
+    ///
+    /// It answers the same question for the caller's own headers (#105), which
+    /// is not a coincidence to be maintained by hand: `perform` gates both on
+    /// one boolean, so "the credential rode" and "the guest headers rode" are
+    /// the same fact. If they ever stop being the same fact, this needs to
+    /// become two flags — journaling a header that did not travel is the same
+    /// false record as journaling a credential that did not.
     Answered { status: u16, body: String, final_url: String, redirects: u32, credential_sent: bool },
     /// A hop was refused by policy; already recorded in `refusals`.
     Refused { detail: String },
@@ -1081,6 +1212,18 @@ enum Dispatched {
 /// chooses. The hop check passes no credential name: credential *membership*
 /// was settled on the initial request, and whether the header actually rides
 /// a given hop is the same-origin rule's decision, not the declaration's.
+/// Guest headers (#105) are settled the same way and for the same reason.
+///
+/// ## Guest headers travel exactly as far as the credential
+///
+/// One rule, not two: a header the caller attached rides while
+/// `send_credential` holds and is dropped the moment the chain leaves its
+/// origin. These are not secrets — the caller chose the values — so the
+/// argument is not confidentiality but intent: `X-Goog-User-Project` was
+/// meant for the host the caller named, and a redirect off-origin is exactly
+/// where "meant for" stops being true. Sending a project id, a tenant, or an
+/// API-version header onward to a destination an intermediary picked would be
+/// the broker volunteering the caller's context to a stranger.
 ///
 /// `max_response_bytes` bounds the READ of the final body, not just its
 /// acceptance — `Some(n)` reads at most `n + 1` bytes, so an upstream cannot
@@ -1091,6 +1234,7 @@ fn dispatch(
     start_method: &str,
     body: Option<&str>,
     credential_headers: &[(String, String)],
+    guest_headers: &[(String, String)],
     policy: &EgressPolicy,
     grant: &CallerGrant,
     declaration: Option<&Declaration>,
@@ -1154,7 +1298,15 @@ fn dispatch(
         // `left_origin` latch is what makes an A→B→A bounce fail closed).
         let send_credential =
             hops == 0 || (!left_origin && crate::egress::same_origin(start_url, &url));
-        let result = perform(&agent, &method, &url, body.as_deref(), credential_headers, send_credential);
+        let result = perform(
+            &agent,
+            &method,
+            &url,
+            body.as_deref(),
+            credential_headers,
+            guest_headers,
+            send_credential,
+        );
 
         let mut resp = match result {
             Ok(r) => r,
@@ -1279,7 +1431,7 @@ fn dispatch(
                     ),
                 };
             }
-            if let Err(denied) = d.permits(&next_url, &next_method, None) {
+            if let Err(denied) = d.permits(&next_url, &next_method, None, &[]) {
                 note_refusal(
                     refusals,
                     EgressRefusal {
@@ -1357,9 +1509,18 @@ fn perform(
     url: &str,
     body: Option<&str>,
     credential_headers: &[(String, String)],
+    guest_headers: &[(String, String)],
     send_credential: bool,
 ) -> std::result::Result<ureq::http::Response<ureq::Body>, ureq::Error> {
-    let headers: &[(String, String)] = if send_credential { credential_headers } else { &[] };
+    // Both sets ride or neither does — see `dispatch`'s "travel exactly as far
+    // as the credential". The credential goes on LAST so that even if the two
+    // ever named the same header, the broker's value is the one that survives;
+    // the guest cannot reach these names at all (`is_broker_owned_header`, and
+    // a `Credential::Header` name is refused beside it), so this is a belt on
+    // top of braces rather than the guarantee itself.
+    let credential_headers: &[(String, String)] =
+        if send_credential { credential_headers } else { &[] };
+    let guest_headers: &[(String, String)] = if send_credential { guest_headers } else { &[] };
     match method {
         "POST" | "PUT" | "PATCH" => {
             let mut b = match method {
@@ -1367,7 +1528,7 @@ fn perform(
                 "PUT" => agent.put(url),
                 _ => agent.patch(url),
             };
-            for (k, v) in headers {
+            for (k, v) in guest_headers.iter().chain(credential_headers) {
                 b = b.header(k, v);
             }
             b.send(body.unwrap_or(""))
@@ -1378,7 +1539,7 @@ fn perform(
                 "DELETE" => agent.delete(url),
                 _ => agent.get(url),
             };
-            for (k, v) in headers {
+            for (k, v) in guest_headers.iter().chain(credential_headers) {
                 b = b.header(k, v);
             }
             b.call()

--- a/crates/areev-run/src/broker.rs
+++ b/crates/areev-run/src/broker.rs
@@ -280,6 +280,27 @@ pub struct EgressCall {
     pub headers: BTreeMap<String, String>,
 }
 
+/// One CAS blob a capability tool READ, kept for the audit trail (#106).
+///
+/// The mirror of [`EgressCall`] on the other mediated door. A `wasm32-areev-io`
+/// module has no file descriptor of its own any more than it has a socket, so
+/// every stored byte it opens comes through the broker and lands here: "it was
+/// allowed to read attachments" is a policy statement, "it opened these two"
+/// is the evidence.
+///
+/// The address IS the content, so recording it is recording exactly which
+/// bytes were read, with no risk of putting the bytes themselves into an
+/// immutable replicating grain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobRead {
+    /// The tool that asked.
+    pub caller: String,
+    /// The `cas://sha256:…` address it opened.
+    pub uri: String,
+    /// How many bytes it got.
+    pub bytes: usize,
+}
+
 /// Per-caller ceilings on a capability tool's mediated egress.
 ///
 /// Extism's model: overruns are typed errors, never truncation — a tool that
@@ -329,6 +350,13 @@ pub struct Broker {
     /// evaluator's connector pass, a bare library embedding) fails closed
     /// rather than open.
     run_principal: Arc<std::sync::Mutex<Option<String>>>,
+    /// The memory whose CAS blobs `POST /blob` serves, if the host wired one
+    /// (#106). `None` means blob reads are refused whatever a module declared
+    /// — the same posture as a capability module under a host that configured
+    /// no broker at all.
+    blobs: Arc<std::sync::Mutex<Option<String>>>,
+    /// Every blob a caller actually read.
+    blob_reads: Arc<std::sync::Mutex<Vec<BlobRead>>>,
     /// caller -> its capability token.
     tokens: BTreeMap<String, String>,
     /// The token an unlisted caller presents, when a default grant exists.
@@ -359,9 +387,13 @@ impl Broker {
             Arc::new(std::sync::Mutex::new(BTreeMap::new()));
         let run_principal: Arc<std::sync::Mutex<Option<String>>> =
             Arc::new(std::sync::Mutex::new(None));
+        let blobs: Arc<std::sync::Mutex<Option<String>>> = Arc::new(std::sync::Mutex::new(None));
+        let blob_reads: Arc<std::sync::Mutex<Vec<BlobRead>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
         let (stop_t, refusals_t) = (Arc::clone(&stop), Arc::clone(&refusals));
         let (calls_t, declared_t) = (Arc::clone(&calls), Arc::clone(&declared));
         let (owners_t, principal_t) = (Arc::clone(&credential_owners), Arc::clone(&run_principal));
+        let (blobs_t, blob_reads_t) = (Arc::clone(&blobs), Arc::clone(&blob_reads));
 
         // One token per caller, minted before the listener serves anything.
         let mut tokens = BTreeMap::new();
@@ -399,6 +431,8 @@ impl Broker {
                             &declared_t,
                             &owners_t,
                             &principal_t,
+                            &blobs_t,
+                            &blob_reads_t,
                             &grants,
                             &by_token,
                             refusal_code,
@@ -421,9 +455,32 @@ impl Broker {
             declared,
             credential_owners,
             run_principal,
+            blobs,
+            blob_reads,
             tokens,
             default_token,
         })
+    }
+
+    /// Serve `POST /blob` from this memory's CAS store (#106).
+    ///
+    /// The path, not a handle: [`areev_store::read_blob_offline`] reads the
+    /// `.blobs` sidecar without opening the database, so serving a blob never
+    /// contends with the driver's exclusive write lock on the same file. That
+    /// is the same property that lets a `--tool-cmd` subprocess run
+    /// `areev blob get` mid-run.
+    ///
+    /// Until a host calls this, blob reads are refused whatever a module
+    /// declared — declaring is not granting here either.
+    pub fn serve_blobs(&self, db_path: &str) {
+        if let Ok(mut b) = self.blobs.lock() {
+            *b = Some(db_path.to_string());
+        }
+    }
+
+    /// Every blob a caller read, for journaling.
+    pub fn blob_reads(&self) -> Vec<BlobRead> {
+        self.blob_reads.lock().map(|b| b.clone()).unwrap_or_default()
     }
 
     /// Bind `name` to the run principal that owns it (#101 follow-through).
@@ -555,6 +612,174 @@ struct EgressRequest {
     headers: BTreeMap<String, String>,
 }
 
+#[derive(serde::Deserialize, Default)]
+#[serde(default)]
+struct BlobRequest {
+    /// A `cas://sha256:<64 hex>` content address. The ONLY way in: there is no
+    /// enumeration and no name lookup, so a module reaches bytes it was handed
+    /// a reference to and cannot go looking for others.
+    uri: String,
+}
+
+/// `POST /blob` — hand a declared capability tool the bytes at one content
+/// address (#106).
+///
+/// ## Why this is the broker's job and not the sandbox's
+///
+/// The obvious design is for the sandbox subprocess to read the `.blobs`
+/// sidecar itself: the read is lock-free, so it looks free. It is not. The
+/// subprocess runs under `EnvPolicy::ClearExcept` and is handed no memory
+/// path; `areev-sandbox` deliberately carries five dependencies and cannot
+/// take `areev-store`, so it would need its own `cas://` parser and its own
+/// SHA-256; the `.blobs` sidecar does not exist on the Postgres backend, where
+/// blobs live in-schema; and — decisively — a read performed inside the
+/// subprocess has **no way back to the driver to be journaled**, because
+/// stdout is contractually the guest's own result and the fuel line on stderr
+/// is prose for a human.
+///
+/// Routing it here answers all four at once. The broker already runs in the
+/// engine's process, already authenticates per-caller tokens, already has a
+/// place to record what happened, and is already the thing that turns "the
+/// module has no socket" into "every byte is mediated and recorded". This
+/// makes the second half true of stored bytes as well: **the guest gets
+/// neither a socket nor a file descriptor.**
+#[allow(clippy::too_many_arguments)]
+fn serve_blob(
+    stream: &mut TcpStream,
+    body: &[u8],
+    caller: &str,
+    declared: &Arc<std::sync::Mutex<BTreeMap<String, Declared>>>,
+    blobs: &Arc<std::sync::Mutex<Option<String>>>,
+    blob_reads: &Arc<std::sync::Mutex<Vec<BlobRead>>>,
+    refusals: &Arc<std::sync::Mutex<Vec<EgressRefusal>>>,
+    refusal_code: &'static str,
+) -> std::io::Result<()> {
+    let req: BlobRequest = match serde_json::from_slice(body) {
+        Ok(r) => r,
+        Err(e) => {
+            return respond(
+                stream,
+                400,
+                &serde_json::json!({ "error": format!("bad blob request: {e}") }).to_string(),
+            )
+        }
+    };
+
+    // Declared ∩ host-granted, the same two-key rule egress lives under: the
+    // module must have declared `{"blob": {"read": true}}`, AND the host must
+    // have wired a memory to serve from. A caller with no declaration at all
+    // — every `--tool-cmd` tool, every connector — is refused here rather than
+    // waved through, because unlike egress there is no host-side grant that
+    // could have admitted it: subprocess tools already read blobs with
+    // `areev blob get`, so this door exists only for the sandboxed ones.
+    let permitted = declared
+        .lock()
+        .map(|d| d.get(caller).is_some_and(|e| e.declaration.declares_blob_read()))
+        .unwrap_or(false);
+    if !permitted {
+        note_refusal(
+            refusals,
+            EgressRefusal {
+                caller: caller.to_string(),
+                destination: req.uri.clone(),
+                reason: "read a CAS blob without declaring the 'blob' capability".into(),
+            },
+        );
+        return respond(
+            stream,
+            403,
+            &serde_json::json!({
+                "error": format!(
+                    "caller '{caller}' asked to read a blob without declaring \
+                     {{\"blob\": {{\"read\": true}}}}"
+                ),
+                "code": refusal_code
+            })
+            .to_string(),
+        );
+    }
+
+    let Some(db_path) = blobs.lock().ok().and_then(|b| b.clone()) else {
+        return respond(
+            stream,
+            503,
+            &serde_json::json!({
+                "error": "this host wired no memory for blob reads"
+            })
+            .to_string(),
+        );
+    };
+
+    // The lock-free door is the `.blobs` sidecar, which is an EMBEDDED-backend
+    // thing: on Postgres a blob lives in-schema and reaching it means opening
+    // the memory. Said plainly and up front rather than letting the sidecar
+    // read miss and report "blob missing", which would send someone hunting
+    // for an attachment that is present and simply not reachable this way.
+    if db_path.starts_with("postgres://") || db_path.starts_with("postgresql://") {
+        return respond(
+            stream,
+            501,
+            &serde_json::json!({
+                "error": "blob reads from a sandboxed tool are not supported on the postgres \
+                          backend: the lock-free path is the .blobs sidecar, which only the \
+                          embedded backend has"
+            })
+            .to_string(),
+        );
+    }
+
+    match areev_store::read_blob_offline(&db_path, &req.uri) {
+        Ok(Some(bytes)) => {
+            note_blob_read(
+                blob_reads,
+                BlobRead {
+                    caller: caller.to_string(),
+                    uri: req.uri.clone(),
+                    bytes: bytes.len(),
+                },
+            );
+            respond_bytes(stream, &bytes)
+        }
+        // A sealed blob needs the memory's derived key, which lives behind an
+        // open handle this lock-free path deliberately does not take. Said
+        // plainly rather than reported as missing: "encrypted" and "not there"
+        // are different problems with different fixes.
+        Ok(None) => respond(
+            stream,
+            409,
+            &serde_json::json!({
+                "error": format!(
+                    "blob {} is encrypted at rest; a sandboxed tool cannot open it",
+                    req.uri
+                )
+            })
+            .to_string(),
+        ),
+        Err(e) => respond(
+            stream,
+            404,
+            &serde_json::json!({ "error": e.to_string() }).to_string(),
+        ),
+    }
+}
+
+/// Ceiling on how many effects one broker keeps in memory for journaling.
+/// Shared by calls and blob reads: both are effects, both are drained at the
+/// superstep boundary, and neither should let a runaway module grow the
+/// driver's heap without bound.
+const MAX_RECORDED_CALLS: usize = 4096;
+
+/// Record one blob read. Unlike a refusal these are NOT deduped: reading the
+/// same attachment twice is two reads, exactly as two successful calls are two
+/// calls.
+fn note_blob_read(reads: &Arc<std::sync::Mutex<Vec<BlobRead>>>, r: BlobRead) {
+    if let Ok(mut list) = reads.lock() {
+        if list.len() < MAX_RECORDED_CALLS {
+            list.push(r);
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 /// Record a refusal once. Bounded by distinct refusals, not by attempts.
 fn note_refusal(refusals: &Arc<std::sync::Mutex<Vec<EgressRefusal>>>, r: EgressRefusal) {
@@ -575,6 +800,8 @@ fn serve_one(
     declared: &Arc<std::sync::Mutex<BTreeMap<String, Declared>>>,
     credential_owners: &Arc<std::sync::Mutex<BTreeMap<String, String>>>,
     run_principal: &Arc<std::sync::Mutex<Option<String>>>,
+    blobs: &Arc<std::sync::Mutex<Option<String>>>,
+    blob_reads: &Arc<std::sync::Mutex<Vec<BlobRead>>>,
     grants: &EgressGrants,
     by_token: &BTreeMap<String, String>,
     refusal_code: &'static str,
@@ -585,6 +812,12 @@ fn serve_one(
     // Request line, then headers, then a Content-Length body.
     let mut line = String::new();
     reader.read_line(&mut line)?;
+    // Two doors, one port and one token: `/` brokers a network call, `/blob`
+    // reads stored bytes (#106). A path rather than a discriminant inside the
+    // JSON, so the two request shapes stay separate types and a blob read can
+    // be refused before anything parses an egress request out of it.
+    let path = line.split_whitespace().nth(1).unwrap_or("/").to_string();
+    let want_blob = path.starts_with("/blob");
     let mut content_length = 0usize;
     let mut presented: Option<String> = None;
     loop {
@@ -647,6 +880,19 @@ fn serve_one(
     }
     let mut body = vec![0u8; content_length];
     reader.read_exact(&mut body)?;
+
+    if want_blob {
+        return serve_blob(
+            &mut stream,
+            &body,
+            &caller,
+            declared,
+            blobs,
+            blob_reads,
+            refusals,
+            refusal_code,
+        );
+    }
 
     let req: EgressRequest = match serde_json::from_slice(&body) {
         Ok(r) => r,
@@ -1122,7 +1368,6 @@ fn digest(body: &str) -> String {
 /// memory here; the ceiling is well above `CapabilityLimits::max_calls`, which
 /// is the real bound for a capability tool.
 fn note_call(calls: &Arc<std::sync::Mutex<Vec<EgressCall>>>, c: EgressCall) {
-    const MAX_RECORDED_CALLS: usize = 4096;
     if let Ok(mut list) = calls.lock() {
         if list.len() < MAX_RECORDED_CALLS {
             list.push(c);
@@ -1571,6 +1816,26 @@ fn respond(stream: &mut TcpStream, status: u16, body: &str) -> std::io::Result<(
     );
     stream.write_all(head.as_bytes())?;
     stream.write_all(body.as_bytes())?;
+    stream.flush()
+}
+
+/// Answer with raw bytes rather than JSON (#106).
+///
+/// A blob is arbitrary bytes — a PDF, an image, a zip — and JSON cannot carry
+/// those without base64, which would cost a third of the size on the wire and,
+/// worse, oblige every guest module to carry a base64 decoder to read its own
+/// attachment. Unlike an HTTP response there is nothing else to report: no
+/// status to relay, no headers, just the bytes at an address that already
+/// names them. So success is `200` plus the body, and every failure is JSON
+/// with an `error` — which the sandbox distinguishes by status, not by
+/// sniffing the payload.
+fn respond_bytes(stream: &mut TcpStream, body: &[u8]) -> std::io::Result<()> {
+    let head = format!(
+        "HTTP/1.1 200 \r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(head.as_bytes())?;
+    stream.write_all(body)?;
     stream.flush()
 }
 

--- a/crates/areev-run/src/executor.rs
+++ b/crates/areev-run/src/executor.rs
@@ -62,6 +62,14 @@ pub trait HostToolExecutor: Send + Sync {
         Vec::new()
     }
 
+    /// Every CAS blob a capability tool READ (#106).
+    ///
+    /// The third audit stream, drained beside [`HostToolExecutor::calls`] at
+    /// the same superstep boundary. Default: none.
+    fn blob_reads(&self) -> Vec<crate::broker::BlobRead> {
+        Vec::new()
+    }
+
     /// Bind the principal the current run executes as, so the broker can
     /// refuse a credential owned by a different principal (#101). Default
     /// no-op: an executor with no broker has nothing to bind. Called by the
@@ -163,6 +171,9 @@ impl EgressHandle {
     fn calls(&self) -> Vec<crate::broker::EgressCall> {
         self.broker.calls()
     }
+    fn blob_reads(&self) -> Vec<crate::broker::BlobRead> {
+        self.broker.blob_reads()
+    }
     /// Does this caller hold a grant (and therefore a token)?
     fn token_for(&self, caller: &str) -> Option<&str> {
         self.broker.token_for(caller)
@@ -233,6 +244,10 @@ impl HostToolExecutor for CommandExecutor {
 
     fn calls(&self) -> Vec<crate::broker::EgressCall> {
         self.egress.as_ref().map(|e| e.calls()).unwrap_or_default()
+    }
+
+    fn blob_reads(&self) -> Vec<crate::broker::BlobRead> {
+        self.egress.as_ref().map(|e| e.blob_reads()).unwrap_or_default()
     }
 
     fn bind_run_principal(&self, principal: &str) {
@@ -452,10 +467,18 @@ impl CodeExecutor {
         // Equally honest: a grant is what mints the token the module presents,
         // so without one it holds no `AREEV_EGRESS_TOKEN` and every call would
         // be a 401 with no explanation.
+        //
+        // This binds blob-only modules (#106) too, and needs no exception: the
+        // token is what identifies the CALLER, and `POST /blob` has to know
+        // who is asking as much as `POST /` does. A module that reads
+        // attachments and touches no network takes the grant that names
+        // neither a credential nor a method — `--tool-egress 'parse_pdf::'` —
+        // which mints a token and authorizes no egress whatsoever.
         if egress.token_for(tool_name).is_none() {
             return Err(format!(
                 "{} declares capabilities but the host granted tool '{tool_name}' no egress — \
-                 add --tool-egress '{tool_name}:<credentials>:<methods>'",
+                 add --tool-egress '{tool_name}:<credentials>:<methods>' (both may be empty for \
+                 a module that only reads blobs)",
                 code.uri
             ));
         }
@@ -526,6 +549,13 @@ impl HostToolExecutor for CodeExecutor {
         match &self.egress {
             Some(e) => e.calls(),
             None => self.inner.calls(),
+        }
+    }
+
+    fn blob_reads(&self) -> Vec<crate::broker::BlobRead> {
+        match &self.egress {
+            Some(e) => e.blob_reads(),
+            None => self.inner.blob_reads(),
         }
     }
 
@@ -611,6 +641,9 @@ impl HostToolExecutor for CodeExecutor {
                     if let Some(n) = limits.get("max_response_bytes").and_then(Value::as_u64) {
                         c.arg("--max-response-bytes").arg(n.to_string());
                     }
+                    if let Some(n) = limits.get("max_blob_bytes").and_then(Value::as_u64) {
+                        c.arg("--max-blob-bytes").arg(n.to_string());
+                    }
                 }
                 // `--allow-fetch` is what LINKS `areev::fetch` into the guest's
                 // import set. Without it the sandbox's frozen set is exactly
@@ -630,6 +663,26 @@ impl HostToolExecutor for CodeExecutor {
                         };
                     }
                     c.arg("--allow-fetch");
+                    // `--allow-blob` links `areev::blob_get` (#106), and comes
+                    // off the pinned DECLARATION rather than the runtime
+                    // string like `--allow-fetch` does. The asymmetry is
+                    // deliberate: egress has a host-side grant behind it that
+                    // narrows the runtime's permission afterwards, so the flag
+                    // can be broad. A blob read has no such second key — the
+                    // declaration is the only thing that says yes — so it must
+                    // be the thing the flag is derived from, or every
+                    // capability module would silently gain the import.
+                    //
+                    // Still manifest-pinned, so a mid-run supersession cannot
+                    // add it: `code.capabilities` is the frozen copy.
+                    if code
+                        .capabilities
+                        .as_ref()
+                        .and_then(|v| areev_core::types::capability::Declaration::parse(v).ok())
+                        .is_some_and(|d| d.declares_blob_read())
+                    {
+                        c.arg("--allow-blob");
+                    }
                 }
                 c
             }

--- a/crates/areev-run/src/journal.rs
+++ b/crates/areev-run/src/journal.rs
@@ -240,6 +240,14 @@ pub fn write_egress_call(
     if let Some(c) = &call.credential {
         ex.insert("credential".into(), json!(c));
     }
+    // Values and all, unlike the credential (#105). The caller supplied these,
+    // so recording them discloses nothing it did not already hold, and it
+    // turns "it was allowed to reach Google" into "it sent these four requests
+    // billing this quota project". Omitted when empty, per the omit-default
+    // rule these extras are canonically serialized under.
+    if !call.headers.is_empty() {
+        ex.insert("headers".into(), json!(call.headers));
+    }
     m.add(&obs)
 }
 

--- a/crates/areev-run/src/journal.rs
+++ b/crates/areev-run/src/journal.rs
@@ -251,6 +251,44 @@ pub fn write_egress_call(
     m.add(&obs)
 }
 
+/// Record one CAS blob a capability tool READ, as a Tier-2 Observation (#106).
+///
+/// The other half of the mediated-I/O trail. `write_egress_call` records what
+/// a module sent; this records what it opened — and for the tool this
+/// capability exists for, parsing an attachment that arrived from outside,
+/// what it opened is the more interesting question. "Which bytes did the thing
+/// that processes untrusted input actually process" is the first thing an
+/// incident asks.
+///
+/// The `cas://` address IS the content hash, so naming it names exactly the
+/// bytes without putting a mailbox attachment into an immutable, replicating
+/// grain — the same reason bodies are recorded as digests.
+///
+/// Deliberately NOT a journal entry, exactly like its two siblings: replay
+/// never sees it, so `verify` stays byte-identical whether or not a broker was
+/// configured. Evidence about the run, not a step of it.
+pub fn write_blob_read(
+    m: &mut Areev,
+    run_id: &str,
+    read: &crate::broker::BlobRead,
+    clock_ms: u64,
+    principal: &str,
+) -> Result<Hash> {
+    let caller = if read.caller.is_empty() { "connector" } else { &read.caller };
+    let mut obs = Observation::new(principal, "system")
+        .subject(&format!("run:{run_id}"))
+        .object(&read.uri)
+        .namespace(HARNESS_NS)
+        .created_at(clock_ms as i64);
+    let ex = &mut obs.common.extra_fields;
+    ex.insert("run_id".into(), json!(run_id));
+    ex.insert("observation_kind".into(), json!("blob_read"));
+    ex.insert("caller".into(), json!(caller));
+    ex.insert("blob".into(), json!(read.uri));
+    ex.insert("bytes".into(), json!(read.bytes));
+    m.add(&obs)
+}
+
 /// Write a checkpoint State grain, chained by `derived_from`.
 #[allow(clippy::too_many_arguments)]
 pub fn write_checkpoint(

--- a/crates/areev-run/src/lib.rs
+++ b/crates/areev-run/src/lib.rs
@@ -28,7 +28,9 @@ pub mod runner;
 pub mod stream;
 
 pub use clock::{Clock, ScriptedClock, SystemClock};
-pub use broker::{Broker, CallerGrant, CapabilityLimits, Credential, EgressCall, EgressGrants};
+pub use broker::{
+    BlobRead, Broker, CallerGrant, CapabilityLimits, Credential, EgressCall, EgressGrants,
+};
 // The capability vocabulary lives in areev-core, beside the grain field it
 // validates, because `areev-cal`'s write path sits BELOW this crate and has to
 // reach the same parser (#101). Re-exported so a host writing against the

--- a/crates/areev-run/src/runner.rs
+++ b/crates/areev-run/src/runner.rs
@@ -1137,6 +1137,7 @@ impl Runner {
         // audit grains. Runs drive sequentially, so whatever is already present
         // belongs to an earlier one and is not ours to journal.
         let mut calls_journaled: usize = self.executor.calls().len();
+        let mut blob_reads_journaled: usize = self.executor.blob_reads().len();
         let mut in_flight: usize = 0;
         let mut st = st;
         let mut events = initial_events;
@@ -1486,6 +1487,27 @@ impl Runner {
                                 .map_err(err_run)?;
                         }
                         calls_journaled = calls.len();
+                        // And the other mediated door (#106): every stored
+                        // byte a capability tool opened. Same boundary, same
+                        // skip-cursor, same not-a-journal-entry status — the
+                        // tool this exists for parses untrusted attachments,
+                        // so "which bytes did it actually read" is evidence an
+                        // incident asks for first.
+                        let reads = self.executor.blob_reads();
+                        for r in reads.iter().skip(blob_reads_journaled) {
+                            self.facade
+                                .with_store(|m| {
+                                    journal::write_blob_read(
+                                        m,
+                                        &run_id,
+                                        r,
+                                        clock,
+                                        &self.principal,
+                                    )
+                                })
+                                .map_err(err_run)?;
+                        }
+                        blob_reads_journaled = reads.len();
                         let h = self
                             .facade
                             .with_store(|m| {

--- a/crates/areev-run/tests/codeexec_tests.rs
+++ b/crates/areev-run/tests/codeexec_tests.rs
@@ -571,6 +571,62 @@ fn the_capability_runtime_passes_allow_fetch_to_the_sandbox() {
     assert!(argv.contains("--fuel 5000"), "{argv}");
 }
 
+/// `--allow-blob` comes off the DECLARATION, not the runtime string (#106).
+///
+/// The asymmetry with `--allow-fetch` is the point: egress has a host-side
+/// grant behind it that narrows the runtime's permission afterwards, so that
+/// flag can be broad. A blob read has no second key — the declaration is the
+/// only thing that says yes — so an http-only module must not get the import
+/// merely for being `wasm32-areev-io`.
+#[cfg(unix)]
+#[test]
+fn allow_blob_is_passed_only_when_the_module_declared_it() {
+    for (caps, want_blob) in [
+        (gmail_caps(), false),
+        (json!([{"blob": {"read": true}}]), true),
+        (
+            json!([
+                {"http": {"hosts": ["https://gmail.googleapis.com"], "methods": ["POST"],
+                          "credentials": ["gmail"]}},
+                {"blob": {"read": true}}
+            ]),
+            true,
+        ),
+        // Declared and declined: the import stays unlinked.
+        (json!([{"blob": {"read": false}}]), false),
+    ] {
+        let rig = Rig::new();
+        let uri = rig.put_blob(b"\0asm-io-module");
+        let plan = plan_with_capabilities(
+            &rig,
+            &uri,
+            "wasm32-areev-io",
+            Some(caps.clone()),
+            Some(json!({"max_blob_bytes": 2048})),
+        );
+        let fake = fake_sandbox(&rig, "fake-sandbox-blob.sh");
+        let exec = areev_run::CodeExecutor::new(Arc::new(Fallback))
+            .allow(&uri)
+            .cache_dir(rig.dir.join("cache"))
+            .sandbox_cmd(fake.to_str().unwrap())
+            .with_egress(areev_run::EgressHandle::new(capability_broker()));
+        let session = rig.runner(Arc::new(exec)).start(&plan, "r1", json!({}), &opts()).unwrap();
+        let RunSession::Finished { outcome, .. } = session else { panic!("expected finish") };
+        assert_eq!(outcome, RunOutcome::Completed);
+
+        let records = rig.facade.with_store(|m| m.step_actions("ops", &plan, None, 10)).unwrap();
+        let grain = rig.facade.with_store(|m| m.get(&records[0].1)).unwrap();
+        let argv = grain.get_str("tool_content").unwrap_or_default().to_string();
+        assert_eq!(
+            argv.contains("--allow-blob"),
+            want_blob,
+            "declaration {caps} should{} open the blob gate: {argv}",
+            if want_blob { "" } else { " not" }
+        );
+        assert!(argv.contains("--max-blob-bytes 2048"), "the ceiling rides too: {argv}");
+    }
+}
+
 /// A capability module with no broker configured fails with the fix named,
 /// rather than starting and having every call refused by a broker that is not
 /// there.

--- a/crates/areev-run/tests/egress_tests.rs
+++ b/crates/areev-run/tests/egress_tests.rs
@@ -1443,6 +1443,332 @@ fn guest_headers_are_journaled_with_their_values() {
     );
 }
 
+// ---- #106: reading CAS blobs through the same broker ----------------------
+
+/// Post a blob request to the broker's `/blob` path, returning
+/// `(http status, raw body)`. Raw, not JSON: a success answer is the blob's
+/// own bytes, which is the whole point of that door.
+fn ask_blob(broker_url: &str, token: &str, uri: &str) -> (u16, Vec<u8>) {
+    use std::io::{BufRead, BufReader, Read, Write};
+    let addr = broker_url.trim_start_matches("http://");
+    let mut s = std::net::TcpStream::connect(addr).unwrap();
+    let body = json!({ "uri": uri }).to_string();
+    let head = format!(
+        "POST /blob HTTP/1.1\r\nHost: {addr}\r\nX-Areev-Egress-Token: {token}\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    s.write_all(head.as_bytes()).unwrap();
+    s.write_all(body.as_bytes()).unwrap();
+    s.flush().unwrap();
+
+    let mut reader = BufReader::new(s);
+    let mut line = String::new();
+    reader.read_line(&mut line).unwrap();
+    let status: u16 = line.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    let mut len = 0usize;
+    loop {
+        let mut h = String::new();
+        if reader.read_line(&mut h).unwrap_or(0) == 0 || h.trim().is_empty() {
+            break;
+        }
+        if let Some(v) = h.to_ascii_lowercase().strip_prefix("content-length:") {
+            len = v.trim().parse().unwrap_or(0);
+        }
+    }
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).unwrap();
+    (status, buf)
+}
+
+/// A memory with one blob in it, and the CAS uri that addresses it.
+fn memory_with_blob(dir: &std::path::Path, bytes: &[u8]) -> (String, String) {
+    use areev_store::Areev;
+    let path = dir.join("m.db").to_str().unwrap().to_string();
+    let mut m = Areev::open(&path).unwrap();
+    let uri = m.put_blob(bytes).unwrap();
+    drop(m);
+    (path, uri)
+}
+
+/// The use case: a declared module reads the attachment it was handed, and
+/// gets the bytes themselves rather than JSON wrapping them.
+#[test]
+fn a_declared_module_reads_a_blob_through_the_broker() {
+    let dir = tempfile::TempDir::new().unwrap();
+    // Deliberately not valid UTF-8 and deliberately starting with `{`: a real
+    // attachment is arbitrary bytes, and anything that sniffed the payload to
+    // decide "is this an error?" would misread exactly this.
+    let payload = b"{\x00\x01\x02 not json, not utf8 \xff\xfe".to_vec();
+    let (db, uri) = memory_with_blob(dir.path(), &payload);
+
+    let broker = Broker::start(
+        EgressPolicy::default(),
+        Default::default(),
+        EgressGrants::new().grant("parse_attachments", CallerGrant::new()),
+        "RUN-E022",
+    )
+    .unwrap();
+    broker.serve_blobs(&db);
+    broker.declare(
+        "parse_attachments",
+        declaration(json!([{"blob": {"read": true}}])),
+        CapabilityLimits::default(),
+    );
+    let token = broker.token_for("parse_attachments").unwrap().to_string();
+
+    let (code, body) = ask_blob(broker.url(), &token, &uri);
+    assert_eq!(code, 200);
+    assert_eq!(body, payload, "the bytes arrive verbatim, not re-encoded");
+
+    let reads = broker.blob_reads();
+    assert_eq!(reads.len(), 1);
+    assert_eq!(reads[0].caller, "parse_attachments");
+    assert_eq!(reads[0].uri, uri);
+    assert_eq!(reads[0].bytes, payload.len());
+}
+
+/// Declaring is the only key, so not declaring is refused — including for the
+/// callers that CAN reach the network. An http capability is not a blob one.
+#[test]
+fn an_undeclared_module_cannot_read_a_blob() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (db, uri) = memory_with_blob(dir.path(), b"secret attachment");
+
+    let broker = Broker::start(
+        EgressPolicy::default(),
+        Default::default(),
+        EgressGrants::new()
+            .grant("http_only", CallerGrant::new().method("POST"))
+            .grant("plain", CallerGrant::new()),
+        "RUN-E022",
+    )
+    .unwrap();
+    broker.serve_blobs(&db);
+    // Declares http, and nothing about blobs.
+    broker.declare(
+        "http_only",
+        declaration(json!([{"http": {"hosts": ["https://api.example.com"], "methods": ["POST"]}}])),
+        CapabilityLimits::default(),
+    );
+
+    for caller in ["http_only", "plain"] {
+        let token = broker.token_for(caller).unwrap().to_string();
+        let (code, body) = ask_blob(broker.url(), &token, &uri);
+        assert_eq!(code, 403, "'{caller}' did not declare the blob capability");
+        assert!(
+            !body.windows(6).any(|w| w == b"secret"),
+            "and got none of the bytes"
+        );
+    }
+    assert!(broker.blob_reads().is_empty(), "nothing was read");
+}
+
+/// A module may fetch bytes it was handed a reference to, and cannot go
+/// looking for others: the address is the only way in, and a malformed or
+/// unknown one is an error rather than a browse.
+#[test]
+fn a_blob_read_is_by_content_address_only() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (db, _uri) = memory_with_blob(dir.path(), b"stored");
+
+    let broker = Broker::start(
+        EgressPolicy::default(),
+        Default::default(),
+        EgressGrants::new().grant("t", CallerGrant::new()),
+        "RUN-E022",
+    )
+    .unwrap();
+    broker.serve_blobs(&db);
+    broker.declare(
+        "t",
+        declaration(json!([{"blob": {"read": true}}])),
+        CapabilityLimits::default(),
+    );
+    let token = broker.token_for("t").unwrap().to_string();
+
+    for bad in [
+        "",
+        "not-a-uri",
+        "file:///etc/passwd",
+        "../../etc/passwd",
+        "cas://sha256:short",
+        // A well-formed address for a blob this memory does not hold.
+        "cas://sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    ] {
+        let (code, _) = ask_blob(broker.url(), &token, bad);
+        assert_eq!(code, 404, "{bad:?} is not readable");
+    }
+    assert!(broker.blob_reads().is_empty(), "and none of them counted as a read");
+}
+
+/// Declared, but the host wired no memory: refused rather than served from
+/// somewhere unexpected. Declaring is not granting on this door either.
+#[test]
+fn a_blob_read_needs_the_host_to_have_wired_a_memory() {
+    let broker = Broker::start(
+        EgressPolicy::default(),
+        Default::default(),
+        EgressGrants::new().grant("t", CallerGrant::new()),
+        "RUN-E022",
+    )
+    .unwrap();
+    broker.declare(
+        "t",
+        declaration(json!([{"blob": {"read": true}}])),
+        CapabilityLimits::default(),
+    );
+    let token = broker.token_for("t").unwrap().to_string();
+    let (code, _) = ask_blob(
+        broker.url(),
+        &token,
+        "cas://sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    );
+    assert_eq!(code, 503, "no memory wired, so nothing to read");
+}
+
+/// The token is the caller's identity on this door too: an unauthenticated
+/// process on the same box gets nothing.
+#[test]
+fn a_blob_read_without_a_token_is_refused() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let (db, uri) = memory_with_blob(dir.path(), b"attachment");
+    let broker = Broker::start(
+        EgressPolicy::default(),
+        Default::default(),
+        EgressGrants::new().grant("t", CallerGrant::new()),
+        "RUN-E022",
+    )
+    .unwrap();
+    broker.serve_blobs(&db);
+    broker.declare(
+        "t",
+        declaration(json!([{"blob": {"read": true}}])),
+        CapabilityLimits::default(),
+    );
+
+    let (code, _) = ask_blob(broker.url(), "not-a-real-token", &uri);
+    assert_eq!(code, 401);
+    assert!(broker.blob_reads().is_empty());
+}
+
+/// The audit half, end to end: a blob a tool read is auditable from the
+/// memory, on the same superstep boundary as a brokered call.
+///
+/// This is the property that made routing blob reads through the broker the
+/// right design rather than reading the sidecar inside the sandbox: a read
+/// performed in the subprocess has no way back to the driver to be journaled,
+/// and the tool this capability exists for is the one that parses untrusted
+/// attachments — precisely where a hole in the audit trail is least
+/// affordable.
+#[test]
+fn a_blob_read_is_auditable_from_the_memory() {
+    use areev_cal::AreevFacade;
+    use areev_core::types::{Grain, Tool, ToolKind, Workflow};
+    use areev_run::{CommandExecutor, EgressHandle, RunOptions, Runner, ScriptedClock};
+    use areev_store::Areev;
+    use tempfile::TempDir;
+
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("m.db").to_str().unwrap().to_string();
+    let mut m = Areev::open(&db).unwrap();
+    let uri = m.put_blob(b"an invoice PDF, pretend").unwrap();
+    let facade = Arc::new(AreevFacade::new(m));
+
+    let def = Tool::new("parse_attachments")
+        .kind(ToolKind::Definition)
+        .tool_description("reads stored bytes")
+        .created_at(500)
+        .namespace("ops");
+    let dh = facade.with_store(|m| m.add(&def)).unwrap();
+    let plan = facade
+        .with_store(|m| {
+            m.add(
+                &Workflow::new(vec!["parse_attachments".into()])
+                    .bind("parse_attachments", &dh.to_hex())
+                    .created_at(600)
+                    .namespace("ops"),
+            )
+        })
+        .unwrap();
+
+    // A grant naming neither a credential nor a method: it mints the token
+    // that identifies the caller and authorizes no egress at all — the shape
+    // a module that only reads attachments takes.
+    let broker = Arc::new(
+        Broker::start(
+            EgressPolicy::default(),
+            Default::default(),
+            EgressGrants::new().grant("parse_attachments", CallerGrant::new()),
+            "RUN-E022",
+        )
+        .unwrap(),
+    );
+    broker.serve_blobs(&db);
+    broker.declare(
+        "parse_attachments",
+        declaration(json!([{"blob": {"read": true}}])),
+        CapabilityLimits::default(),
+    );
+
+    let exec = CommandExecutor::new(&format!(
+        "curl -s -X POST -H \"X-Areev-Egress-Token: $AREEV_EGRESS_TOKEN\" \
+           -d '{{\"uri\":\"{uri}\"}}' \"$AREEV_EGRESS_URL/blob\" >/dev/null; \
+         echo '{{\"parsed\":true}}'"
+    ))
+    .with_egress(EgressHandle::new(Arc::clone(&broker)));
+
+    let runner = Runner {
+        facade: Arc::clone(&facade),
+        clock: Arc::new(ScriptedClock::new(
+            (0..200).map(|i| 1_755_000_000_000 + i * 10).collect(),
+        )),
+        executor: Arc::new(exec),
+        llm: None,
+        observer: None,
+        ns: "ops".into(),
+        principal: "user:runner".into(),
+    };
+    runner
+        .start(
+            &plan,
+            "r-blob",
+            json!({}),
+            &RunOptions {
+                budgets: Default::default(),
+                ask_ttl_sec: None,
+                workers: 1,
+                on_dangling: areev_run::OnDangling::Redispatch,
+                llm_max_tokens: None,
+                inject_crash: None,
+            },
+        )
+        .unwrap();
+
+    let obs = facade
+        .with_store(|m| {
+            m.recent_live_scoped(
+                &[areev_core::authz::HARNESS_NS.to_string()],
+                Some(areev_core::types::GrainType::Observation),
+                50,
+            )
+        })
+        .unwrap();
+    let read = obs
+        .iter()
+        .find(|g| g.get_str("observation_kind") == Some("blob_read"))
+        .expect("the read was journaled");
+
+    assert_eq!(read.get_str("run_id"), Some("r-blob"));
+    assert_eq!(read.get_str("caller"), Some("parse_attachments"));
+    assert_eq!(read.get_str("blob"), Some(uri.as_str()));
+    // The address names the bytes; the bytes themselves are not in the grain.
+    assert!(
+        !format!("{read:?}").contains("an invoice PDF"),
+        "the content must not ride an immutable replicating grain: {read:?}"
+    );
+}
+
 /// The declaration binds every hop, not just the first. An upstream on a
 /// DECLARED path answers `302` pointing at an undeclared path on the same
 /// (host-granted) origin — without the per-hop check, a redirect walks the

--- a/crates/areev-run/tests/egress_tests.rs
+++ b/crates/areev-run/tests/egress_tests.rs
@@ -1346,6 +1346,11 @@ fn guest_headers_do_not_survive_a_cross_origin_redirect() {
 /// header value came from the caller, discloses nothing the caller did not
 /// already hold, and turns "it was allowed to reach Google" into "it billed
 /// this quota project on these four requests".
+// Unix-only for the same reason as every other shell-driven test here: the
+// vehicle is a `curl` pipeline with `$VAR` expansion and single-quoted JSON,
+// which `cmd /C` does not parse. The FEATURE is platform-independent and is
+// covered everywhere by the socket-level tests above.
+#[cfg(unix)]
 #[test]
 fn guest_headers_are_journaled_with_their_values() {
     use areev_cal::AreevFacade;
@@ -1661,6 +1666,10 @@ fn a_blob_read_without_a_token_is_refused() {
 /// and the tool this capability exists for is the one that parses untrusted
 /// attachments — precisely where a hole in the audit trail is least
 /// affordable.
+// Unix-only: same `curl`-through-a-POSIX-shell vehicle as its `egress_call`
+// sibling. The blob door itself is exercised on every platform by
+// `a_declared_module_reads_a_blob_through_the_broker`.
+#[cfg(unix)]
 #[test]
 fn a_blob_read_is_auditable_from_the_memory() {
     use areev_cal::AreevFacade;

--- a/crates/areev-run/tests/egress_tests.rs
+++ b/crates/areev-run/tests/egress_tests.rs
@@ -21,8 +21,14 @@ use std::sync::Arc;
 /// a request path to `(status, extra headers, body)`; every request is also
 /// recorded so a test can assert on what the upstream *saw* — which is how
 /// "the credential did not travel" is checked at the only place it can be.
-/// `(method, path, authorization)` — what one request looked like.
-type SeenRequest = (String, String, Option<String>);
+/// `(method, path, authorization, all headers)` — what one request looked like.
+///
+/// The fourth element is every header the upstream received, lowercased names,
+/// in arrival order: `authorization` is called out separately because most of
+/// this suite is about whether the *credential* travelled, but #105 lets a
+/// caller set its own headers and "did `X-Goog-User-Project` actually arrive"
+/// is answerable only here, at the socket the broker wrote to.
+type SeenRequest = (String, String, Option<String>, Vec<(String, String)>);
 /// `(path, status, extra headers, body)` — one row of the routing table.
 type Route = (&'static str, u16, Vec<(String, String)>, &'static str);
 
@@ -61,12 +67,16 @@ impl Upstream {
                 let path = parts.next().unwrap_or("/").to_string();
                 let mut auth = None;
                 let mut content_length = 0usize;
+                let mut all_headers: Vec<(String, String)> = Vec::new();
                 loop {
                     let mut h = String::new();
                     if reader.read_line(&mut h).unwrap_or(0) == 0 || h.trim().is_empty() {
                         break;
                     }
                     let lower = h.to_ascii_lowercase();
+                    if let Some((k, v)) = h.split_once(':') {
+                        all_headers.push((k.trim().to_ascii_lowercase(), v.trim().to_string()));
+                    }
                     if let Some(v) = lower.strip_prefix("authorization:") {
                         auth = Some(v.trim().to_string());
                     }
@@ -79,7 +89,7 @@ impl Upstream {
                     use std::io::Read;
                     let _ = reader.read_exact(&mut discard);
                 }
-                seen_t.lock().unwrap().push((method, path.clone(), auth));
+                seen_t.lock().unwrap().push((method, path.clone(), auth, all_headers));
 
                 let (status, headers, body) = {
                     let routes = routes_t.lock().unwrap();
@@ -112,7 +122,7 @@ impl Upstream {
         self.routes.lock().unwrap().push(route);
     }
 
-    /// `(method, path, authorization)` for every request this server handled.
+    /// Every request this server handled, in order.
     fn requests(&self) -> Vec<SeenRequest> {
         self.seen.lock().unwrap().clone()
     }
@@ -746,7 +756,7 @@ fn a_declaration_narrows_a_broader_host_grant() {
         body["error"].as_str().unwrap_or_default().contains("path_prefixes"),
         "and the refusal names why: {body}"
     );
-    let paths: Vec<String> = site.requests().into_iter().map(|(_, p, _)| p).collect();
+    let paths: Vec<String> = site.requests().into_iter().map(|(_, p, _, _)| p).collect();
     assert_eq!(paths, vec!["/gmail/v1/users/me/messages/send"], "the upload never went out");
 }
 
@@ -1060,6 +1070,379 @@ fn a_successful_brokered_call_is_auditable_from_the_memory() {
     }
 }
 
+// ---- #105: non-credential request headers ----------------------------------
+
+/// The use case the feature exists for: a declared header reaches the upstream.
+///
+/// Every Google API called with user credentials wants `X-Goog-User-Project`
+/// or answers 403, and that header is not a credential — which is exactly why
+/// the broker could not set it and the guest could not either. Asserted at the
+/// socket, because "the broker accepted the request" is not the same claim as
+/// "the header arrived".
+#[test]
+fn a_declared_header_reaches_the_upstream() {
+    let site = Upstream::start(vec![("/v4/sheets/append", 200, Vec::new(), "appended")]);
+    let broker = Broker::start(
+        policy_for(&[site.origin()]),
+        Default::default(),
+        EgressGrants::new().grant("append_sheet", CallerGrant::new().method("POST")),
+        "RUN-E022",
+    )
+    .unwrap();
+    broker.declare(
+        "append_sheet",
+        declaration(json!([{"http": {
+            "hosts": [site.origin()],
+            "methods": ["POST"],
+            "headers": ["X-Goog-User-Project"]
+        }}])),
+        CapabilityLimits::default(),
+    );
+    let token = broker.token_for("append_sheet").unwrap().to_string();
+
+    let (code, body) = ask(
+        broker.url(),
+        &token,
+        json!({
+            "url": format!("{}/v4/sheets/append", site.origin()),
+            "method": "POST",
+            "headers": { "X-Goog-User-Project": "my-project" },
+            "body": "{}"
+        }),
+    );
+    assert_eq!(code, 200, "the call goes out: {body}");
+
+    let reqs = site.requests();
+    assert_eq!(reqs.len(), 1);
+    assert!(
+        reqs[0].3.iter().any(|(k, v)| k == "x-goog-user-project" && v == "my-project"),
+        "the declared header arrived at the upstream: {:?}",
+        reqs[0].3
+    );
+}
+
+/// An undeclared header is refused, on the same deny-by-default reading the
+/// method and credential sets get: declaring some headers does not declare all
+/// of them, and declaring none declares none.
+#[test]
+fn an_undeclared_header_is_refused() {
+    let site = Upstream::start(vec![("/x", 200, Vec::new(), "ok")]);
+    let broker = Broker::start(
+        policy_for(&[site.origin()]),
+        Default::default(),
+        EgressGrants::new().grant("t", CallerGrant::new().method("POST")),
+        "RUN-E022",
+    )
+    .unwrap();
+    broker.declare(
+        "t",
+        declaration(json!([{"http": {
+            "hosts": [site.origin()],
+            "methods": ["POST"],
+            "headers": ["X-Goog-User-Project"]
+        }}])),
+        CapabilityLimits::default(),
+    );
+    let token = broker.token_for("t").unwrap().to_string();
+
+    let (code, body) = ask(
+        broker.url(),
+        &token,
+        json!({
+            "url": format!("{}/x", site.origin()),
+            "method": "POST",
+            "headers": { "X-Tenant-Id": "acme" },
+            "body": "{}"
+        }),
+    );
+    assert_eq!(code, 403, "an undeclared header is refused: {body}");
+    assert!(
+        body["error"].as_str().unwrap_or_default().contains("X-Tenant-Id"),
+        "and the refusal names it: {body}"
+    );
+    assert!(site.requests().is_empty(), "nothing went out");
+}
+
+/// The load-bearing refusal: the guest may not write the credential channel.
+///
+/// Letting a module set `Authorization` would hand back exactly the surface
+/// brokering exists to remove — it could attach a credential it minted, or
+/// overwrite the one the broker attached. Checked for every spelling, because
+/// HTTP field names are case-insensitive and a check that is not would be
+/// bypassed by `authorization`. `Host` is here too: it re-targets the request
+/// *after* the allowlist judged the URL.
+#[test]
+fn a_guest_cannot_set_the_headers_the_broker_owns() {
+    let site = Upstream::start(vec![("/x", 200, Vec::new(), "ok")]);
+    std::env::set_var("AREEV_TEST_OWNED_HDR", "s3cret-value");
+    let broker = Broker::start(
+        policy_for(&[site.origin()]),
+        [("api".to_string(), Credential::bearer_from_env("AREEV_TEST_OWNED_HDR").unwrap())]
+            .into_iter()
+            .collect(),
+        EgressGrants::new()
+            .grant("t", CallerGrant::new().method("POST").credential("api")),
+        "RUN-E022",
+    )
+    .unwrap();
+    let token = broker.token_for("t").unwrap().to_string();
+
+    for name in ["Authorization", "authorization", "AUTHORIZATION", "Cookie", "Host",
+                 "Proxy-Authorization"]
+    {
+        let (code, body) = ask(
+            broker.url(),
+            &token,
+            json!({
+                "url": format!("{}/x", site.origin()),
+                "method": "POST",
+                "headers": { name: "attacker-chosen" },
+                "body": "{}"
+            }),
+        );
+        assert_eq!(code, 403, "'{name}' is the broker's to set: {body}");
+        assert!(
+            body["error"].as_str().unwrap_or_default().contains("broker owns"),
+            "and the refusal says so: {body}"
+        );
+    }
+    assert!(site.requests().is_empty(), "not one of them went out");
+}
+
+/// A credential carried in a NON-`Authorization` header is protected too.
+///
+/// `Credential::Header` lets an operator put a secret in any header the
+/// upstream wants — `X-Api-Key`, say — and that name is host configuration, so
+/// it cannot be in a static list. The collision is caught after resolution,
+/// which is the only place the name is known.
+#[test]
+fn a_guest_cannot_overwrite_a_header_carrying_a_configured_credential() {
+    let site = Upstream::start(vec![("/x", 200, Vec::new(), "ok")]);
+    let broker = Broker::start(
+        policy_for(&[site.origin()]),
+        [(
+            "api".to_string(),
+            Credential::Header { name: "X-Api-Key".into(), value: "s3cret".into() },
+        )]
+        .into_iter()
+        .collect(),
+        EgressGrants::new().grant("t", CallerGrant::new().method("POST").credential("api")),
+        "RUN-E022",
+    )
+    .unwrap();
+    let token = broker.token_for("t").unwrap().to_string();
+
+    // Different casing from the configured name, to pin that the check is
+    // case-insensitive rather than a string equality that happens to pass.
+    let (code, body) = ask(
+        broker.url(),
+        &token,
+        json!({
+            "url": format!("{}/x", site.origin()),
+            "method": "POST",
+            "credential": "api",
+            "headers": { "x-api-key": "attacker-chosen" },
+            "body": "{}"
+        }),
+    );
+    assert_eq!(code, 403, "the credential's own header is not the guest's to write: {body}");
+    assert!(site.requests().is_empty(), "nothing went out");
+}
+
+/// Header injection: a CR or LF in a value splits one request into two, and
+/// the second one is the caller's to shape. Refused as malformed, before any
+/// policy question is asked.
+#[test]
+fn a_header_value_carrying_crlf_is_refused_as_malformed() {
+    let site = Upstream::start(vec![("/x", 200, Vec::new(), "ok")]);
+    let broker = Broker::start(
+        policy_for(&[site.origin()]),
+        Default::default(),
+        EgressGrants::new().grant("t", CallerGrant::new().method("POST")),
+        "RUN-E022",
+    )
+    .unwrap();
+    let token = broker.token_for("t").unwrap().to_string();
+
+    for (name, value) in [
+        ("X-Evil", "ok\r\nX-Injected: yes"),
+        ("X-Evil", "ok\nX-Injected: yes"),
+        ("X-Bad Name", "fine"),
+        ("X:Colon", "fine"),
+    ] {
+        let (code, _) = ask(
+            broker.url(),
+            &token,
+            json!({
+                "url": format!("{}/x", site.origin()),
+                "method": "POST",
+                "headers": { name: value },
+                "body": "{}"
+            }),
+        );
+        assert_eq!(code, 400, "'{name}: {value}' is malformed, not merely refused");
+    }
+    assert!(site.requests().is_empty(), "nothing went out");
+}
+
+/// Guest headers travel exactly as far as the credential: a cross-origin
+/// redirect drops both.
+///
+/// Not a secrecy argument — the caller chose these values — but an intent one.
+/// The header was meant for the host the caller named; a redirect off-origin
+/// is where "meant for" stops being true, and volunteering a quota project or
+/// tenant id to a destination an intermediary picked is the broker leaking the
+/// caller's context.
+#[test]
+fn guest_headers_do_not_survive_a_cross_origin_redirect() {
+    let elsewhere = Upstream::start(vec![("/landing", 200, Vec::new(), "landed")]);
+    let start = Upstream::start(vec![]);
+    start.add_route((
+        "/go",
+        302,
+        header("Location", &format!("{}/landing", elsewhere.origin())),
+        "",
+    ));
+    let broker = Broker::start(
+        policy_for(&[start.origin(), elsewhere.origin()]),
+        Default::default(),
+        EgressGrants::new().grant("t", CallerGrant::new()),
+        "RUN-E022",
+    )
+    .unwrap();
+    let token = broker.token_for("t").unwrap().to_string();
+
+    let (code, body) = ask(
+        broker.url(),
+        &token,
+        json!({
+            "url": format!("{}/go", start.origin()),
+            "method": "GET",
+            "headers": { "X-Goog-User-Project": "my-project" }
+        }),
+    );
+    assert_eq!(code, 200, "the chain completes: {body}");
+
+    let first = start.requests();
+    assert!(
+        first[0].3.iter().any(|(k, _)| k == "x-goog-user-project"),
+        "it rode the hop the caller named: {:?}",
+        first[0].3
+    );
+    let second = elsewhere.requests();
+    assert_eq!(second.len(), 1, "the redirect was followed");
+    assert!(
+        !second[0].3.iter().any(|(k, _)| k == "x-goog-user-project"),
+        "but not the one an intermediary chose: {:?}",
+        second[0].3
+    );
+}
+
+/// The audit half: headers are journaled with their VALUES, unlike the
+/// credential which is journaled by name only.
+///
+/// The asymmetry is the point. A credential value is the host's secret and an
+/// Observation is immutable and replicates, so it may never carry one. A guest
+/// header value came from the caller, discloses nothing the caller did not
+/// already hold, and turns "it was allowed to reach Google" into "it billed
+/// this quota project on these four requests".
+#[test]
+fn guest_headers_are_journaled_with_their_values() {
+    use areev_cal::AreevFacade;
+    use areev_core::types::{Grain, Tool, ToolKind, Workflow};
+    use areev_run::{CommandExecutor, EgressHandle, RunOptions, Runner, ScriptedClock};
+    use areev_store::Areev;
+    use tempfile::TempDir;
+
+    let site = Upstream::start(vec![("/ok", 200, Vec::new(), "upstream said hi")]);
+    let dir = TempDir::new().unwrap();
+    let m = Areev::open(dir.path().join("m.db").to_str().unwrap()).unwrap();
+    let facade = Arc::new(AreevFacade::new(m));
+
+    let def = Tool::new("reach")
+        .kind(ToolKind::Definition)
+        .tool_description("calls out")
+        .created_at(500)
+        .namespace("ops");
+    let dh = facade.with_store(|m| m.add(&def)).unwrap();
+    let plan = facade
+        .with_store(|m| {
+            m.add(
+                &Workflow::new(vec!["reach".into()])
+                    .bind("reach", &dh.to_hex())
+                    .created_at(600)
+                    .namespace("ops"),
+            )
+        })
+        .unwrap();
+
+    let broker = Arc::new(
+        Broker::start(
+            policy_for(&[site.origin()]),
+            Default::default(),
+            EgressGrants::new().grant("reach", CallerGrant::new()),
+            "RUN-E022",
+        )
+        .unwrap(),
+    );
+    let exec = CommandExecutor::new(&format!(
+        "curl -s -X POST -H \"X-Areev-Egress-Token: $AREEV_EGRESS_TOKEN\" \
+           -d '{{\"url\":\"{origin}/ok\",\"method\":\"GET\",\
+                 \"headers\":{{\"X-Goog-User-Project\":\"my-project\"}}}}' \
+           \"$AREEV_EGRESS_URL\" >/dev/null; \
+         echo '{{\"done\":true}}'",
+        origin = site.origin()
+    ))
+    .with_egress(EgressHandle::new(Arc::clone(&broker)));
+
+    let runner = Runner {
+        facade: Arc::clone(&facade),
+        clock: Arc::new(ScriptedClock::new(
+            (0..200).map(|i| 1_755_000_000_000 + i * 10).collect(),
+        )),
+        executor: Arc::new(exec),
+        llm: None,
+        observer: None,
+        ns: "ops".into(),
+        principal: "user:runner".into(),
+    };
+    runner
+        .start(
+            &plan,
+            "r-hdrs",
+            json!({}),
+            &RunOptions {
+                budgets: Default::default(),
+                ask_ttl_sec: None,
+                workers: 1,
+                on_dangling: areev_run::OnDangling::Redispatch,
+                llm_max_tokens: None,
+                inject_crash: None,
+            },
+        )
+        .unwrap();
+
+    let obs = facade
+        .with_store(|m| {
+            m.recent_live_scoped(
+                &[areev_core::authz::HARNESS_NS.to_string()],
+                Some(areev_core::types::GrainType::Observation),
+                50,
+            )
+        })
+        .unwrap();
+    let call = obs
+        .iter()
+        .find(|g| g.get_str("observation_kind") == Some("egress_call"))
+        .expect("the call was journaled");
+
+    let rendered = format!("{call:?}");
+    assert!(
+        rendered.contains("X-Goog-User-Project") && rendered.contains("my-project"),
+        "the header rides the audit trail, name and value: {rendered}"
+    );
+}
+
 /// The declaration binds every hop, not just the first. An upstream on a
 /// DECLARED path answers `302` pointing at an undeclared path on the same
 /// (host-granted) origin — without the per-hop check, a redirect walks the
@@ -1094,7 +1477,7 @@ fn a_redirect_cannot_walk_a_capability_tool_off_its_declared_paths() {
         json!({ "url": format!("{}/gmail/v1/users/me/go", site.origin()), "method": "GET" }),
     );
     assert_eq!(code, 403, "the hop must be refused by the DECLARATION: {body}");
-    let paths: Vec<String> = site.requests().into_iter().map(|(_, p, _)| p).collect();
+    let paths: Vec<String> = site.requests().into_iter().map(|(_, p, _, _)| p).collect();
     assert_eq!(paths, vec!["/gmail/v1/users/me/go"], "the undeclared endpoint was never fetched");
     assert!(
         broker.refusals().iter().any(|r| r.reason.contains("redirect outside the declared capability")),

--- a/docs/assets/repo-stats-dark.svg
+++ b/docs/assets/repo-stats-dark.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 46,633 lines of test code against 78,555 lines of source, 2,288 tests, 80.1% line coverage">
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 47,001 lines of test code against 78,714 lines of source, 2,299 tests, 80.1% line coverage">
 <style>text{font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}.n{font-weight:700;font-variant-numeric:tabular-nums}.l{font-size:11px;letter-spacing:.06em;text-transform:uppercase}</style>
 <rect width="820" height="268" rx="10" fill="#0d1117" stroke="#30363d"/>
 <text x="32" y="42" class="n" font-size="16" fill="#e6edf3">Areev — repository quality</text>
 <text x="32" y="62" font-size="12" fill="#8b949e">v1.6.0 · 17 crates · 275 Rust files</text>
 <rect x="32.0" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
-<text x="44.0" y="106" class="n" font-size="19" fill="#bc8cff">78,555</text>
+<text x="44.0" y="106" class="n" font-size="19" fill="#bc8cff">78,714</text>
 <text x="44.0" y="122" class="l" fill="#8b949e">source code</text>
 <rect x="185.6" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
-<text x="197.6" y="106" class="n" font-size="19" fill="#58a6ff">46,633</text>
+<text x="197.6" y="106" class="n" font-size="19" fill="#58a6ff">47,001</text>
 <text x="197.6" y="122" class="l" fill="#8b949e">test code</text>
 <rect x="339.2" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
-<text x="351.2" y="106" class="n" font-size="19" fill="#3fb950">2,288</text>
+<text x="351.2" y="106" class="n" font-size="19" fill="#3fb950">2,299</text>
 <text x="351.2" y="122" class="l" fill="#8b949e">tests</text>
 <rect x="492.8" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
 <text x="504.8" y="106" class="n" font-size="19" fill="#3fb950">80.1%</text>
@@ -19,9 +19,9 @@
 <text x="658.4" y="106" class="n" font-size="19" fill="#e6edf3">91</text>
 <text x="658.4" y="122" class="l" fill="#8b949e">error codes</text>
 <rect x="32" y="150" width="756" height="34" rx="6" fill="#bc8cff"/>
-<path d="M32 156a6 6 0 0 1 6-6h276v34h-276a6 6 0 0 1-6-6z" fill="#58a6ff"/>
-<text x="44" y="172" class="n" font-size="12" fill="#0d1117">tests 37.3%</text>
-<text x="776" y="172" class="n" font-size="12" fill="#0d1117" text-anchor="end">source 62.7%</text>
-<text x="32" y="212" font-size="12" fill="#8b949e">24,638 integration · 21,995 unit test lines · 52 reference docs · 17 crates</text>
+<path d="M32 156a6 6 0 0 1 6-6h277v34h-277a6 6 0 0 1-6-6z" fill="#58a6ff"/>
+<text x="44" y="172" class="n" font-size="12" fill="#0d1117">tests 37.4%</text>
+<text x="776" y="172" class="n" font-size="12" fill="#0d1117" text-anchor="end">source 62.6%</text>
+<text x="32" y="212" font-size="12" fill="#8b949e">24,947 integration · 22,054 unit test lines · 52 reference docs · 17 crates</text>
 <text x="32" y="238" font-size="11" fill="#8b949e">Lines exclude blanks and comments; test code counted per block, not per file. Coverage scores source lines only, floored per crate.</text>
 </svg>

--- a/docs/assets/repo-stats-dark.svg
+++ b/docs/assets/repo-stats-dark.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 47,001 lines of test code against 78,714 lines of source, 2,299 tests, 80.1% line coverage">
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 47,356 lines of test code against 78,979 lines of source, 2,309 tests, 80.1% line coverage">
 <style>text{font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}.n{font-weight:700;font-variant-numeric:tabular-nums}.l{font-size:11px;letter-spacing:.06em;text-transform:uppercase}</style>
 <rect width="820" height="268" rx="10" fill="#0d1117" stroke="#30363d"/>
 <text x="32" y="42" class="n" font-size="16" fill="#e6edf3">Areev — repository quality</text>
 <text x="32" y="62" font-size="12" fill="#8b949e">v1.6.0 · 17 crates · 275 Rust files</text>
 <rect x="32.0" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
-<text x="44.0" y="106" class="n" font-size="19" fill="#bc8cff">78,714</text>
+<text x="44.0" y="106" class="n" font-size="19" fill="#bc8cff">78,979</text>
 <text x="44.0" y="122" class="l" fill="#8b949e">source code</text>
 <rect x="185.6" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
-<text x="197.6" y="106" class="n" font-size="19" fill="#58a6ff">47,001</text>
+<text x="197.6" y="106" class="n" font-size="19" fill="#58a6ff">47,356</text>
 <text x="197.6" y="122" class="l" fill="#8b949e">test code</text>
 <rect x="339.2" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
-<text x="351.2" y="106" class="n" font-size="19" fill="#3fb950">2,299</text>
+<text x="351.2" y="106" class="n" font-size="19" fill="#3fb950">2,309</text>
 <text x="351.2" y="122" class="l" fill="#8b949e">tests</text>
 <rect x="492.8" y="80" width="141.6" height="52" rx="7" fill="#161b22" stroke="#30363d"/>
 <text x="504.8" y="106" class="n" font-size="19" fill="#3fb950">80.1%</text>
@@ -20,8 +20,8 @@
 <text x="658.4" y="122" class="l" fill="#8b949e">error codes</text>
 <rect x="32" y="150" width="756" height="34" rx="6" fill="#bc8cff"/>
 <path d="M32 156a6 6 0 0 1 6-6h277v34h-277a6 6 0 0 1-6-6z" fill="#58a6ff"/>
-<text x="44" y="172" class="n" font-size="12" fill="#0d1117">tests 37.4%</text>
-<text x="776" y="172" class="n" font-size="12" fill="#0d1117" text-anchor="end">source 62.6%</text>
-<text x="32" y="212" font-size="12" fill="#8b949e">24,947 integration · 22,054 unit test lines · 52 reference docs · 17 crates</text>
+<text x="44" y="172" class="n" font-size="12" fill="#0d1117">tests 37.5%</text>
+<text x="776" y="172" class="n" font-size="12" fill="#0d1117" text-anchor="end">source 62.5%</text>
+<text x="32" y="212" font-size="12" fill="#8b949e">25,260 integration · 22,096 unit test lines · 52 reference docs · 17 crates</text>
 <text x="32" y="238" font-size="11" fill="#8b949e">Lines exclude blanks and comments; test code counted per block, not per file. Coverage scores source lines only, floored per crate.</text>
 </svg>

--- a/docs/assets/repo-stats-light.svg
+++ b/docs/assets/repo-stats-light.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 46,633 lines of test code against 78,555 lines of source, 2,288 tests, 80.1% line coverage">
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 47,001 lines of test code against 78,714 lines of source, 2,299 tests, 80.1% line coverage">
 <style>text{font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}.n{font-weight:700;font-variant-numeric:tabular-nums}.l{font-size:11px;letter-spacing:.06em;text-transform:uppercase}</style>
 <rect width="820" height="268" rx="10" fill="#ffffff" stroke="#dfe3e8"/>
 <text x="32" y="42" class="n" font-size="16" fill="#111418">Areev — repository quality</text>
 <text x="32" y="62" font-size="12" fill="#5b6470">v1.6.0 · 17 crates · 275 Rust files</text>
 <rect x="32.0" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
-<text x="44.0" y="106" class="n" font-size="19" fill="#8250df">78,555</text>
+<text x="44.0" y="106" class="n" font-size="19" fill="#8250df">78,714</text>
 <text x="44.0" y="122" class="l" fill="#5b6470">source code</text>
 <rect x="185.6" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
-<text x="197.6" y="106" class="n" font-size="19" fill="#1f6feb">46,633</text>
+<text x="197.6" y="106" class="n" font-size="19" fill="#1f6feb">47,001</text>
 <text x="197.6" y="122" class="l" fill="#5b6470">test code</text>
 <rect x="339.2" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
-<text x="351.2" y="106" class="n" font-size="19" fill="#0a7d55">2,288</text>
+<text x="351.2" y="106" class="n" font-size="19" fill="#0a7d55">2,299</text>
 <text x="351.2" y="122" class="l" fill="#5b6470">tests</text>
 <rect x="492.8" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
 <text x="504.8" y="106" class="n" font-size="19" fill="#0a7d55">80.1%</text>
@@ -19,9 +19,9 @@
 <text x="658.4" y="106" class="n" font-size="19" fill="#111418">91</text>
 <text x="658.4" y="122" class="l" fill="#5b6470">error codes</text>
 <rect x="32" y="150" width="756" height="34" rx="6" fill="#8250df"/>
-<path d="M32 156a6 6 0 0 1 6-6h276v34h-276a6 6 0 0 1-6-6z" fill="#1f6feb"/>
-<text x="44" y="172" class="n" font-size="12" fill="#ffffff">tests 37.3%</text>
-<text x="776" y="172" class="n" font-size="12" fill="#ffffff" text-anchor="end">source 62.7%</text>
-<text x="32" y="212" font-size="12" fill="#5b6470">24,638 integration · 21,995 unit test lines · 52 reference docs · 17 crates</text>
+<path d="M32 156a6 6 0 0 1 6-6h277v34h-277a6 6 0 0 1-6-6z" fill="#1f6feb"/>
+<text x="44" y="172" class="n" font-size="12" fill="#ffffff">tests 37.4%</text>
+<text x="776" y="172" class="n" font-size="12" fill="#ffffff" text-anchor="end">source 62.6%</text>
+<text x="32" y="212" font-size="12" fill="#5b6470">24,947 integration · 22,054 unit test lines · 52 reference docs · 17 crates</text>
 <text x="32" y="238" font-size="11" fill="#5b6470">Lines exclude blanks and comments; test code counted per block, not per file. Coverage scores source lines only, floored per crate.</text>
 </svg>

--- a/docs/assets/repo-stats-light.svg
+++ b/docs/assets/repo-stats-light.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 47,001 lines of test code against 78,714 lines of source, 2,299 tests, 80.1% line coverage">
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="268" viewBox="0 0 820 268" role="img" aria-label="Areev repository quality: 47,356 lines of test code against 78,979 lines of source, 2,309 tests, 80.1% line coverage">
 <style>text{font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}.n{font-weight:700;font-variant-numeric:tabular-nums}.l{font-size:11px;letter-spacing:.06em;text-transform:uppercase}</style>
 <rect width="820" height="268" rx="10" fill="#ffffff" stroke="#dfe3e8"/>
 <text x="32" y="42" class="n" font-size="16" fill="#111418">Areev — repository quality</text>
 <text x="32" y="62" font-size="12" fill="#5b6470">v1.6.0 · 17 crates · 275 Rust files</text>
 <rect x="32.0" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
-<text x="44.0" y="106" class="n" font-size="19" fill="#8250df">78,714</text>
+<text x="44.0" y="106" class="n" font-size="19" fill="#8250df">78,979</text>
 <text x="44.0" y="122" class="l" fill="#5b6470">source code</text>
 <rect x="185.6" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
-<text x="197.6" y="106" class="n" font-size="19" fill="#1f6feb">47,001</text>
+<text x="197.6" y="106" class="n" font-size="19" fill="#1f6feb">47,356</text>
 <text x="197.6" y="122" class="l" fill="#5b6470">test code</text>
 <rect x="339.2" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
-<text x="351.2" y="106" class="n" font-size="19" fill="#0a7d55">2,299</text>
+<text x="351.2" y="106" class="n" font-size="19" fill="#0a7d55">2,309</text>
 <text x="351.2" y="122" class="l" fill="#5b6470">tests</text>
 <rect x="492.8" y="80" width="141.6" height="52" rx="7" fill="#f6f7f9" stroke="#dfe3e8"/>
 <text x="504.8" y="106" class="n" font-size="19" fill="#0a7d55">80.1%</text>
@@ -20,8 +20,8 @@
 <text x="658.4" y="122" class="l" fill="#5b6470">error codes</text>
 <rect x="32" y="150" width="756" height="34" rx="6" fill="#8250df"/>
 <path d="M32 156a6 6 0 0 1 6-6h277v34h-277a6 6 0 0 1-6-6z" fill="#1f6feb"/>
-<text x="44" y="172" class="n" font-size="12" fill="#ffffff">tests 37.4%</text>
-<text x="776" y="172" class="n" font-size="12" fill="#ffffff" text-anchor="end">source 62.6%</text>
-<text x="32" y="212" font-size="12" fill="#5b6470">24,947 integration · 22,054 unit test lines · 52 reference docs · 17 crates</text>
+<text x="44" y="172" class="n" font-size="12" fill="#ffffff">tests 37.5%</text>
+<text x="776" y="172" class="n" font-size="12" fill="#ffffff" text-anchor="end">source 62.5%</text>
+<text x="32" y="212" font-size="12" fill="#5b6470">25,260 integration · 22,096 unit test lines · 52 reference docs · 17 crates</text>
 <text x="32" y="238" font-size="11" fill="#5b6470">Lines exclude blanks and comments; test code counted per block, not per file. Coverage scores source lines only, floored per crate.</text>
 </svg>

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1089,6 +1089,12 @@ so a binary payload would have to be base64'd into the response and would blow
 the context window it landed in. Tools that need bytes should take the `cas://`
 URI from a grain's `content_refs` and shell out to `areev blob get`.
 
+A **sandboxed** capability tool has its own door (#106): declare
+`{"blob": {"read": true}}` and call `areev::blob_get`, which reads by content
+address through the run's broker and journals a `blob_read`. That is the path
+for anything processing untrusted attachment bytes, since it needs no
+subprocess and no filesystem access — see [run.md](run.md).
+
 ---
 
 ## 18. Start a workflow when something happens (triggers)

--- a/docs/repo-stats.html
+++ b/docs/repo-stats.html
@@ -61,9 +61,9 @@
     <code>scripts/repo_stats.py</code></p>
 
   <div class="tiles">
-      <div class="tile"><div class="v" style="color:var(--test)">47,001</div><div class="l">lines of test code</div></div>
-      <div class="tile"><div class="v" style="color:var(--source)">78,714</div><div class="l">lines of source code</div></div>
-      <div class="tile"><div class="v" style="color:var(--accent)">2,299</div><div class="l">test functions</div></div>
+      <div class="tile"><div class="v" style="color:var(--test)">47,356</div><div class="l">lines of test code</div></div>
+      <div class="tile"><div class="v" style="color:var(--source)">78,979</div><div class="l">lines of source code</div></div>
+      <div class="tile"><div class="v" style="color:var(--accent)">2,309</div><div class="l">test functions</div></div>
       <div class="tile"><div class="v" style="color:var(--accent)">80.1%</div><div class="l">line coverage (source only)</div></div>
       <div class="tile"><div class="v" style="color:var(--fg)">0.6:1</div><div class="l">test to source</div></div>
       <div class="tile"><div class="v" style="color:var(--fg)">17</div><div class="l">workspace crates</div></div>
@@ -76,11 +76,11 @@
       <thead><tr><th>Crate</th><th>Files</th><th>Source</th><th>Test</th><th>Tests</th>
         <th>Coverage</th><th>Floor</th></tr></thead>
       <tbody>
-      <tr><td><code>areev-cal</code></td><td>39</td><td>23,861</td><td>18,287</td><td>985</td><td class="cov"><span class="meter"><i class="good" style="width:72%"></i></span>72.0%</td><td class="muted">70%</td></tr>
+      <tr><td><code>areev-cal</code></td><td>39</td><td>23,866</td><td>18,287</td><td>985</td><td class="cov"><span class="meter"><i class="good" style="width:72%"></i></span>72.0%</td><td class="muted">70%</td></tr>
       <tr><td><code>areev-store</code></td><td>38</td><td>9,452</td><td>5,136</td><td>248</td><td class="cov"><span class="meter"><i class="good" style="width:86%"></i></span>85.8%</td><td class="muted">83%</td></tr>
-      <tr><td><code>areev-core</code></td><td>49</td><td>8,464</td><td>4,133</td><td>274</td><td class="cov"><span class="meter"><i class="good" style="width:83%"></i></span>82.6%</td><td class="muted">80%</td></tr>
-      <tr><td><code>areev-cli</code></td><td>18</td><td>5,683</td><td>5,549</td><td>165</td><td class="cov"><span class="meter"><i class="good" style="width:72%"></i></span>72.3%</td><td class="muted">70%</td></tr>
-      <tr><td><code>areev-run</code></td><td>20</td><td>4,957</td><td>4,337</td><td>138</td><td class="cov"><span class="meter"><i class="good" style="width:82%"></i></span>81.7%</td><td class="muted">79%</td></tr>
+      <tr><td><code>areev-core</code></td><td>49</td><td>8,497</td><td>4,175</td><td>277</td><td class="cov"><span class="meter"><i class="good" style="width:83%"></i></span>82.6%</td><td class="muted">80%</td></tr>
+      <tr><td><code>areev-cli</code></td><td>18</td><td>5,685</td><td>5,549</td><td>165</td><td class="cov"><span class="meter"><i class="good" style="width:72%"></i></span>72.3%</td><td class="muted">70%</td></tr>
+      <tr><td><code>areev-run</code></td><td>20</td><td>5,182</td><td>4,650</td><td>145</td><td class="cov"><span class="meter"><i class="good" style="width:82%"></i></span>81.7%</td><td class="muted">79%</td></tr>
       <tr><td><code>areev-loop</code></td><td>34</td><td>7,858</td><td>1,187</td><td>137</td><td class="cov"><span class="meter"><i class="good" style="width:93%"></i></span>93.1%</td><td class="muted">90%</td></tr>
       <tr><td><code>areev-context</code></td><td>8</td><td>1,899</td><td>2,421</td><td>90</td><td class="cov"><span class="meter"><i class="good" style="width:81%"></i></span>81.4%</td><td class="muted">79%</td></tr>
       <tr><td><code>areev-trigger</code></td><td>12</td><td>1,646</td><td>2,000</td><td>114</td><td class="cov"><span class="meter"><i class="good" style="width:91%"></i></span>91.0%</td><td class="muted">89%</td></tr>
@@ -127,13 +127,13 @@
     <table>
       <tbody>
         <tr><td>Rust files</td><td>275</td></tr>
-        <tr><td>Physical lines (all Rust)</td><td>164,112</td></tr>
-        <tr><td>Source code (no blanks or comments)</td><td>78,714</td></tr>
-        <tr><td>Unit test code (<code>#[cfg(test)]</code> blocks)</td><td>22,054</td></tr>
-        <tr><td>Integration test code (<code>tests/</code>, <code>benches/</code>)</td><td>24,947</td></tr>
+        <tr><td>Physical lines (all Rust)</td><td>164,996</td></tr>
+        <tr><td>Source code (no blanks or comments)</td><td>78,979</td></tr>
+        <tr><td>Unit test code (<code>#[cfg(test)]</code> blocks)</td><td>22,096</td></tr>
+        <tr><td>Integration test code (<code>tests/</code>, <code>benches/</code>)</td><td>25,260</td></tr>
         <tr><td>Example code (<code>examples/</code>)</td><td>669</td></tr>
-        <tr><td>Test functions</td><td>2,299</td></tr>
-        <tr><td>Reference docs</td><td>52 files, 22,050 lines</td></tr>
+        <tr><td>Test functions</td><td>2,309</td></tr>
+        <tr><td>Reference docs</td><td>52 files, 22,184 lines</td></tr>
         <tr><td>Stable error codes</td><td>91</td></tr>
       </tbody>
     </table>

--- a/docs/repo-stats.html
+++ b/docs/repo-stats.html
@@ -61,11 +61,11 @@
     <code>scripts/repo_stats.py</code></p>
 
   <div class="tiles">
-      <div class="tile"><div class="v" style="color:var(--test)">46,633</div><div class="l">lines of test code</div></div>
-      <div class="tile"><div class="v" style="color:var(--source)">78,555</div><div class="l">lines of source code</div></div>
-      <div class="tile"><div class="v" style="color:var(--accent)">2,288</div><div class="l">test functions</div></div>
+      <div class="tile"><div class="v" style="color:var(--test)">47,001</div><div class="l">lines of test code</div></div>
+      <div class="tile"><div class="v" style="color:var(--source)">78,714</div><div class="l">lines of source code</div></div>
+      <div class="tile"><div class="v" style="color:var(--accent)">2,299</div><div class="l">test functions</div></div>
       <div class="tile"><div class="v" style="color:var(--accent)">80.1%</div><div class="l">line coverage (source only)</div></div>
-      <div class="tile"><div class="v" style="color:var(--fg)">0.59:1</div><div class="l">test to source</div></div>
+      <div class="tile"><div class="v" style="color:var(--fg)">0.6:1</div><div class="l">test to source</div></div>
       <div class="tile"><div class="v" style="color:var(--fg)">17</div><div class="l">workspace crates</div></div>
       <div class="tile"><div class="v" style="color:var(--fg)">91</div><div class="l">stable error codes</div></div>
   </div>
@@ -78,9 +78,9 @@
       <tbody>
       <tr><td><code>areev-cal</code></td><td>39</td><td>23,861</td><td>18,287</td><td>985</td><td class="cov"><span class="meter"><i class="good" style="width:72%"></i></span>72.0%</td><td class="muted">70%</td></tr>
       <tr><td><code>areev-store</code></td><td>38</td><td>9,452</td><td>5,136</td><td>248</td><td class="cov"><span class="meter"><i class="good" style="width:86%"></i></span>85.8%</td><td class="muted">83%</td></tr>
-      <tr><td><code>areev-core</code></td><td>49</td><td>8,396</td><td>4,074</td><td>270</td><td class="cov"><span class="meter"><i class="good" style="width:83%"></i></span>82.6%</td><td class="muted">80%</td></tr>
+      <tr><td><code>areev-core</code></td><td>49</td><td>8,464</td><td>4,133</td><td>274</td><td class="cov"><span class="meter"><i class="good" style="width:83%"></i></span>82.6%</td><td class="muted">80%</td></tr>
       <tr><td><code>areev-cli</code></td><td>18</td><td>5,683</td><td>5,549</td><td>165</td><td class="cov"><span class="meter"><i class="good" style="width:72%"></i></span>72.3%</td><td class="muted">70%</td></tr>
-      <tr><td><code>areev-run</code></td><td>20</td><td>4,866</td><td>4,028</td><td>131</td><td class="cov"><span class="meter"><i class="good" style="width:82%"></i></span>81.7%</td><td class="muted">79%</td></tr>
+      <tr><td><code>areev-run</code></td><td>20</td><td>4,957</td><td>4,337</td><td>138</td><td class="cov"><span class="meter"><i class="good" style="width:82%"></i></span>81.7%</td><td class="muted">79%</td></tr>
       <tr><td><code>areev-loop</code></td><td>34</td><td>7,858</td><td>1,187</td><td>137</td><td class="cov"><span class="meter"><i class="good" style="width:93%"></i></span>93.1%</td><td class="muted">90%</td></tr>
       <tr><td><code>areev-context</code></td><td>8</td><td>1,899</td><td>2,421</td><td>90</td><td class="cov"><span class="meter"><i class="good" style="width:81%"></i></span>81.4%</td><td class="muted">79%</td></tr>
       <tr><td><code>areev-trigger</code></td><td>12</td><td>1,646</td><td>2,000</td><td>114</td><td class="cov"><span class="meter"><i class="good" style="width:91%"></i></span>91.0%</td><td class="muted">89%</td></tr>
@@ -127,13 +127,13 @@
     <table>
       <tbody>
         <tr><td>Rust files</td><td>275</td></tr>
-        <tr><td>Physical lines (all Rust)</td><td>163,376</td></tr>
-        <tr><td>Source code (no blanks or comments)</td><td>78,555</td></tr>
-        <tr><td>Unit test code (<code>#[cfg(test)]</code> blocks)</td><td>21,995</td></tr>
-        <tr><td>Integration test code (<code>tests/</code>, <code>benches/</code>)</td><td>24,638</td></tr>
+        <tr><td>Physical lines (all Rust)</td><td>164,112</td></tr>
+        <tr><td>Source code (no blanks or comments)</td><td>78,714</td></tr>
+        <tr><td>Unit test code (<code>#[cfg(test)]</code> blocks)</td><td>22,054</td></tr>
+        <tr><td>Integration test code (<code>tests/</code>, <code>benches/</code>)</td><td>24,947</td></tr>
         <tr><td>Example code (<code>examples/</code>)</td><td>669</td></tr>
-        <tr><td>Test functions</td><td>2,288</td></tr>
-        <tr><td>Reference docs</td><td>52 files, 21,972 lines</td></tr>
+        <tr><td>Test functions</td><td>2,299</td></tr>
+        <tr><td>Reference docs</td><td>52 files, 22,050 lines</td></tr>
         <tr><td>Stable error codes</td><td>91</td></tr>
       </tbody>
     </table>

--- a/docs/repo-stats.json
+++ b/docs/repo-stats.json
@@ -3,22 +3,22 @@
   "crates": 17,
   "rust": {
     "files": 275,
-    "physical_lines": 164112,
-    "source_code": 78714,
-    "test_code": 47001,
-    "unit_test_code": 22054,
-    "integration_test_code": 24947,
+    "physical_lines": 164996,
+    "source_code": 78979,
+    "test_code": 47356,
+    "unit_test_code": 22096,
+    "integration_test_code": 25260,
     "example_code": 669,
-    "test_functions": 2299,
+    "test_functions": 2309,
     "test_ratio": 0.6,
-    "test_share": 37.4
+    "test_share": 37.5
   },
   "per_crate": [
     {
       "name": "areev-cal",
       "files": 39,
-      "physical": 54391,
-      "source_code": 23861,
+      "physical": 54396,
+      "source_code": 23866,
       "test_code": 18287,
       "tests": 985
     },
@@ -33,26 +33,26 @@
     {
       "name": "areev-core",
       "files": 49,
-      "physical": 16535,
-      "source_code": 8464,
-      "test_code": 4133,
-      "tests": 274
+      "physical": 16638,
+      "source_code": 8497,
+      "test_code": 4175,
+      "tests": 277
     },
     {
       "name": "areev-cli",
       "files": 18,
-      "physical": 14034,
-      "source_code": 5683,
+      "physical": 14046,
+      "source_code": 5685,
       "test_code": 5549,
       "tests": 165
     },
     {
       "name": "areev-run",
       "files": 20,
-      "physical": 12400,
-      "source_code": 4957,
-      "test_code": 4337,
-      "tests": 138
+      "physical": 13162,
+      "source_code": 5182,
+      "test_code": 4650,
+      "tests": 145
     },
     {
       "name": "areev-loop",
@@ -81,7 +81,7 @@
     {
       "name": "areev-run-core",
       "files": 8,
-      "physical": 3794,
+      "physical": 3796,
       "source_code": 1934,
       "test_code": 969,
       "tests": 31
@@ -153,7 +153,7 @@
   ],
   "docs": {
     "files": 52,
-    "lines": 22050
+    "lines": 22184
   },
   "error_codes": 91,
   "bindings": {

--- a/docs/repo-stats.json
+++ b/docs/repo-stats.json
@@ -3,15 +3,15 @@
   "crates": 17,
   "rust": {
     "files": 275,
-    "physical_lines": 163376,
-    "source_code": 78555,
-    "test_code": 46633,
-    "unit_test_code": 21995,
-    "integration_test_code": 24638,
+    "physical_lines": 164112,
+    "source_code": 78714,
+    "test_code": 47001,
+    "unit_test_code": 22054,
+    "integration_test_code": 24947,
     "example_code": 669,
-    "test_functions": 2288,
-    "test_ratio": 0.59,
-    "test_share": 37.3
+    "test_functions": 2299,
+    "test_ratio": 0.6,
+    "test_share": 37.4
   },
   "per_crate": [
     {
@@ -33,10 +33,10 @@
     {
       "name": "areev-core",
       "files": 49,
-      "physical": 16352,
-      "source_code": 8396,
-      "test_code": 4074,
-      "tests": 270
+      "physical": 16535,
+      "source_code": 8464,
+      "test_code": 4133,
+      "tests": 274
     },
     {
       "name": "areev-cli",
@@ -49,10 +49,10 @@
     {
       "name": "areev-run",
       "files": 20,
-      "physical": 11848,
-      "source_code": 4866,
-      "test_code": 4028,
-      "tests": 131
+      "physical": 12400,
+      "source_code": 4957,
+      "test_code": 4337,
+      "tests": 138
     },
     {
       "name": "areev-loop",
@@ -81,7 +81,7 @@
     {
       "name": "areev-run-core",
       "files": 8,
-      "physical": 3793,
+      "physical": 3794,
       "source_code": 1934,
       "test_code": 969,
       "tests": 31
@@ -153,7 +153,7 @@
   ],
   "docs": {
     "files": 52,
-    "lines": 21972
+    "lines": 22050
   },
   "error_codes": 91,
   "bindings": {

--- a/docs/repo-stats.md
+++ b/docs/repo-stats.md
@@ -6,22 +6,22 @@ v1.6.0 · 17 crates · 275 Rust files
 
 | | |
 |---|---|
-| Source code | **78,714** lines |
-| Test code | **47,001** lines (37.4% of all code) |
-| Test functions | **2,299** |
+| Source code | **78,979** lines |
+| Test code | **47,356** lines (37.5% of all code) |
+| Test functions | **2,309** |
 | Line coverage | **80.1%** of 52,407 instrumented source lines |
 | Stable error codes | **91** |
-| Reference docs | 52 files, 22,050 lines |
+| Reference docs | 52 files, 22,184 lines |
 
 ## By crate
 
 | Crate | Files | Source | Test | Tests |
 |---|---:|---:|---:|---:|
-| `areev-cal` | 39 | 23,861 | 18,287 | 985 |
+| `areev-cal` | 39 | 23,866 | 18,287 | 985 |
 | `areev-store` | 38 | 9,452 | 5,136 | 248 |
-| `areev-core` | 49 | 8,464 | 4,133 | 274 |
-| `areev-cli` | 18 | 5,683 | 5,549 | 165 |
-| `areev-run` | 20 | 4,957 | 4,337 | 138 |
+| `areev-core` | 49 | 8,497 | 4,175 | 277 |
+| `areev-cli` | 18 | 5,685 | 5,549 | 165 |
+| `areev-run` | 20 | 5,182 | 4,650 | 145 |
 | `areev-loop` | 34 | 7,858 | 1,187 | 137 |
 | `areev-context` | 8 | 1,899 | 2,421 | 90 |
 | `areev-trigger` | 12 | 1,646 | 2,000 | 114 |
@@ -39,12 +39,12 @@ v1.6.0 · 17 crates · 275 Rust files
 
 | | |
 |---|---:|
-| Physical lines (all Rust) | 164,112 |
-| Source code (no blanks or comments) | 78,714 |
-| Unit test code (`#[cfg(test)]` blocks) | 22,054 |
-| Integration test code (`tests/`, `benches/`) | 24,947 |
+| Physical lines (all Rust) | 164,996 |
+| Source code (no blanks or comments) | 78,979 |
+| Unit test code (`#[cfg(test)]` blocks) | 22,096 |
+| Integration test code (`tests/`, `benches/`) | 25,260 |
 | Example code (`examples/`) | 669 |
-| Test functions | 2,299 |
+| Test functions | 2,309 |
 
 ## Coverage
 

--- a/docs/repo-stats.md
+++ b/docs/repo-stats.md
@@ -6,12 +6,12 @@ v1.6.0 · 17 crates · 275 Rust files
 
 | | |
 |---|---|
-| Source code | **78,555** lines |
-| Test code | **46,633** lines (37.3% of all code) |
-| Test functions | **2,288** |
+| Source code | **78,714** lines |
+| Test code | **47,001** lines (37.4% of all code) |
+| Test functions | **2,299** |
 | Line coverage | **80.1%** of 52,407 instrumented source lines |
 | Stable error codes | **91** |
-| Reference docs | 52 files, 21,972 lines |
+| Reference docs | 52 files, 22,050 lines |
 
 ## By crate
 
@@ -19,9 +19,9 @@ v1.6.0 · 17 crates · 275 Rust files
 |---|---:|---:|---:|---:|
 | `areev-cal` | 39 | 23,861 | 18,287 | 985 |
 | `areev-store` | 38 | 9,452 | 5,136 | 248 |
-| `areev-core` | 49 | 8,396 | 4,074 | 270 |
+| `areev-core` | 49 | 8,464 | 4,133 | 274 |
 | `areev-cli` | 18 | 5,683 | 5,549 | 165 |
-| `areev-run` | 20 | 4,866 | 4,028 | 131 |
+| `areev-run` | 20 | 4,957 | 4,337 | 138 |
 | `areev-loop` | 34 | 7,858 | 1,187 | 137 |
 | `areev-context` | 8 | 1,899 | 2,421 | 90 |
 | `areev-trigger` | 12 | 1,646 | 2,000 | 114 |
@@ -39,12 +39,12 @@ v1.6.0 · 17 crates · 275 Rust files
 
 | | |
 |---|---:|
-| Physical lines (all Rust) | 163,376 |
-| Source code (no blanks or comments) | 78,555 |
-| Unit test code (`#[cfg(test)]` blocks) | 21,995 |
-| Integration test code (`tests/`, `benches/`) | 24,638 |
+| Physical lines (all Rust) | 164,112 |
+| Source code (no blanks or comments) | 78,714 |
+| Unit test code (`#[cfg(test)]` blocks) | 22,054 |
+| Integration test code (`tests/`, `benches/`) | 24,947 |
 | Example code (`examples/`) | 669 |
-| Test functions | 2,288 |
+| Test functions | 2,299 |
 
 ## Coverage
 

--- a/docs/run.md
+++ b/docs/run.md
@@ -388,9 +388,32 @@ run already has.
                 "methods": ["POST"],
                 "path_prefixes": ["/gmail/v1/users/me/"],
                 "credentials": ["gmail"],
-                "headers": ["X-Goog-User-Project"] } }
+                "headers": ["X-Goog-User-Project"] } },
+    { "blob": { "read": true } }
   ] }
 ```
+
+The two capabilities are **independent**. `{"blob": {"read": true}}` (#106)
+lets a module read the memory's stored bytes by content address — the
+attachment a trigger's connector already filed — through the same broker on
+the same token, and grants no network. A module that parses attachments and
+calls nothing declares only `blob`; one that calls an API and reads nothing
+declares only `http`. Read-only, by address only: there is no enumeration, no
+write, and no namespace access, so a module fetches bytes it was handed a
+`cas://` reference to and cannot browse the memory. Every read lands as a
+`blob_read` Observation naming the address and the byte count.
+
+A blob-only module still needs a grant, because the token is what identifies
+the caller: `--tool-egress 'parse_attachments::'` names neither a credential
+nor a method, minting a token and authorizing no egress whatsoever.
+
+⚠️ **Embedded backend only.** The read is lock-free precisely because it goes
+to the `.blobs` sidecar without opening the database — and that sidecar is an
+embedded-backend thing. On PostgreSQL a blob lives in-schema, so
+`areev::blob_get` returns a `501` naming the limitation rather than reporting
+the attachment as missing. On that backend a tool can open the memory
+directly anyway (see [Backend divergence](#backend-divergence-reading-the-memory-mid-run-85)),
+so the capability is closing an embedded-tier gap.
 
 `headers` names the non-credential request headers the module may set, and is
 deny-by-default like `credentials`: declaring none permits none. A name the
@@ -435,6 +458,10 @@ What is enforced, and where:
 | a malformed declaration | CAL write, and again at resolve | write rejected / `RUN-E018` |
 | the runtime with no broker, or no `--tool-egress` for this tool | dispatch | node fails, naming the missing flag |
 | a module importing `areev::fetch` undeclared | sandbox instantiation | `ForbiddenImport`, by name, before one instruction |
+| a module importing `areev::blob_get` without `{"blob": {"read": true}}` | sandbox instantiation | `ForbiddenImport` — gated on the DECLARATION, not the runtime, so an http-only module never gains it |
+| a blob read by a caller that declared no `blob` capability | broker, per read | 403 + a journaled refusal |
+| a blob read when the host wired no memory | broker, per read | 503 — declaring is not granting on this door either |
+| a malformed or unknown `cas://` address | broker, per read | 404 — the address is the only way in, so there is nothing to enumerate |
 | host / path / method / credential / header outside the declaration | broker, per call **and per redirect hop** | 403 + a journaled refusal |
 | a request header the broker owns (`Authorization`, `Cookie`, `Host`, `Proxy-Authorization`, or one carrying a configured credential) | broker, per call — before the call budget is spent | 403 + a journaled refusal; the answer is the same for every caller, so it costs nothing to ask |
 | a malformed header name, or a value containing CR/LF | broker, per call | 400 — header injection is refused as malformed, not merely denied |
@@ -491,9 +518,12 @@ the storage tier, and it silently decides whether an agent design is portable:
 
 - **Embedded (Turso file)**: no — the file lock is exclusive, so even a pure
   `RECALL` from inside a tool is refused (`STO-E001`). Use the doors that
-  exist: `areev blob get` reads CAS attachments lock-free, and a **trigger's
-  `--context-query`** has the evaluator assemble a saved query's result into
-  the run input before the run starts ([triggers](triggers.md)).
+  exist: `areev blob get` reads CAS attachments lock-free, a **capability
+  tool** reads them with `areev::blob_get` through the broker (#106, above),
+  and a **trigger's `--context-query`** has the evaluator assemble a saved
+  query's result into the run input before the run starts
+  ([triggers](triggers.md)). All three are lock-free by construction, which is
+  why they work while the run holds the file.
 - **PostgreSQL (server tier)**: yes — any number of handles may hold the same
   schema and reads never block (MVCC), so a tool may open the memory and
   query it mid-run. If your production target is Postgres, tools can read

--- a/docs/run.md
+++ b/docs/run.md
@@ -216,13 +216,25 @@ The tool gets `AREEV_EGRESS_URL` and `AREEV_EGRESS_TOKEN` in its environment —
 
 ```json
 { "url": "https://books.zoho.com/api/v3/bills", "method": "POST",
-  "credential": "zoho", "body": "{...}" }
+  "credential": "zoho", "headers": { "X-Tenant-Id": "acme" },
+  "body": "{...}" }
 ```
 
 The broker checks the destination against `--allow-host`, the method and
 credential against that tool's grant, attaches the credential, and makes the
 request. The token never enters the tool's process, so a compromised tool has
 nothing to exfiltrate.
+
+`headers` is optional and carries **non-credential** request headers — the
+ones enterprise APIs require and no credential expresses: `X-Goog-User-Project`
+on Google calls made with user credentials, `anthropic-version`, `x-ms-version`,
+a tenant id. The broker refuses `Authorization`, `Proxy-Authorization`,
+`Cookie`, `Host`, and any header a configured credential rides in, whatever
+their casing: those are the broker's to set, and a caller that could write them
+would be holding the credential channel it exists not to hold. A malformed name
+or a value containing CR/LF is a `400` — header injection dies at the parse, not
+at the socket. Because the caller chose these values, they are **journaled in
+full**, unlike a credential, which is journaled by name only.
 
 `--tool-egress tool:credentials:methods` is the grant, `+`-separated within a
 field. Three rules are deliberate:
@@ -375,9 +387,17 @@ run already has.
     { "http": { "hosts": ["https://gmail.googleapis.com"],
                 "methods": ["POST"],
                 "path_prefixes": ["/gmail/v1/users/me/"],
-                "credentials": ["gmail"] } }
+                "credentials": ["gmail"],
+                "headers": ["X-Goog-User-Project"] } }
   ] }
 ```
+
+`headers` names the non-credential request headers the module may set, and is
+deny-by-default like `credentials`: declaring none permits none. A name the
+broker owns (`Authorization`, `Cookie`, `Host`, `Proxy-Authorization`) is
+refused **at write time**, so a module that tries to declare the credential
+channel is unwritable rather than writable-and-refused-later. Matching is
+case-insensitive, because HTTP field names are.
 
 **`capabilities` declares; it never grants.** The effective set is
 `declared ∩ host-granted`, checked on every call, so the declaration can only
@@ -415,7 +435,9 @@ What is enforced, and where:
 | a malformed declaration | CAL write, and again at resolve | write rejected / `RUN-E018` |
 | the runtime with no broker, or no `--tool-egress` for this tool | dispatch | node fails, naming the missing flag |
 | a module importing `areev::fetch` undeclared | sandbox instantiation | `ForbiddenImport`, by name, before one instruction |
-| host / path / method / credential outside the declaration | broker, per call **and per redirect hop** | 403 + a journaled refusal |
+| host / path / method / credential / header outside the declaration | broker, per call **and per redirect hop** | 403 + a journaled refusal |
+| a request header the broker owns (`Authorization`, `Cookie`, `Host`, `Proxy-Authorization`, or one carrying a configured credential) | broker, per call — before the call budget is spent | 403 + a journaled refusal; the answer is the same for every caller, so it costs nothing to ask |
+| a malformed header name, or a value containing CR/LF | broker, per call | 400 — header injection is refused as malformed, not merely denied |
 | an evasive path (`..`, `%2e`/`%2f`/`%5c`, `\\`) against declared `path_prefixes` | broker, per call | 403 — refused rather than normalized |
 | anything outside the host grant | broker, per call | 403 + a journaled refusal |
 | a private/loopback destination (`127.0.0.0/8`, `10/8`, `169.254/16`, `::1`, `fc00::/7`, …) under an **unrestricted** policy | broker, per call and per hop | 403 — a declaration alone cannot authorize local reach; name it in `--allow-host` |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -352,9 +352,13 @@ stories (#101):
 | Runtime | Import set | Determinism |
 |---|---|---|
 | `wasm32-areev` | `areev::emit` | pure — **re-execution-provable** |
-| `wasm32-areev-io` | `+ areev::fetch` | deterministic **modulo journaled effects** |
+| `wasm32-areev-io` | `+ areev::fetch`, `+ areev::blob_get` | deterministic **modulo journaled effects** |
 
-`alloc` is a guest *export* the host calls, not an import, in both.
+`alloc` is a guest *export* the host calls, not an import, in both. The two
+capability imports are linked **independently**: `fetch` off the pinned
+runtime, `blob_get` off the pinned declaration, so an http module does not
+silently gain the ability to read stored bytes and a blob module gets no
+network.
 
 Until 1.6.0 the rule was absolute — *a Tier C module cannot make a network
 call, so a connector will never be one* — and that was the reason the tier
@@ -425,6 +429,20 @@ Four properties make it a capability system rather than a hole:
   declaration binds **every redirect hop**, exactly as the allowlist does: a
   `302` on a declared host must not walk a module from its declared paths to
   an endpoint the host-side grant happens to tolerate.
+- **Stored bytes are mediated on the same terms as the network** (#106). A
+  module that declares `{"blob": {"read": true}}` may read CAS blobs by
+  content address, through the same broker on the same token — so the guest
+  gets **neither a socket nor a file descriptor**, and every read is journaled
+  as a `blob_read`. Read-only and address-only: no enumeration, no write, no
+  namespace access, so a module reaches bytes it was handed a reference to and
+  cannot browse the memory. The import is linked off the pinned *declaration*
+  rather than the runtime string, because unlike egress there is no host-side
+  grant that narrows it afterwards — which also means an `http` module does not
+  quietly acquire it. Routing the read through the broker rather than letting
+  the sandbox open the file is what makes the journal possible at all: a read
+  performed inside the subprocess has no way back to the driver to be recorded,
+  and attachment parsing is precisely the workload where an unrecorded read
+  matters most.
 - **Every call is journaled**, not just the refusals. See below.
 
 Also out, permanently: guest-visible clock and RNG (that is the determinism
@@ -565,6 +583,7 @@ loses at most one superstep of evidence:
 |---|---|---|
 | `egress_refusal` | caller, destination, reason | per distinct `(caller, destination, reason)` |
 | `egress_call` | caller, method, final URL, status, redirect count, request/response **digests**, response size, credential **name**, caller-set request headers **with values** | none |
+| `blob_read` | caller, `cas://` address, byte count | none |
 
 The dedup difference is deliberate: a refusal is a policy fact and forty
 retries against one blocked host are one of them, but a successful call is an

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -394,11 +394,24 @@ Four properties make it a capability system rather than a hole:
   without a capability declaration is refused at instantiation, by name,
   before one instruction runs — the same `ForbiddenImport` treatment WASI gets.
 - **Effective reach is `declared ∩ host-granted`.** The Tool grain's
-  `capabilities` field declares hosts, methods, path prefixes and credential
-  names; the host's `--allow-host` / `--credential` / `--tool-egress` grant
-  independently. Both are checked on every call, so a declaration can only ever
-  narrow. Default deny throughout: no declaration means no reach, no declared
-  methods means read-only, no declared credentials means none.
+  `capabilities` field declares hosts, methods, path prefixes, credential
+  names and request-header names; the host's `--allow-host` / `--credential` /
+  `--tool-egress` grant independently. Both are checked on every call, so a
+  declaration can only ever narrow. Default deny throughout: no declaration
+  means no reach, no declared methods means read-only, no declared credentials
+  means none, no declared headers means none.
+- **The credential channel is not writable from the guest.** A module may set
+  the non-credential headers enterprise APIs demand — `X-Goog-User-Project`,
+  `anthropic-version`, a tenant id — and may not set `Authorization`,
+  `Proxy-Authorization`, `Cookie`, `Host`, or any header a configured
+  credential rides in, at any casing. Declaring one is refused at write time;
+  sending one is refused before the call budget is spent, because that answer
+  is identical for every caller and so leaks no policy. Values containing
+  CR/LF are refused as malformed: header injection dies at the parse rather
+  than at the socket. Caller-set headers travel exactly as far as the
+  credential does — a cross-origin redirect drops both, since a quota project
+  or tenant id was meant for the host the caller named, not for one an
+  intermediary picked.
 - **Path prefixes, which the host-side grant deliberately does not have.**
   `--allow-host` allowlists hosts because a path-level grant there would imply
   an authorization model it does not have. A capability tool is a different
@@ -551,7 +564,7 @@ loses at most one superstep of evidence:
 | `observation_kind` | Records | Dedup |
 |---|---|---|
 | `egress_refusal` | caller, destination, reason | per distinct `(caller, destination, reason)` |
-| `egress_call` | caller, method, final URL, status, redirect count, request/response **digests**, response size, credential **name** | none |
+| `egress_call` | caller, method, final URL, status, redirect count, request/response **digests**, response size, credential **name**, caller-set request headers **with values** | none |
 
 The dedup difference is deliberate: a refusal is a policy fact and forty
 retries against one blocked host are one of them, but a successful call is an
@@ -562,7 +575,10 @@ and replicates, so an inbox body written into one cannot be taken back, and the
 digest is what pins *which* request anyway. The credential appears by name
 only, which is all the broker ever received: the caller sends a label and the
 value is attached internally, so the record is safe by construction rather than
-by scrubbing.
+by scrubbing. Caller-set headers are the deliberate asymmetry: they are
+recorded with their **values**, because the caller supplied them, so the record
+discloses nothing the caller did not already hold — and "it billed this quota
+project on these four requests" is evidence "it reached Google" is not.
 
 Neither kind is a journal entry. Replay never sees them, so `verify` stays
 byte-identical whether or not a broker was configured — they are evidence

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -508,8 +508,12 @@ posts the call it wants:
 
 ```json
 { "url": "https://gmail.googleapis.com/gmail/v1/users/me/messages",
-  "method": "GET", "credential": "gmail" }
+  "method": "GET", "credential": "gmail",
+  "headers": { "X-Goog-User-Project": "my-project" } }
 ```
+
+(`headers` is optional and carries non-credential request headers only — the
+broker refuses the ones it owns; see [run.md](run.md).)
 
 and the broker checks the allowlist, attaches the credential, and makes the
 request. The token never enters the connector's process. Posta's CB4A calls this


### PR DESCRIPTION
Closes #105. Closes #106.

Two commits, one per issue — the last two things between capability tools and the workloads they are pitched at.

## #105 — non-credential request headers

`areev::fetch` takes an optional `headers` map; a Tool grain declares which names it may use as `capabilities.http.headers`. Every Google API called with user credentials requires `X-Goog-User-Project` or answers `403 … requires a quota project`, and that header is not a credential — so neither the broker nor the guest could set it. Same gap blocked `anthropic-version`, `x-ms-version`, and every tenant header.

**The credential channel stays closed.** `Authorization`, `Proxy-Authorization`, `Cookie`, `Host` are refused at any casing — and so is whatever header a configured `Credential::Header` rides in, which is host configuration rather than a constant, so that check lives *after* credential resolution where the name is first known. Declaring one is refused at **write** time, so a module that tries is unwritable rather than writable-and-refused-on-the-run-someone-needed-it-for.

Three decisions worth flagging for review:

- **The broker-owned refusal is deliberately free**, not charged to the call budget. Spending-before-checking exists so a module cannot probe *per-caller* policy for nothing; "may I write `Authorization`?" has one answer for every caller that ever asks, so answering it reveals no policy.
- **Malformed names and CR/LF values are `400`, not `403`** — header injection is malformed rather than merely denied, and must die at the parse instead of at the socket where it would split one request into two.
- **Guest headers are a separate vector from `credential_headers`** all the way into `perform()`. The reflection scrub iterates the credential vector, and scrubbing a guest-supplied non-secret string out of a response body would corrupt the response.

They ride exactly as far as the credential does — one `send_credential` boolean gates both — so a cross-origin redirect drops both. Not secrecy (the caller chose the values) but intent: a quota project was meant for the host the caller named, not one an intermediary picked. That shared boolean is also why `EgressCall.headers` can be journaled under `credential_sent`, noted at the `Answered` variant so a future split of the flags splits this too. Journaled **with values**, the deliberate asymmetry against the credential's name-only record.

The sandbox needed no change — it forwards guest JSON verbatim, so the guest ABI is the broker ABI.

## #106 — reading CAS blobs

`{"blob": {"read": true}}` gives a module `areev::blob_get`, reading one stored blob by content address. A trigger's connector already files email attachments as CAS blobs, and the tool that parses them is the one that *most* wants sandboxing — untrusted input by construction — yet it was the one tool that structurally could not be.

**I did not implement this the way the issue proposes, and that is the main thing to review.** #106 says reading the `.blobs` sidecar from the sandbox "needs no new engine IPC". The read is lock-free, but the subprocess:

- is handed no memory path under `EnvPolicy::ClearExcept`;
- cannot take `areev-store` without giving up the five-dependency standalone posture that makes it a credible boundary — it would need its own `cas://` parser and SHA-256;
- reads nothing at all on the Postgres backend, where blobs live in-schema;
- and **has no channel back to the driver.** `Outcome.fetches` never reaches the engine as data: stdout is contractually the guest's own result, and the fuel line on stderr is prose for a human.

That last one is decisive — a read performed there could not be journaled, putting the hole in the evidence exactly where the untrusted bytes are. Routing through the broker answers all four at once, since it already runs in the engine's process, already authenticates per-caller tokens, and already records what it mediates. The guarantee becomes one sentence: **the guest gets neither a socket nor a file descriptor.**

Other decisions:

- **`--allow-blob` derives from the pinned declaration; `--allow-fetch` from the pinned runtime.** Asymmetric on purpose: egress has a host-side grant narrowing the runtime's permission afterwards, a blob read has no second key, so deriving it from the runtime would hand the import to every capability module silently.
- **Success answers raw bytes, errors answer JSON, told apart by status** — never by sniffing the payload, since a real attachment is arbitrary binary and may legitimately begin with `{`. Base64-in-JSON would cost a third of the size and oblige every guest to carry a decoder to read its own attachment.
- **One reentrancy flag for every host call**, not one per import: the hazard is re-entering any host function from inside the guest's `alloc`, so per-import flags would leave `blob_get`-inside-`fetch` open.
- **Blob-only tools need no relaxation** of `register_capability` — the token identifies the caller, and `--tool-egress 'parse_pdf::'` already mints one while authorizing no egress.
- **Postgres returns a typed `501`** naming the limitation, rather than letting the sidecar read miss and report "blob missing" — which would send someone hunting for an attachment that is present and simply unreachable this way.

Journaled as `blob_read` Observations (address + byte count) on the same superstep drain as `egress_call`. The address *is* the content hash, so the record names exactly which bytes were opened without putting an attachment into an immutable, replicating grain.

## Error codes

`RUN-E022` covers both refusals rather than minting new codes — it already names three distinct reasons, and these are the same condition: the broker said no. Its registry description is widened; codes stay append-only.

## Verification

- **25 new tests** across four suites (`egress_tests`, `codeexec_tests`, `sandbox_tests`, and the `capability` vocabulary).
- **#105's tests verified non-vacuous by mutation**: dropping `guest_headers` in `perform()` fails exactly the two that assert the header reached the socket, and no others.
- Full workspace green (124 suites), sandbox package green, `clippy -D warnings` clean on both, `repo_stats.py --check` and `check_versions.py` current.
- Docs contract swept: `run.md` (request shape, capability JSON, enforcement table), `security-model.md` (import-set table, capability properties, audit-trail table), `triggers.md`, `cookbook.md` (its "shell out to `areev blob get`" line was made incomplete by #106), the sandbox README + module docs, `ERROR_CODES.md`, `areev-run/CLAUDE.md`, and an `ARCHITECTURE.md` §10 decision for #106.
