### PR TITLE
README: refresh the test count to 2,309

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ not raise the same evidence twice. Both scripts assert their own results and
 | **[CAL](docs/cal-reference.md)** — the context | A query language that **assembles**, not just retrieves: budget-aware rendering, Full → Summary → Omit | A turn needs a *budget-shaped* prompt, and deterministic allocation is what makes a replay comparable |
 | **[The store](docs/why-areev.md#storage-a-plain-sqlite-file-or-a-postgres-schema)** — the record | A provenance graph in a plain **SQLite file** ([Turso](https://github.com/tursodatabase/turso)), or a **PostgreSQL** schema for the server tier | **~30 µs** recall in-process; one conformance suite pins both backends to identical semantics |
 
-| **~30 µs** recall, in-process | runs on a **$35 Raspberry Pi** | **2,288 tests · 80.1% coverage** | **`FORGET SUBJECT`** is one operation |
+| **~30 µs** recall, in-process | runs on a **$35 Raspberry Pi** | **2,309 tests · 80.1% coverage** | **`FORGET SUBJECT`** is one operation |
 |:---:|:---:|:---:|:---:|
 | [benchmarks →](crates/areev-bench/RESULTS.md) | [edge results →](crates/areev-bench/RESULTS.md) | [quality, measured →](docs/quality.md) | [GDPR map →](docs/gdpr.md) |
 


### PR DESCRIPTION
One-line fix. #108 added 25 tests; #109 set this figure from main's then-current 2,288. They touched different files, so both merged clean and the number drifted the moment the second landed.

I had predicted git would flag a conflict between them on this line — it did not, because #108 never touched the root `README.md` (it changed `docs/repo-stats.json` and `areev-sandbox/README.md`). My mistake, and the drift went through silently as a result.

Worth stating because it will recur: **nothing checks this number.** `scripts/repo_stats.py --check` compares the committed artifacts against a fresh scan of the tree and never parses `README.md` — the CI message says "repo stats in README.md have drifted" only because the README is where the figures are quoted. Coverage (80.1%) is still correct by luck, not by a gate.

If this table is worth guarding, the cheap fix is to have `repo_stats.py --check` read the two figures out of the README and compare them to `docs/repo-stats.json` with the same tolerance it already applies. Happy to add that if you want it.