### PR TITLE
examples: connectors must not turn bounces or their own asks into runs

### DIFF
--- a/examples/agents/docs/email-providers.md
+++ b/examples/agents/docs/email-providers.md
@@ -102,6 +102,16 @@ Hard-won guidance from the production deployment:
   cannot set `In-Reply-To` (clients ignore RFC 6068's attempt), so a
   clicked reply may land outside the thread. Resolve replies by thread
   *first*, marker search second.
+- **Not every message in the mailbox is work.** Both connectors drop two
+  kinds before they become items, and a hand-rolled connector must too:
+  *our own asks coming back* (they carry the run marker, the reply path owns
+  them, and a second run can only ever conclude "nothing could be
+  extracted"), and *postmaster mail* — a bounce carries neither the marker
+  nor an invoice, so it parks a run asking a human about a delivery failure,
+  and that ask can bounce in turn. Mind the cursor when you add such a
+  filter: advance it on everything you **looked at**, not on what you
+  returned, or a batch that is entirely bounces leaves it parked and
+  re-fetches the same mail forever.
 - **Email the approver, never the external sender.** Getting that backwards
   emails your vendor an approval link.
 - **Classify deterministically first**: strip quoted history (Gmail's

--- a/examples/agents/invoice-to-accounting/connectors/gmail.py
+++ b/examples/agents/invoice-to-accounting/connectors/gmail.py
@@ -48,6 +48,7 @@ import base64
 import email
 import json
 import os
+import re
 import subprocess
 import sys
 import urllib.parse
@@ -118,6 +119,43 @@ def flatten(raw_bytes, mailbox):
     }
 
 
+# ── mail that must never become work ──────────────────────────────────────
+# Two kinds, both found running this example against a live tenant:
+#
+#   * our own asks coming back. A reply carries the run marker; the reply
+#     path owns it. Letting it through starts a second run that can only
+#     ever conclude "nothing could be extracted".
+#   * postmaster mail. A bounce carries neither the marker (Exchange
+#     rewrites the subject and drops the body) nor an invoice, so it parks a
+#     run asking a human about a delivery failure — and that ask can bounce
+#     too, which starts the loop again.
+#
+# Duplicated in both connectors on purpose: each is a standalone stdio
+# script with no imports beyond the stdlib, and that is worth more than
+# saving fifteen lines.
+MARKER_RE = re.compile(r"\[areev:[a-z]{2}/[0-9a-f]{12}\]")
+SYSTEM_SUBJECT_RE = re.compile(
+    r"^\s*(undeliverable|undelivered mail|delivery status notification|"
+    r"mail delivery (failed|subsystem)|returned mail|automatic reply|"
+    r"out of office|auto(matic)?[- ]?reply)\b",
+    re.I,
+)
+SYSTEM_SENDER_RE = re.compile(
+    r"^(microsoftexchange[0-9a-f]*@|postmaster@|mailer-daemon@|no-?reply@)", re.I
+)
+
+
+def not_new_work(payload):
+    """True for mail that must not start a run."""
+    email = payload.get("email") or {}
+    subject = email.get("subject") or ""
+    sender = email.get("from") or ""
+    body = (email.get("body") or "")[:4000]
+    if MARKER_RE.search("%s %s" % (subject, body)):
+        return True
+    return bool(SYSTEM_SENDER_RE.match(sender)) or bool(SYSTEM_SUBJECT_RE.match(subject))
+
+
 def poll(req):
     mailbox = os.environ.get("AP_MAILBOX") or (req.get("scope") or "").removeprefix("mailbox:")
     tok = token()
@@ -148,11 +186,15 @@ def poll(req):
         full = gapi(f"messages/{gid}", tok, format="raw")
         mid, blobs, payload = flatten(base64.urlsafe_b64decode(full["raw"]), mailbox)
         newest = max(newest, int(full["internalDate"]) // 1000)
-        if mid:
-            payload["gmail_id"] = gid
-            items.append({"id": mid, "payload": payload, "blobs": blobs})
+        if not mid or not_new_work(payload):
+            continue
+        payload["gmail_id"] = gid
+        items.append({"id": mid, "payload": payload, "blobs": blobs})
     out = {"items": items, "more": False}
-    if items:
+    # Advance on anything LOOKED AT, not only on what was returned. A batch
+    # that is entirely bounces yields no items, and cursoring on `items`
+    # leaves it parked — re-fetching the same mail on every poll, forever.
+    if ids:
         out["cursor"] = str(newest + 1)
     return out
 

--- a/examples/agents/invoice-to-accounting/connectors/outlook_graph.py
+++ b/examples/agents/invoice-to-accounting/connectors/outlook_graph.py
@@ -38,6 +38,7 @@ Never run by CI: the keyless floor uses the fixture connector instead.
 import base64
 import json
 import os
+import re
 import sys
 import time
 import urllib.error
@@ -187,6 +188,43 @@ SELECT = ("id,internetMessageId,conversationId,subject,from,toRecipients,"
           "receivedDateTime,hasAttachments,body")
 
 
+# ── mail that must never become work ──────────────────────────────────────
+# Two kinds, both found running this example against a live tenant:
+#
+#   * our own asks coming back. A reply carries the run marker; the reply
+#     path owns it. Letting it through starts a second run that can only
+#     ever conclude "nothing could be extracted".
+#   * postmaster mail. A bounce carries neither the marker (Exchange
+#     rewrites the subject and drops the body) nor an invoice, so it parks a
+#     run asking a human about a delivery failure — and that ask can bounce
+#     too, which starts the loop again.
+#
+# Duplicated in both connectors on purpose: each is a standalone stdio
+# script with no imports beyond the stdlib, and that is worth more than
+# saving fifteen lines.
+MARKER_RE = re.compile(r"\[areev:[a-z]{2}/[0-9a-f]{12}\]")
+SYSTEM_SUBJECT_RE = re.compile(
+    r"^\s*(undeliverable|undelivered mail|delivery status notification|"
+    r"mail delivery (failed|subsystem)|returned mail|automatic reply|"
+    r"out of office|auto(matic)?[- ]?reply)\b",
+    re.I,
+)
+SYSTEM_SENDER_RE = re.compile(
+    r"^(microsoftexchange[0-9a-f]*@|postmaster@|mailer-daemon@|no-?reply@)", re.I
+)
+
+
+def not_new_work(payload):
+    """True for mail that must not start a run."""
+    email = payload.get("email") or {}
+    subject = email.get("subject") or ""
+    sender = email.get("from") or ""
+    body = (email.get("body") or "")[:4000]
+    if MARKER_RE.search("%s %s" % (subject, body)):
+        return True
+    return bool(SYSTEM_SENDER_RE.match(sender)) or bool(SYSTEM_SUBJECT_RE.match(subject))
+
+
 def poll(req):
     mailbox = os.environ.get("AP_MAILBOX") or (req.get("scope") or "").removeprefix("mailbox:")
     tok = token()
@@ -204,15 +242,20 @@ def poll(req):
         "$orderby": "receivedDateTime asc",
         "$top": req.get("max_items", 100),
         "$select": SELECT})
+    messages = listing.get("value", [])
     items, newest = [], cursor
-    for msg in listing.get("value", []):
-        mid, blobs, payload = flatten(msg, tok, mailbox)
+    for msg in messages:
         newest = max(newest, msg.get("receivedDateTime", newest))
-        if mid:
-            payload["graph_id"] = msg["id"]
-            items.append({"id": mid, "payload": payload, "blobs": blobs})
+        mid, blobs, payload = flatten(msg, tok, mailbox)
+        if not mid or not_new_work(payload):
+            continue
+        payload["graph_id"] = msg["id"]
+        items.append({"id": mid, "payload": payload, "blobs": blobs})
     out = {"items": items, "more": "@odata.nextLink" in listing}
-    if items:
+    # Advance on anything LOOKED AT, not only on what was returned. A batch
+    # that is entirely bounces yields no items, and cursoring on `items`
+    # leaves it parked — re-fetching the same mail on every poll, forever.
+    if messages:
         out["cursor"] = newest
     return out
 


### PR DESCRIPTION
## What

Two kinds of mail reach an AP mailbox that must never start a run. Both connectors now drop them before they become items, and the cursor bug that filtering exposes is fixed with them.

Found running `invoice-to-accounting` against a live Microsoft 365 tenant (rounic.com) — neither is visible under the keyless CI floor, which uses the fixture connector by design.

## 1. Our own asks coming back

A reply carries the run marker and belongs to the reply-reading path. Letting it through the connector starts a **second** run over the reply text, whose only possible conclusion is "nothing could be extracted" — noise in the journal, and a parked ask nobody wants.

## 2. Postmaster mail, which can loop

A bounce carries **neither** the marker nor an invoice. Exchange rewrites the subject (`Undeliverable: RE: …`) and drops the body, so a marker filter alone cannot catch it. It parks a run asking a human about a delivery failure — and because that ask is itself email, it can bounce too.

Observed live, in this order:

1. an ask to an external approver was refused with `550 5.7.708 … traffic not accepted from this IP` (a new-tenant outbound reputation block);
2. the NDR arrived in the AP mailbox and became a run;
3. that run parked, asking the approver about the NDR;
4. **that** ask bounced.

## 3. The cursor bug the filter exposes

Both polls advanced the cursor only `if items`. Once mail can be skipped, a batch containing *only* skipped messages returns no items and leaves the cursor parked — re-fetching the same mail on every poll, forever. They now advance on anything **looked at**, not only on what was returned.

## Notes on the shape

The helper is **duplicated** in `outlook_graph.py` and `gmail.py` rather than shared. Each connector is a standalone stdio script with no imports beyond the stdlib, and keeping that property seemed worth more than saving fifteen lines — happy to factor it out if you'd rather.

The subject patterns cover `Undeliverable` / `Delivery Status Notification` / `Mail Delivery Failed` / `Automatic reply` / out-of-office; the sender patterns cover `MicrosoftExchange…@`, `postmaster@`, `mailer-daemon@`, `no-reply@`. The marker regex is deliberately `\[areev:[a-z]{2}/[0-9a-f]{12}\]` so it matches any two-letter marker family, not just `ap/`.

## Testing

CI is unaffected — the smokes use the fixture connector, and these are live-only paths. Verified by loading each connector and exercising `not_new_work` over a real invoice, a real NDR, an ask echo, and an auto-reply; the first is kept and the rest skipped in both.

## Not included, but observed

Two things from the same deployment that felt like design calls rather than bugs, so I left them alone:

- **A clean approval teaches nothing.** `agent.py` only records a lesson when the approval carried *corrections*. In production almost every invoice is approved as-extracted, so a desk can ask about the same vendor forever. Treating an uncorrected approval as evidence (the approver confirmed the vendor is real) is what made ours stop asking — but it changes the example's story and touches all three language stacks.
- **`Revise` pre-fills every field**, so a reply almost always carries a full set of `Field: value` lines. That makes "the deterministic parse found lines" useless as a test for whether the parser understood the person: someone who writes *"the category is Software, not Utilities"* above the untouched block has their sentence ignored **and** the pre-filled values re-applied over it — while the email's own footer promises plain English works. Testing whether any line actually *changes* something fixes it.

Happy to send either as a follow-up if useful.
