### PR TITLE
bench: passive-memory arms — the comparison that answers "plain memory does this too"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,8 +353,15 @@ jobs:
   # to baseline, re-apply recovers it, and rollback really does empty the
   # LESSONS prompt section. It is never a learning claim (no model runs); the
   # live numbers come from `--agent-cmd` and are published with transcripts.
+  # `--arms` extends the same floor to the passive-memory providers: keyless
+  # throughout (m-llm summarizes with the mock summarizer, no API key), and
+  # PLUMBING-ONLY by construction — the deterministic agent complies with any
+  # context it is handed, so these arms prove a provider reached the prompt
+  # and can never rank curation against retrieval. `--workers 4` is the
+  # parallel path; it must emit byte-identical output to `--workers 1`, which
+  # `cargo test -p areev-bench` pins separately.
   selfimprove:
-    name: selfimprove A/B/A/B (mock)
+    name: selfimprove A/B/A/B + passive arms (mock)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -363,7 +370,8 @@ jobs:
       - name: A/B/A/B shape holds under the deterministic agent
         run: |
           cargo run -p areev-bench --bin selfimprove_aba -- \
-            --workdir "$RUNNER_TEMP/aba" --seed 1 --mock --assert-shape
+            --workdir "$RUNNER_TEMP/aba" --seed 1 --mock --assert-shape \
+            --arms m-steel,m-all,m-llm --workers 4
 
   versions:
     name: versions agree

--- a/README.md
+++ b/README.md
@@ -106,9 +106,13 @@ failures, cited every one by hash, and proposed a fix. **A person approved it.**
 The next prompt carried it.
 
 There is no benchmark mode here. The prompt is assembled from live memory on
-every run, so rolling the lesson back empties it structurally — and that round
-trip is only possible because every apply stores its inverse. **A memory system
-without governance cannot run this experiment at all.**
+every run, so rolling the lesson back empties it structurally. Two properties
+of the architecture make the round trip possible: learning is **separate from
+storage**, so the lesson can be removed *while the experience stays* — a
+system whose write path *is* its learning (LLM extraction on every write) has
+nothing to ablate without also losing the memory — and re-applying re-derives
+the lesson **deterministically from the same evidence**, byte-for-byte, which
+a model-in-the-write-path cannot guarantee.
 
 <sub>Single-seed pilot on Qwen3-30B (a small, cheap open-weights model) via
 OpenRouter. Rows 1 and 3 are an agent with no lesson in its prompt, so this

--- a/crates/areev-bench/RESULTS.md
+++ b/crates/areev-bench/RESULTS.md
@@ -482,6 +482,14 @@ the calls that could fail this way) with `rate_limited`. It applies twice
 because a rolled-back hash is terminal: B2 is a *fresh* governed proposal
 (propose → approve → apply), so the run exercises the whole gated path twice.
 
+That second pass is itself a result: **the loop re-derived the identical lesson
+content from the same evidence** — same subject, same signature, same count,
+same rate; only the proposal timestamp differs. Deterministic re-derivation is
+what makes the restore leg of an ablation meaningful (B2 tests *the same*
+learned state, not a paraphrase of it), and it is structurally unavailable to a
+write path that runs a model on every add — re-running an LLM extraction over
+the same history may store different text.
+
 Kept precise, because these bound the claim:
 
 - **The baseline is no-lesson, not no-memory-system.** A0 and A1 run the bare

--- a/crates/areev-bench/SELFIMPROVE.md
+++ b/crates/areev-bench/SELFIMPROVE.md
@@ -207,18 +207,123 @@ agent adapter answers `op: "chat"` with tool calls, the loop adapter answers
 `probe`/`discover`/`ground`/`verify`/`enrich`. Pointing `--llm-cmd` at the
 agent adapter (or the reverse) fails at the loop's construction-time probe.
 
+## Bench 2: the passive-memory arms — does the LOOP add value over the store?
+
+The A/B/A/B pilot's baseline is an **unaided** agent, so it proves the applied
+lesson caused the gain — not that curation beats retrieval. These arms close
+that gap, and they are deliberately framed as **the same store with the loop
+OFF**, not as an imitation of any competitor: the delta isolates the loop, and
+there is no third-party retrieval implementation for anyone to dispute.
+
+Three built-in variants form a ladder, so nobody can claim the weak one was
+chosen. All run over the SAME captured experience, on the SAME held-out set,
+after the governed states; the eval prompt carries the provider's context and
+never the lesson (lessons live as Facts, providers read only Tool grains, so
+nothing leaks between arms):
+
+| arm | what enters the prompt | the objection it answers |
+|---|---|---|
+| `m-steel` | per-error structured retrieval: when a tool call fails, past grains matching that exact (tool, error code) are injected right at the decision point — a better hook than semantic similarity would get | "retrieval with the perfect hook would have caught it" |
+| `m-all` | the full failure history rendered at task start, generous budget — the information upper bound | "you under-retrieved" |
+| `m-llm` | the raw history summarized once into operator notes by an LLM after the experience phase (cost recorded), notes into every prompt | the extraction-at-write-time shape of LLM-memory products |
+
+A fourth arm is a **seam, not an implementation**: `--context-cmd 'CMD'` runs
+any external context provider over the protocol below, so any vendor can plug
+their own memory into the identical experiment. We do not benchmark named
+competitors in this repo; we publish the harness and the invitation.
+
+### Pre-registered interpretation (written before the arms ever ran)
+
+- **B > M:** curation beats retrieval on accuracy — and on cost, which the
+  per-arm token columns quantify. The maximal claim.
+- **B ≈ M:** the loop's value on this workload is cost, determinism, and
+  governance, not accuracy: a one-line lesson against a per-turn context tax,
+  zero model calls at write time against N, byte-stable re-derivation against
+  extraction drift. That is what gets published, with those numbers.
+- **B < m-all:** the lesson rendering leaves information on the table — a
+  measured argument for the LLM-authored procedural lesson on the roadmap.
+  Also published.
+
+Whatever lands, the result ships with per-arm success, per-rule recurrence,
+prompt/completion tokens, and model-call counts.
+
+### The context-provider contract (frozen — code against this)
+
+In-process trait (`src/selfimprove/context.rs`):
+
+```rust
+pub struct ExperienceGrain {          // one experience-phase tool call
+    pub task_id: String,
+    pub tool: String,
+    pub input_json: String,
+    pub output_json: String,
+    pub is_error: bool,
+    pub code: Option<String>,          // frozen error code when is_error
+    pub rendered: String,              // the product renderer's one-line form
+}
+
+pub trait ContextProvider: Sync + Send {
+    fn label(&self) -> &'static str;   // "m-steel" | "m-all" | "m-llm" | "m-cmd"
+    /// Markdown for the system prompt's "## MEMORY (from passive recall)"
+    /// section at task start; empty string = no section.
+    fn task_start(&self, task_prompt: &str) -> Result<String, String>;
+    /// Markdown appended to a failing tool result as
+    /// "\n\n[memory] Relevant past experience:\n…"; empty = nothing.
+    fn on_tool_error(&self, task_prompt: &str, tool: &str, code: &str, body: &str)
+        -> Result<String, String>;
+}
+```
+
+**Why the arms render their own line, and why that favours them.** The bench
+renders each recalled grain as ``- `refund` call failed with `rate_limited`:
+{body ≤160 chars}`` rather than calling `areev_cal`'s one-line *summary* form,
+which emits `refund [FAIL]` — terse by design, and correct for a summary, but
+it carries neither the error code nor the payload the arms exist to inject.
+(The product's `sml` and `toon` formats do carry the body; only the summary
+line does not.) The bench line mirrors the lesson renderer's shape so both
+read alike in a prompt, and at 160 chars it preserves the whole error object
+including `retry_after_s` — so an M arm sees strictly **more** raw detail than
+the governed lesson's single summarizing line. The comparison is tilted toward
+retrieval on purpose; that is what makes a win meaningful.
+
+Ingest happens at construction (providers are read-only afterwards — that is
+what makes eval workers safe). Caps, all logged when they truncate (no silent
+caps): `m-all` ≤ 24_000 chars; `m-steel` ≤ 4_000 chars per injection, most
+recent first; `m-llm` notes ≤ 4_000 chars, summarizer input = the error grains
+plus per-tool call counts.
+
+External providers (`--context-cmd`): ONE persistent process per eval pass,
+newline-delimited JSON, calls serialized:
+
+```
+→ {"selfimprove":1,"op":"ingest","grains":[{…ExperienceGrain fields…}]}
+← {"ok":true}
+→ {"op":"context","stage":"task_start","task_prompt":"…"}
+← {"context":"…markdown or empty…"}
+→ {"op":"context","stage":"tool_error","task_prompt":"…","tool":"…","code":"…","body":"…"}
+← {"context":"…"}
+```
+
+**The provider owns its framing; the caller is idempotent as a guard.**
+`task_start` returns a COMPLETE section (heading included) and `on_tool_error`
+a COMPLETE block (prefix included), mirroring `memory::lessons_markdown`,
+which owns its own `## LESSONS` heading — so all four arms emit structurally
+identical prompt bytes, which is what makes them comparable. The caller adds
+a marker only when it is absent, because double-framing is merely cosmetic
+while no-framing would read as "no memory at all" to the mock's marker scan
+instead of failing loudly.
+
+Ordering note: `GrainRecord` exposes no sequence number, so recording order is
+`created_at_ms` then `hash`. "Most recent first" therefore holds across tasks;
+calls recorded inside one millisecond fall back to hash order — deterministic
+and stable across runs, which is what the prompt bytes require.
+
+The mock agent treats codes found in "## MEMORY" sections and "[memory]"
+blocks exactly like LESSONS codes — it models "an agent that uses whatever
+context it is given", so mock M arms prove plumbing, never a comparison.
+
 ## Roadmap — the benches this skeleton is built to grow
 
-- **`passive memory` arm — the decisive comparison, and the next run.** A0
-  here is an agent with *nothing* in its prompt, so the pilot proves the
-  applied lesson caused the gain but not that curation beats retrieval. The
-  arm to add renders raw recalled history (the failure grains themselves)
-  into the prompt instead of the loop's lesson, on the same held-out set,
-  with a deliberately *generous* budget so the comparison steelmans
-  retrieval. `B > M` is the result that answers "a plain memory store does
-  this too"; `B ≈ M` would mean the loop's value is cost and governance
-  rather than accuracy, and that is the honest thing to report if it
-  happens. Cheap: one extra eval pass, ~60 task runs.
 - `selfimprove_curve` — the learning curve: task stream with loop checkpoints
   every K tasks, arms `vanilla | passive-memory | loop-deterministic |
   loop+LLM | placebo(shuffled lessons)`, cumulative + held-out curves, 3+
@@ -255,13 +360,55 @@ agent adapter (or the reverse) fails at the loop's construction-time probe.
 - CI runs `--mock --assert-shape` only (keyless-deterministic floor); no live
   keys in CI, no live numbers asserted.
 
-## Reproduce (live pilot, ~$3–5)
+## Flags
+
+| flag | what it does |
+|---|---|
+| `--workdir PATH` | run directory; refuses a pre-existing `bench.db` (a stale memory would poison A0) |
+| `--seed N` `--experience N` `--eval N` | task generation; `--seed` reproduces the task sets exactly |
+| `--mock` \| `--agent-cmd 'CMD'` | exactly one: the deterministic keyless agent, or a chat adapter |
+| `--llm-cmd` / `--ground-cmd 'CMD'` | the loop's DISCOVER/VERIFY and GROUND backends (**loop** protocol) |
+| `--arms LIST` | comma list of `m-steel,m-all,m-llm,m-cmd`; empty = governed states only |
+| `--context-cmd 'CMD'` | the external context provider; required by (and only by) `m-cmd` |
+| `--mllm-cmd 'CMD'` | chat adapter for the `m-llm` summarizer; defaults to `--agent-cmd`, unused under `--mock` |
+| `--workers N` | eval concurrency (default 4). Output is byte-identical at any N: workers buffer, the main thread writes in task order and is the only writer of the memory |
+| `--max-turns N` `--assert-shape` | turn cap; the CI shape gate |
+
+**Two adapters, two protocols.** `--agent-cmd`/`--mllm-cmd` speak the chat +
+tool-call protocol (`openrouter_toolcall.py`); `--llm-cmd`/`--ground-cmd`
+speak the loop's `probe`/`discover`/`ground`/`verify` protocol
+(`openrouter_loop.py`). Crossing them fails at the loop's construction-time
+probe, which is the intended loud failure.
+
+## Reproduce
+
+Keyless floor (what CI runs — plumbing only, never a learning claim):
+
+```bash
+cargo run -p areev-bench --bin selfimprove_aba -- \
+  --workdir /tmp/aba --seed 1 --mock --assert-shape \
+  --arms m-steel,m-all,m-llm --workers 4
+```
+
+Live pilot, governed states only (~$3–5):
 
 ```bash
 export OPENROUTER_API_KEY=…
+AGENT='python3 crates/areev-bench/scripts/openrouter_toolcall.py qwen/qwen3-30b-a3b-instruct-2507'
 cargo run --release -p areev-bench --bin selfimprove_aba -- \
-  --workdir /tmp/aba --seed 1 --experience 150 --eval 60 \
-  --agent-cmd 'python3 crates/areev-bench/scripts/openrouter_toolcall.py qwen/qwen3-30b-a3b-instruct-2507' \
-  --llm-cmd   'python3 crates/areev-bench/scripts/openrouter_toolcall.py qwen/qwen3-30b-a3b-instruct-2507' \
-  --ground-cmd 'python3 crates/areev-bench/scripts/openrouter_toolcall.py deepseek/deepseek-chat'
+  --workdir /tmp/aba --seed 1 --experience 150 --eval 60 --agent-cmd "$AGENT" \
+  --llm-cmd    'python3 crates/areev-bench/scripts/openrouter_loop.py qwen/qwen3-30b-a3b-instruct-2507' \
+  --ground-cmd 'python3 crates/areev-bench/scripts/openrouter_loop.py deepseek/deepseek-chat'
+```
+
+Full comparison — governed states **and** the passive-memory arms. Run it at
+three seeds and feed all three run dirs to `scripts/aba_stats.py`:
+
+```bash
+cargo run --release -p areev-bench --bin selfimprove_aba -- \
+  --workdir /tmp/aba-s1 --seed 1 --experience 300 --eval 100 --workers 4 \
+  --agent-cmd "$AGENT" --mllm-cmd "$AGENT" \
+  --llm-cmd    'python3 crates/areev-bench/scripts/openrouter_loop.py qwen/qwen3-30b-a3b-instruct-2507' \
+  --ground-cmd 'python3 crates/areev-bench/scripts/openrouter_loop.py deepseek/deepseek-chat' \
+  --arms m-steel,m-all,m-llm
 ```

--- a/crates/areev-bench/scripts/aba_stats.py
+++ b/crates/areev-bench/scripts/aba_stats.py
@@ -18,24 +18,48 @@ The A/B/A/B claim needs all three to hold together:
   B→A1   removing the lessons undoes it (the causal step)
   A1→B2  restoring them recovers it
 
+States are DISCOVERED from the run directory, not enumerated, so the
+passive-memory arms (SELFIMPROVE.md "Bench 2") are picked up without editing
+this script. Every discovered M arm is additionally paired against A0 (does
+passive recall beat no memory?) and against B (does curation beat retrieval?)
+— the pre-registered comparisons.
+
 Stdlib only. Multiple RUNDIRs are treated as independent seeds and pooled
 per state pair, with each seed also reported on its own line.
 """
+import glob
 import json
 import math
 import os
 import sys
 
-STATES = ["A0", "B", "A1", "B2"]
-PAIRS = [("A0", "B"), ("B", "A1"), ("A1", "B2"), ("A0", "A1"), ("B", "B2")]
+EVAL_PREFIX = "transcripts-eval-"
+EVAL_SUFFIX = ".jsonl"
+GOVERNED_PAIRS = [("A0", "B"), ("B", "A1"), ("A1", "B2"), ("A0", "A1"), ("B", "B2")]
+
+
+def pairs_for(states):
+    """Governed pairs first, then each discovered M arm vs A0 and vs B.
+
+    An arm is any state whose name starts with M. The match is
+    case-insensitive because the frozen arm labels are lowercase
+    (`m-steel`, `m-all`, `m-llm`, `m-cmd`) while the governed states are
+    upper — a case-sensitive test would silently report nothing.
+    Pairs whose states are absent everywhere are dropped, not printed empty.
+    """
+    present = set(states)
+    out = [p for p in GOVERNED_PAIRS if p[0] in present and p[1] in present]
+    for arm in sorted(s for s in present if s.upper().startswith("M")):
+        out.extend((base, arm) for base in ("A0", "B") if base in present)
+    return out
 
 
 def load_run(d):
     """{state: {task_id: success}} for one run directory."""
     out = {}
-    for state in STATES:
-        path = os.path.join(d, f"transcripts-eval-{state}.jsonl")
-        if not os.path.exists(path):
+    for path in sorted(glob.glob(os.path.join(d, EVAL_PREFIX + "*" + EVAL_SUFFIX))):
+        state = os.path.basename(path)[len(EVAL_PREFIX):-len(EVAL_SUFFIX)]
+        if not state:
             continue
         rows = {}
         with open(path) as fh:
@@ -101,8 +125,12 @@ def main():
     if not runs:
         sys.exit(1)
 
-    print(f"paired McNemar over {len(runs)} run(s): {', '.join(n for n, _ in runs)}\n")
-    for x, y in PAIRS:
+    states = set()
+    for _, r in runs:
+        states |= set(r)
+    print(f"paired McNemar over {len(runs)} run(s): {', '.join(n for n, _ in runs)}")
+    print(f"states: {', '.join(sorted(states))}\n")
+    for x, y in pairs_for(states):
         b, c, n, lines = compare(runs, x, y)
         if n == 0:
             continue

--- a/crates/areev-bench/src/bin/selfimprove_aba.rs
+++ b/crates/areev-bench/src/bin/selfimprove_aba.rs
@@ -20,21 +20,45 @@
 //! Phases run at strictly increasing engine clocks (base + n·1h, total span
 //! far under the 1-day outcome_review horizon, so no revert fires mid-bench).
 //!
+//! `--arms` adds the passive-memory ladder (SELFIMPROVE.md "Bench 2") after
+//! B2: one extra eval pass per arm over the SAME held-out tasks with the
+//! LESSONS section EMPTY and a `ContextProvider` in its place. The arms are
+//! the same store with the loop OFF — the delta isolates the loop, and it is
+//! attributable because providers read only Tool grains, so the applied
+//! lesson Facts living in the very same memory file cannot leak into an M
+//! prompt.
+//!
 //! `--mock` is the keyless deterministic plumbing reference (CI runs
-//! `--mock --assert-shape`); it is never a learning claim. Live numbers come
-//! from `--agent-cmd` (see SELFIMPROVE.md "Reproduce").
+//! `--mock --assert-shape`); it is never a learning claim, and under `--mock`
+//! an M arm proves the provider PLUMBING only — the mock obeys whatever
+//! context it is handed, so it can never rank curation against retrieval.
+//! Live numbers come from `--agent-cmd` (see SELFIMPROVE.md "Reproduce").
+//!
+//! `--workers N` parallelizes the eval and experience passes. It is an
+//! optimization and never a variable: workers buffer their own transcript
+//! rows, and the main thread writes rows (and the experience phase's
+//! `record_task`) strictly in task-index order, so output is byte-identical
+//! at any worker count and the single-writer store is only ever written from
+//! one thread.
 
+use areev_bench::selfimprove::context::{ContextProvider, ExperienceGrain};
 use areev_bench::selfimprove::memory::Memory;
-use areev_bench::selfimprove::{agent, env, report::Reporter};
+use areev_bench::selfimprove::{agent, context, env, report::Reporter};
 use areev_bench::selfimprove::{EvalSummary, Ledger, RuleId, RuleStat, TaskRunRecord, Usage};
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::BTreeSet;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc;
+use std::thread;
 
 /// Engine phase clocks: fixed base (determinism rule — never the wall clock
 /// when the value decides behavior), +1h per phase.
 const BASE_MS: i64 = 1_700_000_000_000;
 const HOUR_MS: i64 = 3_600_000;
+
+/// The passive-memory arms, in ladder order (SELFIMPROVE.md "Bench 2").
+const KNOWN_ARMS: [&str; 4] = ["m-steel", "m-all", "m-llm", "m-cmd"];
 
 struct Args {
     workdir: PathBuf,
@@ -45,8 +69,38 @@ struct Args {
     agent_cmd: Option<String>,
     llm_cmd: Option<String>,
     ground_cmd: Option<String>,
+    /// Requested passive arms, deduped, in the order given (empty = the
+    /// A/B/A/B states only, i.e. exactly the pre-arms behavior).
+    arms: Vec<String>,
+    context_cmd: Option<String>,
+    mllm_cmd: Option<String>,
+    workers: usize,
     max_turns: u32,
     assert_shape: bool,
+}
+
+impl Args {
+    fn wants(&self, arm: &str) -> bool {
+        self.arms.iter().any(|a| a == arm)
+    }
+
+    /// The chat adapter the m-llm summarizer runs on: its own flag, else the
+    /// agent's (same protocol, and one model is the honest default).
+    fn mllm_cmd(&self) -> Option<&str> {
+        self.mllm_cmd.as_deref().or(self.agent_cmd.as_deref())
+    }
+}
+
+/// Arm → the `EvalSummary.state` label. `aba_stats.py` keys the passive arms
+/// off the leading "M", so these strings are a cross-tool contract.
+fn arm_state(arm: &str) -> &'static str {
+    match arm {
+        "m-steel" => "M-steel",
+        "m-all" => "M-all",
+        "m-llm" => "M-llm",
+        "m-cmd" => "M-cmd",
+        other => die(&format!("unknown arm {other}")),
+    }
 }
 
 fn die(msg: &str) -> ! {
@@ -59,9 +113,35 @@ fn usage() -> ! {
         "usage: selfimprove_aba --workdir PATH (--mock | --agent-cmd 'CMD')\n\
          \x20                       [--seed N] [--experience N] [--eval N]\n\
          \x20                       [--llm-cmd 'CMD'] [--ground-cmd 'CMD']\n\
-         \x20                       [--max-turns N] [--assert-shape]"
+         \x20                       [--arms m-steel,m-all,m-llm,m-cmd]\n\
+         \x20                       [--context-cmd 'CMD'] [--mllm-cmd 'CMD']\n\
+         \x20                       [--workers N] [--max-turns N] [--assert-shape]"
     );
     std::process::exit(2);
+}
+
+/// `--arms` value → validated, deduped arm list preserving the given order.
+/// An unknown name is a hard error: silently dropping it would publish an arm
+/// table missing the arm someone asked for.
+fn parse_arms(value: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for raw in value.split(',') {
+        let arm = raw.trim();
+        if arm.is_empty() {
+            continue;
+        }
+        if !KNOWN_ARMS.contains(&arm) {
+            eprintln!(
+                "selfimprove_aba: unknown arm {arm:?} (known: {})",
+                KNOWN_ARMS.join(", ")
+            );
+            usage()
+        }
+        if !out.iter().any(|a| a == arm) {
+            out.push(arm.to_string());
+        }
+    }
+    out
 }
 
 fn parse_args() -> Args {
@@ -74,6 +154,10 @@ fn parse_args() -> Args {
     let mut agent_cmd: Option<String> = None;
     let mut llm_cmd: Option<String> = None;
     let mut ground_cmd: Option<String> = None;
+    let mut arms: Vec<String> = Vec::new();
+    let mut context_cmd: Option<String> = None;
+    let mut mllm_cmd: Option<String> = None;
+    let mut workers: usize = 4;
     let mut max_turns: u32 = 24;
     let mut assert_shape = false;
 
@@ -98,6 +182,13 @@ fn parse_args() -> Args {
                     "--agent-cmd" => agent_cmd = Some(value.clone()),
                     "--llm-cmd" => llm_cmd = Some(value.clone()),
                     "--ground-cmd" => ground_cmd = Some(value.clone()),
+                    "--arms" => arms = parse_arms(value),
+                    "--context-cmd" => context_cmd = Some(value.clone()),
+                    "--mllm-cmd" => mllm_cmd = Some(value.clone()),
+                    // A worker count below 1 would run nothing at all.
+                    "--workers" => {
+                        workers = value.parse::<usize>().unwrap_or_else(|_| usage()).max(1)
+                    }
                     "--max-turns" => max_turns = value.parse().unwrap_or_else(|_| usage()),
                     _ => usage(),
                 }
@@ -116,6 +207,14 @@ fn parse_args() -> Args {
         eprintln!("selfimprove_aba: exactly one of --mock / --agent-cmd is required");
         usage()
     }
+    // The external-provider seam is required by, and only meaningful for, the
+    // m-cmd arm — a --context-cmd nobody runs is a silently ignored flag.
+    if arms.iter().any(|a| a == "m-cmd") != context_cmd.is_some() {
+        eprintln!(
+            "selfimprove_aba: --context-cmd is required for --arms m-cmd, and meaningless without it"
+        );
+        usage()
+    }
     Args {
         workdir,
         seed,
@@ -125,6 +224,10 @@ fn parse_args() -> Args {
         agent_cmd,
         llm_cmd,
         ground_cmd,
+        arms,
+        context_cmd,
+        mllm_cmd,
+        workers,
         max_turns,
         assert_shape,
     }
@@ -190,32 +293,89 @@ fn summarize(state: &str, tasks: &[env::Task], records: &[TaskRunRecord]) -> Eva
     }
 }
 
+/// One finished task, tagged with its index in the task list.
+type PooledTask = (usize, TaskRunRecord, Vec<Value>);
+
+/// Run `tasks` across `args.workers` threads and return one
+/// `(record, transcript rows)` per task **in task order**.
+///
+/// The determinism argument, which is the whole design: a worker claims the
+/// next index off an atomic counter, builds its OWN backend and its OWN `Env`
+/// (both per task already), and buffers its transcript rows locally instead
+/// of writing them. Nothing is written from a worker. The main thread sorts
+/// by task index before it writes anything, so `--workers 4` emits exactly
+/// the bytes `--workers 1` does, and the single-writer memory file is only
+/// ever touched from one thread (the experience phase's `record_task`).
+///
+/// `run_task` takes only per-worker (`backend`), per-task (`Env`, the row
+/// buffer) or `Sync` borrows (`Args`, `lessons`, and `ContextProvider`'s own
+/// `Sync + Send` bound), which is what makes this safe to fan out at all.
+fn run_pool(
+    tasks: &[env::Task],
+    args: &Args,
+    lessons: &str,
+    context: Option<&dyn ContextProvider>,
+) -> Vec<(TaskRunRecord, Vec<Value>)> {
+    let next = AtomicUsize::new(0);
+    let (tx, rx) = mpsc::channel::<PooledTask>();
+    let workers = args.workers.clamp(1, tasks.len().max(1));
+    thread::scope(|scope| {
+        for _ in 0..workers {
+            let tx = tx.clone();
+            let next = &next;
+            scope.spawn(move || loop {
+                let i = next.fetch_add(1, Ordering::Relaxed);
+                let Some(task) = tasks.get(i) else { break };
+                let mut e = env::Env::new(task);
+                let mut backend = make_backend(args);
+                let mut rows: Vec<Value> = Vec::new();
+                let rec = agent::run_task(
+                    backend.as_mut(),
+                    &mut e,
+                    &task.id,
+                    &task.prompt,
+                    lessons,
+                    context,
+                    args.max_turns,
+                    |ev| rows.push(ev.clone()),
+                );
+                // A closed receiver means the main thread is already gone.
+                if tx.send((i, rec, rows)).is_err() {
+                    break;
+                }
+            });
+        }
+        // The workers hold the only remaining senders, so `rx` ends when the
+        // last one finishes.
+        drop(tx);
+        let mut out: Vec<PooledTask> = rx.iter().collect();
+        out.sort_by_key(|(i, _, _)| *i);
+        out.into_iter().map(|(_, rec, rows)| (rec, rows)).collect()
+    })
+}
+
 /// One eval pass: the SAME held-out tasks in the SAME order, fresh Env per
-/// task, `lessons` fetched once by the caller. Eval tool calls are NEVER
-/// recorded into memory — the held-out set must not leak into learning.
+/// task, `lessons` fetched once by the caller (empty on the passive arms,
+/// which pass a `context` provider instead — never both). Eval tool calls are
+/// NEVER recorded into memory: the held-out set must not leak into learning,
+/// and the providers ingest only the experience phase for the same reason.
 fn run_eval(
     state: &str,
     tasks: &[env::Task],
     lessons: &str,
+    context: Option<&dyn ContextProvider>,
     args: &Args,
     reporter: &Reporter,
 ) -> EvalSummary {
     let mut tx = reporter
         .transcript(&format!("transcripts-eval-{state}.jsonl"))
         .unwrap_or_else(|e| die(&format!("open eval-{state} transcript: {e}")));
+    let finished = run_pool(tasks, args, lessons, context);
     let mut records = Vec::with_capacity(tasks.len());
-    for task in tasks {
-        let mut e = env::Env::new(task);
-        let mut backend = make_backend(args);
-        let rec = agent::run_task(
-            backend.as_mut(),
-            &mut e,
-            &task.id,
-            &task.prompt,
-            lessons,
-            args.max_turns,
-            |ev| tx.row(ev),
-        );
+    for (task, (rec, rows)) in tasks.iter().zip(finished) {
+        for row in &rows {
+            tx.row(row);
+        }
         // Per-task outcome row: the paired unit. Aggregates alone cannot
         // support the paired test the stats rule requires (same instances
         // across states), and per-task outcomes cannot be reconstructed
@@ -237,6 +397,45 @@ fn run_eval(
         records.push(rec);
     }
     summarize(state, tasks, &records)
+}
+
+/// Build one passive-memory provider over the captured experience.
+///
+/// This is the ONLY place coupled to `context.rs`'s constructors; everything
+/// else in the bin talks to the frozen `ContextProvider` trait. The second
+/// return is the summarizer's token cost — `Some` only for m-llm, whose model
+/// calls at write time are precisely the thing its column has to price.
+fn build_provider(
+    arm: &str,
+    grains: &[ExperienceGrain],
+    args: &Args,
+) -> (Box<dyn ContextProvider>, Option<Usage>) {
+    match arm {
+        "m-steel" => (Box::new(context::SteelProvider::build(grains.to_vec())), None),
+        "m-all" => (Box::new(context::AllProvider::build(grains.to_vec())), None),
+        "m-llm" => {
+            // Mock mode summarizes deterministically and keylessly: CI runs
+            // this arm, and it must not need a model or a key.
+            let provider = if args.mock {
+                context::LlmProvider::build_mock(grains.to_vec())
+            } else {
+                let cmd = args
+                    .mllm_cmd()
+                    .unwrap_or_else(|| die("m-llm needs --mllm-cmd or --agent-cmd"));
+                context::LlmProvider::build(cmd, grains.to_vec())
+                    .unwrap_or_else(|e| die(&format!("m-llm summarizer: {e}")))
+            };
+            let usage = provider.usage();
+            (Box::new(provider), Some(usage))
+        }
+        "m-cmd" => {
+            let cmd = args.context_cmd.as_deref().expect("validated at parse");
+            let provider = context::CmdProvider::spawn(cmd, grains)
+                .unwrap_or_else(|e| die(&format!("--context-cmd: {e}")));
+            (Box::new(provider), None)
+        }
+        other => die(&format!("unknown arm {other}")),
+    }
 }
 
 fn git_rev() -> String {
@@ -269,20 +468,48 @@ fn print_results(args: &Args, evals: &[EvalSummary], ledger: &Ledger, applied1: 
             "B" => "B  lessons applied",
             "A1" => "A1 lessons rolled back",
             "B2" => "B2 lessons re-applied",
+            // The passive ladder: no lessons in the prompt, a provider instead.
+            "M-steel" => "M-steel per-error recall",
+            "M-all" => "M-all  whole failure history",
+            "M-llm" => "M-llm  summarized notes",
+            "M-cmd" => "M-cmd  external provider",
             other => other,
         }
     }
     for e in evals {
         let mean_steps = if e.n == 0 { 0.0 } else { e.total_steps as f64 / e.n as f64 };
+        // A mock M row is plumbing evidence, and the table outlives the
+        // caveat under it the moment someone screenshots the rows — so the
+        // row carries its own warning. The mock complies with any context it
+        // is handed, which makes "more context" win by construction.
+        let label = if args.mock && e.state.starts_with('M') {
+            format!("{} ⚠ plumbing only", name(&e.state))
+        } else {
+            name(&e.state).to_string()
+        };
         println!(
             "| {} | {}/{} | {:.1}% | {} | {:.1} |",
-            name(&e.state),
+            label,
             e.successes,
             e.n,
             e.success_rate() * 100.0,
             e.tool_errors,
             mean_steps
         );
+    }
+
+    if !args.arms.is_empty() {
+        println!(
+            "\nM-* are the passive-memory arms: the same store with the loop OFF — no lessons in \
+             the prompt, a context provider instead."
+        );
+        if args.mock {
+            println!(
+                "Under --mock they prove the provider plumbing only: the deterministic agent \
+                 complies with any context it is handed, so these rows never rank curation \
+                 against retrieval."
+            );
+        }
     }
 
     // Per-rule recurrence: tasks mishandling / tasks exercising, per state.
@@ -330,7 +557,13 @@ fn print_results(args: &Args, evals: &[EvalSummary], ledger: &Ledger, applied1: 
 
 /// The CI gate for `--mock`: the shape of causality, not a magnitude claim.
 /// (The A1 lessons-empty check is hard-asserted in the pipeline itself.)
-fn check_shape(a0: &EvalSummary, b: &EvalSummary, a1: &EvalSummary, b2: &EvalSummary) {
+///
+/// `evals` is `[A0, B, A1, B2]` followed by one row per requested arm. The
+/// arm checks are PLUMBING assertions and nothing more: the mock complies
+/// with whatever context it is given, so "M-all beats A0" says the provider
+/// reached the prompt, never that retrieval works.
+fn check_shape(evals: &[EvalSummary], eval_n: u32) {
+    let (a0, b, a1, b2) = (&evals[0], &evals[1], &evals[2], &evals[3]);
     let mut fails = Vec::new();
     if b.success_rate() <= a0.success_rate() + 0.1 {
         fails.push(format!(
@@ -353,8 +586,34 @@ fn check_shape(a0: &EvalSummary, b: &EvalSummary, a1: &EvalSummary, b2: &EvalSum
             b.success_rate()
         ));
     }
+    let arms = &evals[4..];
+    for s in arms {
+        if s.n != eval_n {
+            fails.push(format!(
+                "{} ran {} of {eval_n} held-out tasks — an arm must see the SAME set",
+                s.state, s.n
+            ));
+        }
+    }
+    if let Some(m_all) = arms.iter().find(|s| s.state == "M-all") {
+        if m_all.success_rate() <= a0.success_rate() + 0.05 {
+            fails.push(format!(
+                "M-all ({:.3}) must exceed A0 ({:.3}) by more than 0.05 — the mock uses any \
+                 context it is given, so this failing means the provider never reached the prompt",
+                m_all.success_rate(),
+                a0.success_rate()
+            ));
+        }
+    }
     if fails.is_empty() {
         println!("\nassert-shape: PASS (B > A0 + 0.10, |A1−A0| ≤ 0.05, |B2−B| ≤ 0.05, A1 lessons empty)");
+        if !arms.is_empty() {
+            let labels: Vec<&str> = arms.iter().map(|s| s.state.as_str()).collect();
+            println!(
+                "assert-shape: PASS arms {} (n = {eval_n} each; plumbing only under --mock)",
+                labels.join(", ")
+            );
+        }
     } else {
         for f in &fails {
             eprintln!("assert-shape FAIL: {f}");
@@ -381,18 +640,14 @@ fn main() {
         let mut tx = reporter
             .transcript("transcripts-experience.jsonl")
             .unwrap_or_else(|e| die(&format!("open experience transcript: {e}")));
-        for task in &exp_tasks {
-            let mut e = env::Env::new(task);
-            let mut backend = make_backend(&args);
-            let rec = agent::run_task(
-                backend.as_mut(),
-                &mut e,
-                &task.id,
-                &task.prompt,
-                "",
-                args.max_turns,
-                |ev| tx.row(ev),
-            );
+        // Workers run the tasks; the main thread alone writes — both the
+        // transcript and the memory, in task-index order. The store is
+        // single-writer per file, and the grain order must not depend on how
+        // many threads happened to be free.
+        for (rec, rows) in run_pool(&exp_tasks, &args, "", None) {
+            for row in &rows {
+                tx.row(row);
+            }
             mem.record_task(&rec).unwrap_or_else(|e| die(&e));
         }
     }
@@ -407,7 +662,7 @@ fn main() {
         die("A0 precondition broken: LESSONS section non-empty before any apply");
     }
     eprintln!("eval A0: {} tasks", eval_tasks.len());
-    let a0 = run_eval("A0", &eval_tasks, &lessons, &args, &reporter);
+    let a0 = run_eval("A0", &eval_tasks, &lessons, None, &args, &reporter);
 
     // 3 LEARN → apply (scripted review: executable non-destructive approved
     // + applied, destructive rejected, advisory ledgered) → eval B.
@@ -420,7 +675,7 @@ fn main() {
         applied1.len()
     );
     let lessons = mem.lessons_markdown().unwrap_or_else(|e| die(&e));
-    let b = run_eval("B", &eval_tasks, &lessons, &args, &reporter);
+    let b = run_eval("B", &eval_tasks, &lessons, None, &args, &reporter);
 
     // 4 ROLLBACK → eval A1. The load-bearing honesty check: rollback changes
     // the FILE, and the file must change the PROMPT to empty.
@@ -429,7 +684,7 @@ fn main() {
     if !lessons.is_empty() {
         die("rollback did not empty the LESSONS section — the causal lever is broken");
     }
-    let a1 = run_eval("A1", &eval_tasks, &lessons, &args, &reporter);
+    let a1 = run_eval("A1", &eval_tasks, &lessons, None, &args, &reporter);
 
     // 5 RE-APPLY → eval B2. RolledBack is terminal per hash, so this is the
     // whole governed path a second time: re-propose → approve → apply.
@@ -445,10 +700,46 @@ fn main() {
         die("re-apply pass applied nothing — B2 would silently equal A1");
     }
     let lessons = mem.lessons_markdown().unwrap_or_else(|e| die(&e));
-    let b2 = run_eval("B2", &eval_tasks, &lessons, &args, &reporter);
+    let b2 = run_eval("B2", &eval_tasks, &lessons, None, &args, &reporter);
+    let mut evals = vec![a0, b, a1, b2];
 
-    // 6 Report: config (every flag + git rev), the merged ledger verbatim
-    // (failures are evidence), the four summaries.
+    // 6 PASSIVE ARMS (--arms) — the same store with the loop OFF, run last so
+    // the governed states are already measured and nothing about them moves.
+    //
+    // Two properties make an arm's number attributable. (a) The prompt: the
+    // LESSONS section is EMPTY here and a `ContextProvider` supplies the
+    // context instead — never both, asserted in `run_task`. (b) The source:
+    // providers ingest `experience_grains()`, which reads only Tool grains
+    // from the experience phase, so the applied lesson Facts sitting in this
+    // very same memory file cannot leak into an M prompt, and neither can the
+    // held-out set. One ingest per arm, before its pass — providers are
+    // read-only afterwards, which is what makes the eval workers safe.
+    if !args.arms.is_empty() {
+        let grains = mem.experience_grains().unwrap_or_else(|e| die(&e));
+        eprintln!("arms: {} experience grains ingested per provider", grains.len());
+        for arm in &args.arms {
+            let state = arm_state(arm);
+            let (provider, summarizer) = build_provider(arm, &grains, &args);
+            eprintln!("eval {state}: {} tasks", eval_tasks.len());
+            let mut summary =
+                run_eval(state, &eval_tasks, "", Some(provider.as_ref()), &args, &reporter);
+            // The summarizer's model calls are part of what this arm COST —
+            // an extraction-at-write-time memory that reported only its read
+            // tokens would be priced dishonestly.
+            if let Some(u) = summarizer {
+                println!(
+                    "m-llm summarizer: {} prompt + {} completion tokens",
+                    u.prompt_tokens, u.completion_tokens
+                );
+                summary.usage.prompt_tokens += u.prompt_tokens;
+                summary.usage.completion_tokens += u.completion_tokens;
+            }
+            evals.push(summary);
+        }
+    }
+
+    // 7 Report: config (every flag + git rev), the merged ledger verbatim
+    // (failures are evidence), the four governed summaries + any arms.
     let mut ledger = Ledger::default();
     ledger.entries.extend(ledger1.entries);
     ledger.entries.extend(ledger2.entries);
@@ -463,6 +754,10 @@ fn main() {
         "agent_cmd": args.agent_cmd,
         "llm_cmd": args.llm_cmd,
         "ground_cmd": args.ground_cmd,
+        "arms": args.arms,
+        "context_cmd": args.context_cmd,
+        "mllm_cmd": args.wants("m-llm").then(|| args.mllm_cmd()).flatten(),
+        "workers": args.workers,
         "max_turns": args.max_turns,
         "assert_shape": args.assert_shape,
         "runner_actor": mem.runner_actor(),
@@ -470,7 +765,6 @@ fn main() {
         "phase_base_ms": BASE_MS,
         "git_rev": git_rev(),
     });
-    let evals = [a0, b, a1, b2];
     reporter
         .write_report(&config, &ledger, &evals)
         .unwrap_or_else(|e| die(&format!("write report: {e}")));
@@ -478,6 +772,167 @@ fn main() {
     print_results(&args, &evals, &ledger, applied1.len(), applied2.len());
 
     if args.assert_shape {
-        check_shape(&evals[0], &evals[1], &evals[2], &evals[3]);
+        check_shape(&evals, args.eval as u32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_args(workers: usize) -> Args {
+        Args {
+            workdir: PathBuf::new(),
+            seed: 7,
+            experience: 0,
+            eval: 6,
+            mock: true,
+            agent_cmd: None,
+            llm_cmd: None,
+            ground_cmd: None,
+            arms: vec![],
+            context_cmd: None,
+            mllm_cmd: None,
+            workers,
+            max_turns: 24,
+            assert_shape: false,
+        }
+    }
+
+    fn rows_of(finished: &[(TaskRunRecord, Vec<Value>)]) -> Vec<Value> {
+        finished.iter().flat_map(|(_, rows)| rows.iter().cloned()).collect()
+    }
+
+    fn outcomes_of(finished: &[(TaskRunRecord, Vec<Value>)]) -> Vec<(String, bool, u32, String)> {
+        finished
+            .iter()
+            .map(|(r, _)| (r.task_id.clone(), r.success, r.steps, r.failure_reason.clone()))
+            .collect()
+    }
+
+    /// The pool is an optimization, never a variable. Transcript bytes and the
+    /// memory write order both derive from task-INDEX order, so four workers
+    /// must produce exactly what one does — otherwise `--workers` would
+    /// quietly become a parameter of the published numbers.
+    #[test]
+    fn the_pool_is_deterministic_across_worker_counts() {
+        let tasks = env::gen_tasks(7, env::Split::Eval, 6);
+        let one = run_pool(&tasks, &mock_args(1), "", None);
+        let four = run_pool(&tasks, &mock_args(4), "", None);
+
+        assert_eq!(one.len(), tasks.len());
+        // Task order, not completion order.
+        let ids: Vec<String> = tasks.iter().map(|t| t.id.clone()).collect();
+        assert_eq!(outcomes_of(&one).iter().map(|o| o.0.clone()).collect::<Vec<_>>(), ids);
+        assert_eq!(outcomes_of(&one), outcomes_of(&four));
+        // The rows are the transcript: identical sequence, identical bytes.
+        let (a, b) = (rows_of(&one), rows_of(&four));
+        assert!(!a.is_empty(), "the mock must actually call tools");
+        assert_eq!(a, b);
+        assert_eq!(
+            serde_json::to_string(&a).unwrap(),
+            serde_json::to_string(&b).unwrap()
+        );
+    }
+
+    /// More workers than tasks must not spin up idle threads that then race
+    /// for an empty queue — and an empty task list must not hang.
+    #[test]
+    fn the_pool_handles_more_workers_than_tasks_and_no_tasks() {
+        let tasks = env::gen_tasks(7, env::Split::Eval, 2);
+        let many = run_pool(&tasks, &mock_args(16), "", None);
+        assert_eq!(many.len(), 2);
+        assert!(run_pool(&[], &mock_args(4), "", None).is_empty());
+    }
+
+    /// Canned provider: proves `Option<&dyn ContextProvider>` really does
+    /// cross into the workers (the trait's `Sync + Send` bound is what allows
+    /// it), and that a shared provider stays deterministic under fan-out.
+    struct ConstProvider;
+
+    impl ContextProvider for ConstProvider {
+        fn label(&self) -> &'static str {
+            "m-const"
+        }
+        fn task_start(&self, _task_prompt: &str) -> Result<String, String> {
+            Ok("- past runs hit rate_limited and invalid_timestamp\n".to_string())
+        }
+        fn on_tool_error(
+            &self,
+            _task_prompt: &str,
+            _tool: &str,
+            _code: &str,
+            _body: &str,
+        ) -> Result<String, String> {
+            Ok(String::new())
+        }
+    }
+
+    #[test]
+    fn a_shared_provider_fans_out_and_stays_deterministic() {
+        let tasks = env::gen_tasks(7, env::Split::Eval, 6);
+        let provider = ConstProvider;
+        let one = run_pool(&tasks, &mock_args(1), "", Some(&provider));
+        let four = run_pool(&tasks, &mock_args(4), "", Some(&provider));
+        assert_eq!(outcomes_of(&one), outcomes_of(&four));
+        assert_eq!(rows_of(&one), rows_of(&four));
+        // The context reached the agent: with the codes above the mock waits
+        // out a 429 instead of hot-retrying it, which the bare pool does not.
+        let bare = run_pool(&tasks, &mock_args(1), "", None);
+        assert_ne!(
+            outcomes_of(&one),
+            outcomes_of(&bare),
+            "a provider that names frozen codes must change the mock's behavior"
+        );
+    }
+
+    #[test]
+    fn parse_arms_dedupes_and_keeps_the_given_order() {
+        assert_eq!(parse_arms(""), Vec::<String>::new());
+        assert_eq!(parse_arms("m-all"), vec!["m-all"]);
+        assert_eq!(
+            parse_arms(" m-llm , m-steel ,m-all, m-llm ,"),
+            vec!["m-llm", "m-steel", "m-all"]
+        );
+    }
+
+    /// The arm labels are a cross-tool contract (`aba_stats.py` keys the
+    /// passive arms off the leading "M"), so every known arm must map, and
+    /// map to exactly that shape.
+    #[test]
+    fn every_known_arm_maps_to_an_m_prefixed_state() {
+        for arm in KNOWN_ARMS {
+            let state = arm_state(arm);
+            assert!(state.starts_with("M-"), "{arm} → {state}");
+            assert_eq!(state.to_ascii_lowercase(), arm);
+        }
+    }
+
+    fn summary(state: &str, n: u32, successes: u32) -> EvalSummary {
+        EvalSummary {
+            state: state.to_string(),
+            n,
+            successes,
+            tool_errors: 0,
+            total_steps: n,
+            per_rule: vec![],
+            usage: Usage::default(),
+        }
+    }
+
+    /// `check_shape` exits the process on failure, so the tests here pin the
+    /// PASSING shape: the four governed states plus arms that ran the whole
+    /// held-out set, with M-all clear of A0.
+    #[test]
+    fn check_shape_accepts_the_governed_states_with_arms() {
+        let evals = vec![
+            summary("A0", 10, 3),
+            summary("B", 10, 9),
+            summary("A1", 10, 3),
+            summary("B2", 10, 9),
+            summary("M-steel", 10, 6),
+            summary("M-all", 10, 8),
+        ];
+        check_shape(&evals, 10);
     }
 }

--- a/crates/areev-bench/src/selfimprove/agent.rs
+++ b/crates/areev-bench/src/selfimprove/agent.rs
@@ -185,9 +185,16 @@ fn excerpt(s: &str) -> String {
 // MockBackend — the deterministic keyless agent (CI's --mock path)
 // ---------------------------------------------------------------------------
 
-/// Deterministic agent: naive against the hidden rules unless the system
-/// prompt's `## LESSONS` section names a frozen error code, which unlocks the
-/// corresponding learned behavior (mod.rs "The fixed cross-module contract").
+/// Deterministic agent: naive against the hidden rules unless the context it
+/// is given names a frozen error code, which unlocks the corresponding
+/// learned behavior (mod.rs "The fixed cross-module contract"). "Context"
+/// means any of the places the harness can legitimately put it: the system
+/// prompt's `## LESSONS` section (governed lessons), its `## MEMORY` section
+/// (passive-recall arms), or a `[memory]` block appended to a tool result.
+/// The mock models "an agent that uses whatever context it is given" — so
+/// mock M arms prove the provider plumbing end-to-end and NEVER a comparison
+/// between curation and retrieval (a real model decides what to do with
+/// context; the mock obeys it by construction).
 /// State is reconstructed from the messages slice alone — no env access, no
 /// randomness, no clock. R2 (`invalid_id`) never fires here: ids are always
 /// taken verbatim from search results, so there is no naive id-guessing to fix.
@@ -206,7 +213,7 @@ impl ChatBackend for MockBackend {
             .find(|m| m.role == "user")
             .and_then(|m| m.content.as_deref())
             .unwrap_or("");
-        let lessons = Lessons::from_system(system);
+        let lessons = Lessons::from_context(&context_text(system, messages));
         let intent = Intent::from_prompt(user);
         let pairs = collect_pairs(messages);
         let n = messages
@@ -219,8 +226,12 @@ impl ChatBackend for MockBackend {
     }
 }
 
-/// Which learned behaviors the LESSONS section unlocks (one per frozen code;
+/// Which learned behaviors the context unlocks (one per frozen code;
 /// `invalid_id` is recognized in the contract but has no mock behavior).
+/// "Context" is whatever [`context_text`] gathered — a governed `## LESSONS`
+/// section, a passive-recall `## MEMORY` section, or a `[memory]` block on a
+/// tool result. The map is identical for all three: the mock does not care
+/// where a code came from, only that it was given one.
 #[derive(Debug, Default)]
 struct Lessons {
     customer_not_found: bool,
@@ -231,19 +242,40 @@ struct Lessons {
 }
 
 impl Lessons {
-    fn from_system(system: &str) -> Self {
-        let section = match system.find("## LESSONS") {
-            Some(i) => &system[i..],
-            None => return Self::default(),
-        };
+    fn from_context(context: &str) -> Self {
         Self {
-            customer_not_found: section.contains("customer_not_found"),
-            approval_required: section.contains("approval_required"),
-            cancel_before_refund: section.contains("cancel_before_refund"),
-            invalid_timestamp: section.contains("invalid_timestamp"),
-            rate_limited: section.contains("rate_limited"),
+            customer_not_found: context.contains("customer_not_found"),
+            approval_required: context.contains("approval_required"),
+            cancel_before_refund: context.contains("cancel_before_refund"),
+            invalid_timestamp: context.contains("invalid_timestamp"),
+            rate_limited: context.contains("rate_limited"),
         }
     }
+}
+
+/// Everything the harness legitimately handed the agent as *context*, joined
+/// for code scanning. Each chunk starts at its marker and runs to the end of
+/// its string, which is what keeps the scan honest: a tool result's own error
+/// body sits BEFORE its `[memory]` block, so an error the agent just hit can
+/// never unlock the behavior by itself — only a provider that chose to recall
+/// something can. (`## MEMORY` is appended after `## LESSONS`, so when both
+/// exist the first slice already covers the second; the union is the same.)
+fn context_text(system: &str, messages: &[ChatMessage]) -> String {
+    let mut buf = String::new();
+    for marker in ["## LESSONS", super::context::MEMORY_SECTION_HEADING] {
+        if let Some(i) = system.find(marker) {
+            buf.push_str(&system[i..]);
+            buf.push('\n');
+        }
+    }
+    for m in messages.iter().filter(|m| m.role == "tool") {
+        let content = m.content.as_deref().unwrap_or("");
+        if let Some(i) = content.find(super::context::MEMORY_INJECTION_PREFIX) {
+            buf.push_str(&content[i..]);
+            buf.push('\n');
+        }
+    }
+    buf
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -343,7 +375,17 @@ fn collect_pairs(messages: &[ChatMessage]) -> Vec<Pair> {
         }
         for tc in &m.tool_calls {
             let body = results.get(tc.id.as_str()).copied().unwrap_or("{}");
-            let result: Value = serde_json::from_str(body).unwrap_or_else(|_| json!({}));
+            // A passive arm's per-error hook appends a `[memory]` block AFTER
+            // the env's JSON body, so the message is no longer parseable as
+            // one value. Split it off: the mock reads its state from the
+            // env's result and its lessons from the block (`context_text`),
+            // and conflating them would make the whole result read as `{}` —
+            // an unrecognized error, silently steering the flow logic.
+            let json_part = body
+                .split(super::context::MEMORY_INJECTION_PREFIX)
+                .next()
+                .unwrap_or(body);
+            let result: Value = serde_json::from_str(json_part).unwrap_or_else(|_| json!({}));
             let args: Value = serde_json::from_str(&tc.arguments).unwrap_or_else(|_| json!({}));
             let is_error = result.get("error").is_some();
             let code = result.pointer("/error/code").and_then(Value::as_str).map(String::from);
@@ -782,25 +824,83 @@ Call one tool at a time and read each result before deciding the next call.\n\
 When the task is done, reply with a short final answer and no tool calls.\n\
 If the task cannot be completed, say so briefly in the final answer.";
 
+/// Frame a provider's output so the prompt carries its marker EXACTLY once.
+///
+/// SELFIMPROVE.md's frozen contract reads as "the provider returns the body,
+/// the caller adds the heading"; `context.rs` reads it the other way and has
+/// each provider emit a complete section — deliberately, so the four arms
+/// produce structurally identical prompt bytes the way `lessons_markdown`
+/// owns its own `## LESSONS` heading. Both are defensible and the difference
+/// is invisible here: the marker is added only when the provider did not
+/// supply it, so a bare body still reaches the model framed (and the mock,
+/// which keys on the marker, can still see it) and a complete section is
+/// never double-headed.
+fn framed(text: &str, marker: &str) -> String {
+    if text.starts_with(marker) {
+        text.to_string()
+    } else {
+        format!("{marker}\n{text}")
+    }
+}
+
 /// Run one task to completion. `steps` counts model turns. A backend `Err`
 /// records `failure_reason: "backend_error: …"` and returns — a flaky
 /// provider must not kill a 900-task run. `on_event` receives one row per
-/// executed tool call ({task_id, turn, tool, args, is_error, code}) plus a
-/// {task_id, turn, error} row on backend failure.
+/// executed tool call ({task_id, turn, tool, args, is_error, code}), a
+/// {task_id, turn, error} row on backend failure, and a
+/// {task_id, turn, provider_error} row whenever `context` returns `Err`.
+///
+/// `lessons_md` and `context` are the two ways memory can reach the prompt,
+/// and the bench passes exactly one of them: the governed states (A0/B/A1/B2)
+/// carry lessons and no provider, the passive arms carry a provider and no
+/// lessons. Mixing them would make an arm's numbers unattributable, so the
+/// XOR is asserted here rather than trusted.
+///
+/// A provider `Err` never fails the task: it is logged to the transcript and
+/// the turn proceeds without that context — the same fail-soft philosophy as
+/// the engine's LLM stages, and the report stays honest because the failure
+/// is in the transcript rather than silently absorbed.
+///
+/// Callable from worker threads: everything borrowed across the call is per
+/// worker (`backend`), per task (`env`, `on_event`), or `Sync` (`lessons_md`,
+/// and `ContextProvider`'s own `Sync + Send` bound).
+// Eight arguments, each one a distinct axis of a single call (backend, env,
+// identity, prompt, the two context sources, the turn cap, the sink). A
+// parameter struct would only move the same list behind a name that no
+// caller reuses — there are four call sites in the tree, all in this crate.
+#[allow(clippy::too_many_arguments)]
 pub fn run_task<E: AgentEnv + ?Sized>(
     backend: &mut dyn ChatBackend,
     env: &mut E,
     task_id: &str,
     task_prompt: &str,
     lessons_md: &str,
+    context: Option<&dyn super::context::ContextProvider>,
     max_turns: u32,
     mut on_event: impl FnMut(&Value),
 ) -> TaskRunRecord {
-    let system = if lessons_md.is_empty() {
+    debug_assert!(
+        lessons_md.is_empty() || context.is_none(),
+        "lessons XOR provider: a passive arm must run with the LESSONS section empty"
+    );
+    let mut system = if lessons_md.is_empty() {
         AGENT_SYSTEM_PROMPT.to_string()
     } else {
         format!("{AGENT_SYSTEM_PROMPT}\n\n{lessons_md}")
     };
+    if let Some(provider) = context {
+        match provider.task_start(task_prompt) {
+            Ok(text) if !text.is_empty() => {
+                system.push_str("\n\n");
+                system.push_str(&framed(&text, super::context::MEMORY_SECTION_HEADING));
+            }
+            Ok(_) => {}
+            // turn 0: before the first model call.
+            Err(e) => {
+                on_event(&json!({ "task_id": task_id, "turn": 0, "provider_error": e }))
+            }
+        }
+    }
     let tools = env.tools();
     let mut messages = vec![ChatMessage::system(&system), ChatMessage::user(task_prompt)];
     let mut calls: Vec<RecordedCall> = Vec::new();
@@ -846,7 +946,40 @@ pub fn run_task<E: AgentEnv + ?Sized>(
             if outcome.is_error {
                 tool_errors += 1;
             }
-            messages.push(ChatMessage::tool_result(&tc.id, &outcome.body));
+            // The per-error hook: a provider may append recall to the FAILING
+            // result the model is about to read (the m-steel injection point).
+            // `RecordedCall` below keeps the env's body verbatim — what the
+            // environment produced is not what the harness chose to add.
+            let mut recall = String::new();
+            if outcome.is_error {
+                if let Some(provider) = context {
+                    match provider.on_tool_error(
+                        task_prompt,
+                        &tc.name,
+                        outcome.code.as_deref().unwrap_or(""),
+                        &outcome.body,
+                    ) {
+                        Ok(text) if !text.is_empty() => {
+                            recall = format!(
+                                "\n\n{}",
+                                framed(&text, super::context::MEMORY_INJECTION_PREFIX)
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(e) => on_event(
+                            &json!({ "task_id": task_id, "turn": turn, "provider_error": e }),
+                        ),
+                    }
+                }
+            }
+            if recall.is_empty() {
+                messages.push(ChatMessage::tool_result(&tc.id, &outcome.body));
+            } else {
+                messages.push(ChatMessage::tool_result(
+                    &tc.id,
+                    &format!("{}{recall}", outcome.body),
+                ));
+            }
             calls.push(RecordedCall {
                 call_id: tc.id.clone(),
                 tool: tc.name.clone(),
@@ -1093,10 +1226,62 @@ mod tests {
     }
 
     fn run_mock(env: &mut DeskDouble, prompt: &str, lessons: &str) -> (TaskRunRecord, Vec<Value>) {
+        run_mock_with(env, prompt, lessons, None)
+    }
+
+    fn run_mock_with(
+        env: &mut DeskDouble,
+        prompt: &str,
+        lessons: &str,
+        context: Option<&dyn crate::selfimprove::context::ContextProvider>,
+    ) -> (TaskRunRecord, Vec<Value>) {
         let mut backend = MockBackend;
         let mut events = Vec::new();
-        let rec = run_task(&mut backend, env, "t1", prompt, lessons, 20, |e| events.push(e.clone()));
+        let rec = run_task(&mut backend, env, "t1", prompt, lessons, context, 20, |e| {
+            events.push(e.clone())
+        });
         (rec, events)
+    }
+
+    /// Local stand-in for the real providers (`context.rs`): returns canned
+    /// markdown at whichever hook it was built for, so the mock's context
+    /// awareness is testable without any ingest or LLM.
+    struct ProviderDouble {
+        at_start: Result<String, String>,
+        at_error: Result<String, String>,
+    }
+
+    impl ProviderDouble {
+        fn at_start(text: &str) -> Self {
+            Self { at_start: Ok(text.to_string()), at_error: Ok(String::new()) }
+        }
+        fn at_error(text: &str) -> Self {
+            Self { at_start: Ok(String::new()), at_error: Ok(text.to_string()) }
+        }
+        fn failing() -> Self {
+            Self {
+                at_start: Err("provider ingest is broken".to_string()),
+                at_error: Err("provider lookup is broken".to_string()),
+            }
+        }
+    }
+
+    impl crate::selfimprove::context::ContextProvider for ProviderDouble {
+        fn label(&self) -> &'static str {
+            "m-double"
+        }
+        fn task_start(&self, _task_prompt: &str) -> Result<String, String> {
+            self.at_start.clone()
+        }
+        fn on_tool_error(
+            &self,
+            _task_prompt: &str,
+            _tool: &str,
+            _code: &str,
+            _body: &str,
+        ) -> Result<String, String> {
+            self.at_error.clone()
+        }
     }
 
     fn tool_seq(rec: &TaskRunRecord) -> Vec<&str> {
@@ -1233,6 +1418,201 @@ mod tests {
         assert!(rec.rule_failures.is_empty());
     }
 
+    // --- passive-recall arms: the mock uses whatever context it is given ----
+
+    /// A `## MEMORY` section unlocks exactly what the same codes unlock from
+    /// `## LESSONS` — the arms differ in where context comes from, never in
+    /// what the mock does with it.
+    #[test]
+    fn memory_section_unlocks_the_same_behaviors_as_lessons() {
+        let recall = "- `search_customers` results were incomplete (customer_not_found)\n\
+                      - `refund` returned rate_limited with retry_after_s\n";
+        let provider = ProviderDouble::at_start(recall);
+        let mut env = DeskDouble::new(Goal::Refund, pages_two());
+        env.want_amount = 50.0;
+        env.refund_429s = 1;
+        let (rec, _) = run_mock_with(&mut env, REFUND_PROMPT, "", Some(&provider));
+        assert!(rec.success, "failure: {}", rec.failure_reason);
+        assert!(rec
+            .calls
+            .iter()
+            .any(|c| c.tool == "search_customers" && c.input_json.contains("\"page\":2")));
+        assert_eq!(env.refunds, vec![("cus_200".to_string(), 50.0)]);
+        assert_eq!(env.waits, vec![7.0]);
+    }
+
+    /// The per-error hook (m-steel's shape): nothing at task start, recall
+    /// appended to the failing result itself, and the mock adapts from there.
+    #[test]
+    fn memory_block_on_a_failing_tool_result_unlocks_the_wait_retry() {
+        let provider =
+            ProviderDouble::at_error("- refund previously answered rate_limited; a wait helped\n");
+        let mut env = DeskDouble::new(Goal::Refund, pages_one());
+        env.want_amount = 50.0;
+        env.refund_429s = 1;
+        let (rec, _) = run_mock_with(&mut env, REFUND_PROMPT, "", Some(&provider));
+        assert!(rec.success, "failure: {}", rec.failure_reason);
+        assert_eq!(env.waits, vec![7.0], "the 429 was answered with a wait, not a hot retry");
+    }
+
+    /// The negative half of the test above, and the honesty check on the
+    /// scan: the 429 body itself carries the string `rate_limited`, and it
+    /// must NOT unlock anything on its own — only a provider that chose to
+    /// recall something can. A provider that returns empty leaves the agent
+    /// exactly as naive as it was.
+    #[test]
+    fn an_error_body_alone_never_unlocks_a_behavior() {
+        let provider = ProviderDouble::at_error("");
+        let mut env = DeskDouble::new(Goal::Refund, pages_one());
+        env.want_amount = 50.0;
+        env.refund_429s = 10;
+        let (rec, _) = run_mock_with(&mut env, REFUND_PROMPT, "", Some(&provider));
+        assert!(!rec.success);
+        assert!(env.waits.is_empty(), "no lesson, no wait — the hot-retry storm stands");
+        assert_eq!(rec.calls.iter().filter(|c| c.tool == "refund").count(), 3);
+    }
+
+    /// Both injection points, pinned to the byte: the section heading in the
+    /// system prompt and the block marker on the tool result are the contract
+    /// the mock (and any live model's prompt) reads.
+    #[test]
+    fn context_reaches_the_prompt_in_the_documented_shape() {
+        #[derive(Default)]
+        struct RecordingMock {
+            inner: MockBackend,
+            systems: Vec<String>,
+            tool_bodies: Vec<String>,
+        }
+        impl ChatBackend for RecordingMock {
+            fn chat(
+                &mut self,
+                messages: &[ChatMessage],
+                tools: &Value,
+            ) -> Result<(ChatMessage, Usage), String> {
+                if let Some(s) =
+                    messages.iter().find(|m| m.role == "system").and_then(|m| m.content.clone())
+                {
+                    self.systems.push(s);
+                }
+                self.tool_bodies = messages
+                    .iter()
+                    .filter(|m| m.role == "tool")
+                    .filter_map(|m| m.content.clone())
+                    .collect();
+                self.inner.chat(messages, tools)
+            }
+        }
+
+        let provider = ProviderDouble {
+            at_start: Ok("start-recall".to_string()),
+            at_error: Ok("error-recall".to_string()),
+        };
+        let mut backend = RecordingMock::default();
+        let mut env = DeskDouble::new(Goal::Refund, pages_one());
+        env.want_amount = 50.0;
+        env.refund_429s = 1;
+        let rec = run_task(
+            &mut backend,
+            &mut env,
+            "t-shape",
+            REFUND_PROMPT,
+            "",
+            Some(&provider),
+            20,
+            |_| {},
+        );
+        assert!(rec.success, "failure: {}", rec.failure_reason);
+        let system = &backend.systems[0];
+        assert!(
+            system.starts_with(AGENT_SYSTEM_PROMPT),
+            "the operator role stays first: {system:?}"
+        );
+        assert!(
+            system.ends_with("\n\n## MEMORY (from passive recall)\nstart-recall"),
+            "memory section shape: {system:?}"
+        );
+        assert!(!system.contains("## LESSONS"), "an M arm carries no lessons: {system:?}");
+        let errored = backend
+            .tool_bodies
+            .iter()
+            .find(|b| b.contains("rate_limited"))
+            .expect("the 429 result");
+        assert!(
+            errored.ends_with("\n\n[memory] Relevant past experience:\nerror-recall"),
+            "memory block shape: {errored:?}"
+        );
+        // The env's own body is untouched in the RECORD — the harness only
+        // added context to what the model reads.
+        let recorded = rec.calls.iter().find(|c| c.is_error).expect("a recorded failure");
+        assert!(!recorded.output_json.contains("[memory]"), "{}", recorded.output_json);
+    }
+
+    /// The other half of the framing seam, and the one the REAL providers
+    /// take: `context.rs` returns a complete section (heading included), so
+    /// the prompt must carry that heading exactly once — a doubled heading
+    /// would still "work" (the mock scans for codes) while quietly corrupting
+    /// every live arm's prompt, which is why it is asserted rather than
+    /// assumed.
+    #[test]
+    fn a_provider_that_frames_its_own_output_is_not_double_headed() {
+        let heading = crate::selfimprove::context::MEMORY_SECTION_HEADING;
+        let prefix = crate::selfimprove::context::MEMORY_INJECTION_PREFIX;
+        assert_eq!(
+            framed(&format!("{heading}\n- already framed\n"), heading),
+            format!("{heading}\n- already framed\n"),
+            "a complete section passes through untouched"
+        );
+        assert_eq!(framed("- bare body\n", heading), format!("{heading}\n- bare body\n"));
+        assert_eq!(framed("- bare body\n", prefix), format!("{prefix}\n- bare body\n"));
+        // End to end through a real provider: exactly one heading, and the
+        // mock still sees the codes inside it.
+        let provider = crate::selfimprove::context::AllProvider::build(vec![
+            crate::selfimprove::context::ExperienceGrain {
+                task_id: "exp-1".to_string(),
+                tool: "refund".to_string(),
+                input_json: "{}".to_string(),
+                output_json: r#"{"error":{"code":"rate_limited"}}"#.to_string(),
+                is_error: true,
+                code: Some("rate_limited".to_string()),
+                rendered: "- `refund` failed with `rate_limited`".to_string(),
+            },
+        ]);
+        let section =
+            crate::selfimprove::context::ContextProvider::task_start(&provider, "any").unwrap();
+        let framed_once = framed(&section, heading);
+        assert_eq!(framed_once.matches(heading).count(), 1, "{framed_once:?}");
+        assert!(Lessons::from_context(&framed_once).rate_limited);
+    }
+
+    /// A provider that errors is logged and stepped over — never fatal. The
+    /// run must be indistinguishable from the no-provider run, because the
+    /// engine's LLM stages fail soft the same way and the transcript, not a
+    /// dead run, is what keeps the report honest.
+    #[test]
+    fn a_failing_provider_is_logged_and_the_task_continues() {
+        let provider = ProviderDouble::failing();
+        let mut env = DeskDouble::new(Goal::Refund, pages_one());
+        env.want_amount = 50.0;
+        env.refund_429s = 10;
+        let (rec, events) = run_mock_with(&mut env, REFUND_PROMPT, "", Some(&provider));
+        assert!(!rec.failure_reason.starts_with("backend_error"), "{}", rec.failure_reason);
+        // Identical to the naive no-context run (an_error_body_alone…).
+        assert_eq!(rec.calls.iter().filter(|c| c.tool == "refund").count(), 3);
+        assert!(env.waits.is_empty());
+        let errors: Vec<&Value> =
+            events.iter().filter(|e| e.get("provider_error").is_some()).collect();
+        assert_eq!(
+            errors[0]["turn"],
+            json!(0),
+            "the task_start failure is logged before the first turn"
+        );
+        assert_eq!(errors[0]["task_id"], json!("t1"));
+        assert!(
+            errors.iter().any(|e| e["turn"].as_u64().unwrap_or(0) > 0),
+            "each failing per-error lookup is logged too: {errors:?}"
+        );
+    }
+
     #[test]
     fn to_utc_z_handles_offsets_and_rollover() {
         assert_eq!(to_utc_z_off("2026-03-01T00:30:00+05:30", None), "2026-02-28T19:00:00Z");
@@ -1334,7 +1714,7 @@ mod tests {
     fn run_task_enforces_the_turn_limit() {
         let mut backend = AlwaysTool;
         let mut env = DeskDouble::new(Goal::Refund, pages_one());
-        let rec = run_task(&mut backend, &mut env, "t-limit", "loop forever", "", 3, |_| {});
+        let rec = run_task(&mut backend, &mut env, "t-limit", "loop forever", "", None, 3, |_| {});
         assert!(!rec.success);
         assert_eq!(rec.failure_reason, "turn_limit");
         assert_eq!(rec.steps, 3);
@@ -1353,8 +1733,9 @@ mod tests {
         let mut backend = FailBackend;
         let mut env = DeskDouble::new(Goal::Refund, pages_one());
         let mut events = Vec::new();
-        let rec =
-            run_task(&mut backend, &mut env, "t-err", "anything", "", 5, |e| events.push(e.clone()));
+        let rec = run_task(&mut backend, &mut env, "t-err", "anything", "", None, 5, |e| {
+            events.push(e.clone())
+        });
         assert!(!rec.success);
         assert_eq!(rec.failure_reason, "backend_error: boom");
         assert_eq!(rec.steps, 0);

--- a/crates/areev-bench/src/selfimprove/context.rs
+++ b/crates/areev-bench/src/selfimprove/context.rs
@@ -1,0 +1,1108 @@
+//! context — the passive-memory arms (SELFIMPROVE.md "Bench 2: the
+//! passive-memory arms", whose "context-provider contract" is frozen).
+//!
+//! Four arms answer "does the LOOP add value over the STORE?". They all read
+//! the SAME captured experience (Tool grains only — lessons live as Facts, so
+//! nothing leaks between arms) and differ only in what reaches the prompt:
+//!
+//!   m-steel  per-error structured retrieval at the decision point
+//!   m-all    the whole failure history at task start (information upper bound)
+//!   m-llm    the history summarized once into operator notes (cost recorded)
+//!   m-cmd    any external provider over the newline-delimited JSON protocol
+//!
+//! ## Two rules the whole module is built around
+//!
+//! **Ingest happens at construction.** Every provider is immutable afterwards
+//! and its trait methods take `&self`, which is what makes parallel eval
+//! workers safe. `CmdProvider` keeps a `Mutex` purely to serialize calls into
+//! its one subprocess — the provider's *content* is still frozen at spawn.
+//!
+//! **No silent caps.** Every truncation appends a line saying how much was
+//! dropped. A provider that quietly cut its own history would make the arm
+//! look weaker than the retrieval it stands for, which is exactly the
+//! criticism these arms exist to pre-empt.
+//!
+//! ## Prompt framing belongs to the provider, not the caller
+//!
+//! `task_start` returns a COMPLETE section (heading included) and
+//! `on_tool_error` a COMPLETE block (prefix included), mirroring
+//! `memory::lessons_markdown`, which owns its own `## LESSONS` heading. Two
+//! reasons: the four arms then produce structurally identical prompt bytes,
+//! which is what makes them comparable; and the mock agent keys on the
+//! [`MEMORY_SECTION_HEADING`] / [`MEMORY_INJECTION_PREFIX`] markers, so a
+//! provider that emitted a bare body would read as "no memory at all" rather
+//! than failing loudly.
+
+use std::collections::BTreeMap;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{mpsc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+
+use super::agent::{ChatBackend, CmdBackend};
+use super::{ChatMessage, Usage};
+
+/// The system-prompt heading every arm's `task_start` output carries.
+pub const MEMORY_SECTION_HEADING: &str = "## MEMORY (from passive recall)";
+/// The prefix every arm's non-empty `on_tool_error` output carries.
+pub const MEMORY_INJECTION_PREFIX: &str = "[memory] Relevant past experience:";
+
+/// `m-steel`: chars per injection.
+const STEEL_CAP: usize = 4_000;
+/// `m-all`: chars per task-start section.
+const ALL_CAP: usize = 24_000;
+/// `m-llm`: chars of summarizer notes carried into every prompt.
+const LLM_NOTES_CAP: usize = 4_000;
+/// `m-llm`: chars of history handed to the summarizer.
+const LLM_INPUT_CAP: usize = 200_000;
+/// Chars of a tool-result body kept in a rendered line.
+const BODY_EXCERPT_CHARS: usize = 160;
+/// A wedged external provider must not hang a 900-task run.
+const PROVIDER_TIMEOUT: Duration = Duration::from_secs(120);
+
+// ---------------------------------------------------------------------------
+// The frozen contract
+// ---------------------------------------------------------------------------
+
+/// One experience-phase tool call, as the arms see it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExperienceGrain {
+    pub task_id: String,
+    pub tool: String,
+    pub input_json: String,
+    pub output_json: String,
+    pub is_error: bool,
+    /// The frozen error code (mod.rs contract) when `is_error`.
+    pub code: Option<String>,
+    /// The one-line form the arms render this call as ([`render_line`]).
+    pub rendered: String,
+}
+
+impl ExperienceGrain {
+    /// Wire form for the `--context-cmd` ingest payload.
+    pub fn to_json(&self) -> Value {
+        json!({
+            "task_id": self.task_id,
+            "tool": self.tool,
+            "input_json": self.input_json,
+            "output_json": self.output_json,
+            "is_error": self.is_error,
+            "code": self.code,
+            "rendered": self.rendered,
+        })
+    }
+}
+
+/// A passive-memory arm. `Sync + Send` with `&self` methods: providers are
+/// immutable after construction, so eval workers can share one.
+pub trait ContextProvider: Sync + Send {
+    fn label(&self) -> &'static str;
+    /// The `## MEMORY (from passive recall)` section for the system prompt at
+    /// task start; empty string = no section.
+    fn task_start(&self, task_prompt: &str) -> Result<String, String>;
+    /// The `[memory]` block appended to a failing tool result; empty = nothing.
+    fn on_tool_error(
+        &self,
+        task_prompt: &str,
+        tool: &str,
+        code: &str,
+        body: &str,
+    ) -> Result<String, String>;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering — one mechanical line per grain
+// ---------------------------------------------------------------------------
+
+/// The one-line form of a recorded tool call, shared by every arm and by
+/// `memory::experience_grains`.
+///
+/// Deliberately NOT `areev_cal::render_grain_text_line`: the product's
+/// one-line form for a Tool grain is `refund [FAIL]` (the `"tool"` arm of
+/// `known_type_summary`), which carries neither the error code nor any of the
+/// body. Those two are the entire payload the m-arms exist to inject, so the
+/// product renderer would hand every arm an empty comparison. The shape below
+/// mirrors the lesson renderer's (`` `tool` ``, backticked code, then detail)
+/// so the arms and the governed lessons read alike in a prompt.
+///
+/// The result is always ONE line: the body excerpt is whitespace-collapsed and
+/// capped, so a multi-line JSON error can never break the bullet list.
+pub fn render_line(tool: &str, is_error: bool, code: Option<&str>, body: &str) -> String {
+    if !is_error {
+        return format!("- `{tool}` call succeeded");
+    }
+    let excerpt = truncate_chars(&collapse_ws(body), BODY_EXCERPT_CHARS);
+    match code {
+        Some(code) => format!("- `{tool}` call failed with `{code}`: {excerpt}"),
+        None => format!("- `{tool}` call failed: {excerpt}"),
+    }
+}
+
+/// Whitespace-collapse to a single line (a "rendered line" must be one line).
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn truncate_chars(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        return s.to_string();
+    }
+    let kept: String = s.chars().take(n).collect();
+    format!("{kept}…")
+}
+
+/// Join `lines` (each newline-terminated) up to `cap` chars, appending
+/// `note(n)` when `n` lines had to be dropped. Returns the text and that
+/// dropped count.
+///
+/// The cap is enforced by dropping WHOLE lines — nothing is ever sliced, so no
+/// output can split a UTF-8 sequence or a half-written bullet. Room for the
+/// note is reserved before each line is admitted, so the returned string is
+/// `<= cap` whenever `cap` exceeds the longest note the caller can produce.
+///
+/// `note` is called once per candidate line to size that reserve, so it must
+/// be PURE — a caller that wants to log a truncation logs it off the returned
+/// count, not from inside the closure.
+fn cap_lines(lines: &[String], cap: usize, note: &dyn Fn(usize) -> String) -> (String, usize) {
+    let mut out = String::new();
+    let mut used = 0usize;
+    for (i, line) in lines.iter().enumerate() {
+        let line_chars = line.chars().count() + 1; // + '\n'
+        let left_after = lines.len() - i - 1;
+        let reserve = if left_after == 0 {
+            0
+        } else {
+            note(left_after).chars().count()
+        };
+        if used + line_chars + reserve > cap {
+            let dropped = lines.len() - i;
+            out.push_str(&note(dropped));
+            return (out, dropped);
+        }
+        out.push_str(line);
+        out.push('\n');
+        used += line_chars;
+    }
+    (out, 0)
+}
+
+/// Wrap a body as the task-start section; empty body ⇒ empty section.
+fn section(body: &str) -> String {
+    if body.trim().is_empty() {
+        return String::new();
+    }
+    format!("{MEMORY_SECTION_HEADING}\n{body}")
+}
+
+/// Wrap a body as the tool-error injection; empty body ⇒ nothing appended.
+fn injection(body: &str) -> String {
+    if body.trim().is_empty() {
+        return String::new();
+    }
+    format!("{MEMORY_INJECTION_PREFIX}\n{body}")
+}
+
+/// `(tool → total calls, tool → errors)`, sorted by tool for stable bytes.
+fn tool_counts(grains: &[ExperienceGrain]) -> BTreeMap<&str, (usize, usize)> {
+    let mut counts: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+    for g in grains {
+        let e = counts.entry(g.tool.as_str()).or_insert((0, 0));
+        e.0 += 1;
+        if g.is_error {
+            e.1 += 1;
+        }
+    }
+    counts
+}
+
+fn counts_line(tool: &str, calls: usize, errors: usize) -> String {
+    format!("`{tool}`: {calls} calls, {errors} errors")
+}
+
+// ---------------------------------------------------------------------------
+// m-steel — per-error structured retrieval
+// ---------------------------------------------------------------------------
+
+/// The "retrieval with a perfect hook" arm: on a tool failure, every past
+/// grain matching that exact `(tool, code)` is injected at the decision point.
+/// A better hook than semantic similarity would get, by construction.
+#[derive(Debug)]
+pub struct SteelProvider {
+    /// `(tool, code)` → rendered lines in RECORDING order (oldest first).
+    index: BTreeMap<(String, String), Vec<String>>,
+}
+
+impl SteelProvider {
+    /// `grains` arrive in recording order; "most recent" is therefore later.
+    /// Only error grains carry a code, so only they are indexed — a lookup is
+    /// always by `(tool, code)`.
+    pub fn build(grains: Vec<ExperienceGrain>) -> SteelProvider {
+        let mut index: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+        for g in grains {
+            if let Some(code) = g.code.filter(|_| g.is_error) {
+                index
+                    .entry((g.tool, code))
+                    .or_default()
+                    .push(g.rendered);
+            }
+        }
+        SteelProvider { index }
+    }
+}
+
+impl ContextProvider for SteelProvider {
+    fn label(&self) -> &'static str {
+        "m-steel"
+    }
+
+    fn task_start(&self, _task_prompt: &str) -> Result<String, String> {
+        // Nothing at task start: this arm's whole claim is that the hook fires
+        // at the decision point, not that the prompt is pre-loaded.
+        Ok(String::new())
+    }
+
+    fn on_tool_error(
+        &self,
+        _task_prompt: &str,
+        tool: &str,
+        code: &str,
+        _body: &str,
+    ) -> Result<String, String> {
+        let Some(hits) = self.index.get(&(tool.to_string(), code.to_string())) else {
+            return Ok(String::new());
+        };
+        // Most recent first: recording order reversed.
+        let lines: Vec<String> = hits.iter().rev().cloned().collect();
+        let (body, _) = cap_lines(&lines, STEEL_CAP, &|n| {
+            format!("… ({n} earlier occurrences not shown)\n")
+        });
+        Ok(injection(&body))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// m-all — the information upper bound
+// ---------------------------------------------------------------------------
+
+/// The "you under-retrieved" arm: the entire failure history at task start,
+/// grouped by tool, on a generous budget.
+#[derive(Debug)]
+pub struct AllProvider {
+    /// Precomputed at build — the provider is immutable afterwards.
+    body: String,
+}
+
+impl AllProvider {
+    pub fn build(grains: Vec<ExperienceGrain>) -> AllProvider {
+        let counts = tool_counts(&grains);
+        // Group errors by tool; `BTreeMap` + recording order within a group
+        // keeps the prompt bytes stable across runs.
+        let mut by_tool: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for g in grains.iter().filter(|g| g.is_error) {
+            by_tool.entry(g.tool.as_str()).or_default().push(&g.rendered);
+        }
+        let mut lines = vec![
+            "Every tool-call failure recorded in earlier runs.".to_string(),
+            String::new(),
+        ];
+        for (tool, rendered) in &by_tool {
+            let (calls, errors) = counts.get(tool).copied().unwrap_or((0, 0));
+            lines.push(counts_line(tool, calls, errors));
+            lines.extend(rendered.iter().map(|r| (*r).to_string()));
+            lines.push(String::new());
+        }
+        let body = if by_tool.is_empty() {
+            String::new()
+        } else {
+            cap_lines(&lines, ALL_CAP, &|n| {
+                format!("… ({n} more history lines not shown — {ALL_CAP}-char cap)\n")
+            })
+            .0
+        };
+        AllProvider { body }
+    }
+}
+
+impl ContextProvider for AllProvider {
+    fn label(&self) -> &'static str {
+        "m-all"
+    }
+
+    fn task_start(&self, _task_prompt: &str) -> Result<String, String> {
+        Ok(section(&self.body))
+    }
+
+    fn on_tool_error(
+        &self,
+        _task_prompt: &str,
+        _tool: &str,
+        _code: &str,
+        _body: &str,
+    ) -> Result<String, String> {
+        // The whole history is already in the prompt: injecting again would
+        // price this arm's tokens twice.
+        Ok(String::new())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// m-llm — extraction at write time
+// ---------------------------------------------------------------------------
+
+const SUMMARIZER_SYSTEM: &str = "You are building memory notes for a support-desk agent. \
+From the tool-call history below, write concise markdown bullet notes capturing recurring \
+failure patterns worth remembering for future tasks.";
+
+/// The "LLM-memory product" arm: ONE summarizer call over the raw history at
+/// construction, its notes into every prompt. The call's cost is retained
+/// (`usage`) because it is part of what this arm charges and the governed
+/// arm does not.
+#[derive(Debug)]
+pub struct LlmProvider {
+    notes: String,
+    usage: Usage,
+}
+
+impl LlmProvider {
+    /// One summarizer call over the agent chat-adapter protocol
+    /// (SELFIMPROVE.md "Runner protocol"), reusing [`CmdBackend`]. `model` is
+    /// empty: the adapter command pins the model, as it does for the agent.
+    pub fn build(chat_cmd: &str, grains: Vec<ExperienceGrain>) -> Result<LlmProvider, String> {
+        let input = summarizer_input(&grains);
+        let mut backend = CmdBackend { cmd: chat_cmd.to_string(), model: String::new() };
+        let messages = [ChatMessage::system(SUMMARIZER_SYSTEM), ChatMessage::user(&input)];
+        let (msg, usage) = backend
+            .chat(&messages, &json!([]))
+            .map_err(|e| format!("m-llm summarizer: {e}"))?;
+        let raw = msg.content.unwrap_or_default();
+        let notes = cap_notes(&raw);
+        Ok(LlmProvider { notes, usage })
+    }
+
+    /// The keyless deterministic summarizer for `--mock` CI: one bullet per
+    /// `(tool, code)` cluster, sorted, no subprocess and no cost. It proves
+    /// the plumbing; it is never a summarization claim.
+    pub fn build_mock(grains: Vec<ExperienceGrain>) -> LlmProvider {
+        let mut clusters: BTreeMap<(&str, &str), usize> = BTreeMap::new();
+        for g in grains.iter().filter(|g| g.is_error) {
+            if let Some(code) = g.code.as_deref() {
+                *clusters.entry((g.tool.as_str(), code)).or_insert(0) += 1;
+            }
+        }
+        let notes = clusters
+            .iter()
+            .map(|((tool, code), n)| format!("- `{tool}` failed {n} times with `{code}`\n"))
+            .collect::<String>();
+        LlmProvider { notes, usage: Usage::default() }
+    }
+
+    /// What the summarizer cost. Zero for [`build_mock`](Self::build_mock).
+    pub fn usage(&self) -> Usage {
+        self.usage
+    }
+}
+
+impl ContextProvider for LlmProvider {
+    fn label(&self) -> &'static str {
+        "m-llm"
+    }
+
+    fn task_start(&self, _task_prompt: &str) -> Result<String, String> {
+        Ok(section(&self.notes))
+    }
+
+    fn on_tool_error(
+        &self,
+        _task_prompt: &str,
+        _tool: &str,
+        _code: &str,
+        _body: &str,
+    ) -> Result<String, String> {
+        // Extraction-at-write-time: the notes are the whole product of this
+        // arm, and they are already in the prompt.
+        Ok(String::new())
+    }
+}
+
+/// The summarizer's user content: per-tool call counts + every error line.
+/// Capped, with the truncation logged to stderr — the cost of this arm is a
+/// published number, so a silently shortened input would misprice it.
+fn summarizer_input(grains: &[ExperienceGrain]) -> String {
+    let mut lines: Vec<String> = vec!["Tool-call counts:".to_string()];
+    for (tool, (calls, errors)) in tool_counts(grains) {
+        lines.push(counts_line(tool, calls, errors));
+    }
+    lines.push(String::new());
+    lines.push("Failures, oldest first:".to_string());
+    lines.extend(
+        grains
+            .iter()
+            .filter(|g| g.is_error)
+            .map(|g| g.rendered.clone()),
+    );
+    let (out, dropped) = cap_lines(&lines, LLM_INPUT_CAP, &|n| {
+        format!("… ({n} more history lines not shown — {LLM_INPUT_CAP}-char cap)\n")
+    });
+    if dropped > 0 {
+        eprintln!(
+            "m-llm: summarizer input hit the {LLM_INPUT_CAP}-char cap; \
+             {dropped} history lines dropped"
+        );
+    }
+    out
+}
+
+/// Notes cap. Slices on a char boundary and says so.
+fn cap_notes(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.chars().count() <= LLM_NOTES_CAP {
+        return trimmed.to_string();
+    }
+    let note = format!("\n… (notes truncated at the {LLM_NOTES_CAP}-char cap)");
+    let keep = LLM_NOTES_CAP - note.chars().count();
+    let kept: String = trimmed.chars().take(keep).collect();
+    format!("{kept}{note}")
+}
+
+// ---------------------------------------------------------------------------
+// m-cmd — the external-provider seam
+// ---------------------------------------------------------------------------
+
+/// One persistent `sh -c` subprocess speaking the frozen newline-delimited
+/// JSON protocol, so any vendor can plug their memory into this experiment.
+///
+/// The `Mutex` serializes calls into the single stdio pair; it does NOT make
+/// the provider mutable — ingest already happened at spawn.
+#[derive(Debug)]
+pub struct CmdProvider {
+    cmd: String,
+    io: Mutex<ProviderIo>,
+}
+
+#[derive(Debug)]
+struct ProviderIo {
+    child: Child,
+    stdin: ChildStdin,
+    /// Lines from a reader thread. The sender drops when the child's stdout
+    /// closes, so a dead provider surfaces as `Disconnected` at once rather
+    /// than after the timeout.
+    lines: mpsc::Receiver<String>,
+}
+
+impl CmdProvider {
+    /// Spawn, ingest, and verify the ack. `Err` on anything the caller would
+    /// otherwise mistake for "this arm had no memory to offer".
+    pub fn spawn(cmd: &str, grains: &[ExperienceGrain]) -> Result<CmdProvider, String> {
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(cmd)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // Inherited: provider diagnostics belong on the bench's stderr, and
+            // a pipe nobody drains would deadlock a chatty provider.
+            .stderr(Stdio::inherit())
+            .spawn()
+            .map_err(|e| format!("spawn `sh -c {cmd}`: {e}"))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| "context provider stdin not captured".to_string())?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| "context provider stdout not captured".to_string())?;
+        let (tx, rx) = mpsc::channel();
+        thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                match line {
+                    Ok(l) => {
+                        if tx.send(l).is_err() {
+                            return;
+                        }
+                    }
+                    Err(_) => return,
+                }
+            }
+        });
+        let provider = CmdProvider {
+            cmd: cmd.to_string(),
+            io: Mutex::new(ProviderIo { child, stdin, lines: rx }),
+        };
+        let ack = provider.call(json!({
+            "selfimprove": 1,
+            "op": "ingest",
+            "grains": grains.iter().map(ExperienceGrain::to_json).collect::<Vec<Value>>(),
+        }))?;
+        if ack.get("ok").and_then(Value::as_bool) != Some(true) {
+            return Err(format!(
+                "context provider did not ack ingest with {{\"ok\":true}}: {ack}"
+            ));
+        }
+        Ok(provider)
+    }
+
+    /// One request → one response. Blank lines are skipped (framing slack);
+    /// anything else unparseable is a garbled provider, which is an error.
+    fn call(&self, request: Value) -> Result<Value, String> {
+        let mut io = self
+            .io
+            .lock()
+            .map_err(|_| format!("context provider `{}` mutex poisoned", self.cmd))?;
+        let mut line = request.to_string();
+        line.push('\n');
+        // A provider that has already exited fails HERE with EPIPE rather than
+        // at the read below — which of the two notices first is a race with
+        // the child's exit, so both must report provider death the same way or
+        // the caller's error handling depends on scheduling.
+        if let Err(e) = io
+            .stdin
+            .write_all(line.as_bytes())
+            .and_then(|()| io.stdin.flush())
+        {
+            if e.kind() == std::io::ErrorKind::BrokenPipe {
+                return Err(match io.child.try_wait() {
+                    Ok(Some(st)) => format!("context provider `{}` exited with {st}", self.cmd),
+                    _ => format!("context provider `{}` closed its stdin", self.cmd),
+                });
+            }
+            return Err(format!("write to context provider `{}`: {e}", self.cmd));
+        }
+        loop {
+            let got = match io.lines.recv_timeout(PROVIDER_TIMEOUT) {
+                Ok(l) => l,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    return Err(format!(
+                        "context provider `{}` timed out after {}s",
+                        self.cmd,
+                        PROVIDER_TIMEOUT.as_secs()
+                    ))
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    let status = io.child.wait().ok();
+                    return Err(match status {
+                        Some(st) => {
+                            format!("context provider `{}` exited with {st}", self.cmd)
+                        }
+                        None => format!("context provider `{}` closed its stdout", self.cmd),
+                    });
+                }
+            };
+            if got.trim().is_empty() {
+                continue;
+            }
+            return serde_json::from_str(&got)
+                .map_err(|e| format!("context provider `{}` sent unparseable JSON ({e})", self.cmd));
+        }
+    }
+
+    fn context(&self, request: Value) -> Result<String, String> {
+        let v = self.call(request)?;
+        Ok(v.get("context")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string())
+    }
+}
+
+impl ContextProvider for CmdProvider {
+    fn label(&self) -> &'static str {
+        "m-cmd"
+    }
+
+    fn task_start(&self, task_prompt: &str) -> Result<String, String> {
+        let body = self.context(json!({
+            "op": "context",
+            "stage": "task_start",
+            "task_prompt": task_prompt,
+        }))?;
+        // The harness owns the framing for every arm — see the module docs.
+        Ok(section(&body))
+    }
+
+    fn on_tool_error(
+        &self,
+        task_prompt: &str,
+        tool: &str,
+        code: &str,
+        body: &str,
+    ) -> Result<String, String> {
+        let ctx = self.context(json!({
+            "op": "context",
+            "stage": "tool_error",
+            "task_prompt": task_prompt,
+            "tool": tool,
+            "code": code,
+            "body": body,
+        }))?;
+        Ok(injection(&ctx))
+    }
+}
+
+impl Drop for CmdProvider {
+    fn drop(&mut self) {
+        // One process per eval pass: a provider that ignores EOF must not
+        // outlive the run.
+        if let Ok(mut io) = self.io.lock() {
+            let _ = io.child.kill();
+            let _ = io.child.wait();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn grain(tool: &str, code: Option<&str>, marker: &str) -> ExperienceGrain {
+        let is_error = code.is_some();
+        let body = match code {
+            Some(c) => format!(r#"{{"error":{{"code":"{c}","message":"{marker}"}}}}"#),
+            None => format!(r#"{{"ok":"{marker}"}}"#),
+        };
+        ExperienceGrain {
+            task_id: format!("task-{marker}"),
+            tool: tool.to_string(),
+            input_json: "{}".to_string(),
+            output_json: body.clone(),
+            is_error,
+            code: code.map(str::to_string),
+            rendered: render_line(tool, is_error, code, &body),
+        }
+    }
+
+    // --- rendering ---------------------------------------------------------
+
+    #[test]
+    fn rendered_lines_carry_the_code_and_stay_one_line() {
+        let line = render_line(
+            "refund",
+            true,
+            Some("rate_limited"),
+            "{\n  \"error\": {\n    \"code\": \"rate_limited\"\n  }\n}",
+        );
+        assert_eq!(
+            line,
+            "- `refund` call failed with `rate_limited`: { \"error\": { \"code\": \"rate_limited\" } }"
+        );
+        assert!(!line.contains('\n'), "multi-line bodies must collapse: {line:?}");
+        assert_eq!(render_line("refund", false, None, "{}"), "- `refund` call succeeded");
+        assert_eq!(
+            render_line("refund", true, None, "boom"),
+            "- `refund` call failed: boom"
+        );
+    }
+
+    #[test]
+    fn a_long_body_is_excerpted_not_dropped() {
+        let body = "x".repeat(500);
+        let line = render_line("log_case", true, Some("invalid_timestamp"), &body);
+        assert!(line.ends_with('…'), "excerpt must be marked: {line:?}");
+        assert!(line.contains("invalid_timestamp"));
+        assert_eq!(line.chars().filter(|c| *c == 'x').count(), BODY_EXCERPT_CHARS);
+    }
+
+    // --- cap_lines ---------------------------------------------------------
+
+    #[test]
+    fn cap_lines_drops_whole_lines_and_says_how_many() {
+        let lines: Vec<String> = (0..10).map(|i| format!("line-{i}")).collect();
+        let note = |n: usize| format!("[{n} dropped]\n");
+        // Wide enough for everything: no note at all.
+        let (full, dropped) = cap_lines(&lines, 10_000, &note);
+        assert!(!full.contains("dropped"), "{full:?}");
+        assert_eq!(full.lines().count(), 10);
+        assert_eq!(dropped, 0);
+        // Tight: the note is present, counts the remainder, and the whole
+        // output still respects the cap.
+        let (cut, dropped) = cap_lines(&lines, 40, &note);
+        assert!(cut.chars().count() <= 40, "cap breached: {cut:?}");
+        let kept = cut.lines().filter(|l| l.starts_with("line-")).count();
+        assert!(kept > 0 && kept < 10, "expected a partial keep: {cut:?}");
+        assert_eq!(dropped, 10 - kept, "reported count must match: {cut:?}");
+        assert!(cut.contains(&format!("[{dropped} dropped]")), "{cut:?}");
+    }
+
+    /// The note closure sizes the reserve, so it runs once per candidate line.
+    /// A caller that logged from inside it would spam one line per input line
+    /// — the dropped count exists so truncation is logged exactly once.
+    #[test]
+    fn cap_lines_note_is_called_for_sizing_not_only_for_output() {
+        use std::cell::Cell;
+        let lines: Vec<String> = (0..6).map(|i| format!("line-{i}")).collect();
+        let calls = Cell::new(0usize);
+        let (_, dropped) = cap_lines(&lines, 10_000, &|n| {
+            calls.set(calls.get() + 1);
+            format!("[{n}]\n")
+        });
+        assert_eq!(dropped, 0, "nothing dropped at this cap");
+        assert!(
+            calls.get() > 1,
+            "note is a sizing function, not an emit hook: {} call(s)",
+            calls.get()
+        );
+    }
+
+    #[test]
+    fn the_summarizer_system_prompt_is_the_frozen_one() {
+        assert_eq!(
+            SUMMARIZER_SYSTEM,
+            "You are building memory notes for a support-desk agent. From the tool-call \
+             history below, write concise markdown bullet notes capturing recurring failure \
+             patterns worth remembering for future tasks."
+        );
+    }
+
+    // --- m-steel -----------------------------------------------------------
+
+    #[test]
+    fn steel_matches_on_tool_and_code_only() {
+        let p = SteelProvider::build(vec![
+            grain("refund", Some("rate_limited"), "a"),
+            grain("refund", Some("approval_required"), "b"),
+            grain("log_case", Some("rate_limited"), "c"),
+            grain("refund", None, "d"),
+        ]);
+        assert_eq!(p.label(), "m-steel");
+        assert_eq!(p.task_start("t").unwrap(), "", "steel injects at the hook, not at start");
+
+        let hit = p.on_tool_error("t", "refund", "rate_limited", "body").unwrap();
+        assert!(hit.starts_with(MEMORY_INJECTION_PREFIX), "{hit:?}");
+        assert!(hit.contains("\"a\""), "the matching grain: {hit:?}");
+        // Negative assertions: a filter that is ignored fails open.
+        assert!(!hit.contains("\"b\""), "other code leaked: {hit:?}");
+        assert!(!hit.contains("\"c\""), "other tool leaked: {hit:?}");
+        assert!(!hit.contains("succeeded"), "successes are not indexed: {hit:?}");
+
+        assert_eq!(p.on_tool_error("t", "refund", "invalid_id", "b").unwrap(), "");
+        assert_eq!(p.on_tool_error("t", "wait", "rate_limited", "b").unwrap(), "");
+    }
+
+    #[test]
+    fn steel_renders_most_recent_first() {
+        let p = SteelProvider::build(vec![
+            grain("refund", Some("rate_limited"), "oldest"),
+            grain("refund", Some("rate_limited"), "middle"),
+            grain("refund", Some("rate_limited"), "newest"),
+        ]);
+        let out = p.on_tool_error("t", "refund", "rate_limited", "b").unwrap();
+        let order: Vec<&str> = ["newest", "middle", "oldest"]
+            .into_iter()
+            .filter(|m| out.contains(m))
+            .collect();
+        assert_eq!(order, vec!["newest", "middle", "oldest"], "{out:?}");
+        let newest = out.find("newest").unwrap();
+        let oldest = out.find("oldest").unwrap();
+        assert!(newest < oldest, "recording order must be reversed: {out:?}");
+    }
+
+    #[test]
+    fn steel_caps_and_reports_the_dropped_occurrences() {
+        // Each rendered line is ~200 chars, so 100 of them blow the 4k cap.
+        let big = "y".repeat(BODY_EXCERPT_CHARS);
+        let grains: Vec<ExperienceGrain> = (0..100)
+            .map(|i| {
+                let mut g = grain("refund", Some("rate_limited"), &format!("g{i}"));
+                g.rendered = render_line("refund", true, Some("rate_limited"), &format!("{i}-{big}"));
+                g
+            })
+            .collect();
+        let out = SteelProvider::build(grains)
+            .on_tool_error("t", "refund", "rate_limited", "b")
+            .unwrap();
+        assert!(out.chars().count() <= STEEL_CAP + MEMORY_INJECTION_PREFIX.len() + 1);
+        assert!(out.contains("earlier occurrences not shown"), "silent cap: {out:?}");
+        // The kept ones are the most recent, and the count adds up.
+        assert!(out.contains("99-"), "newest must survive the cap: {out:?}");
+        let kept = out.lines().filter(|l| l.starts_with("- `refund`")).count();
+        assert!(
+            out.contains(&format!("({} earlier occurrences not shown)", 100 - kept)),
+            "dropped count must match kept={kept}: {out:?}"
+        );
+    }
+
+    #[test]
+    fn steel_with_no_experience_is_silent() {
+        let p = SteelProvider::build(vec![]);
+        assert_eq!(p.on_tool_error("t", "refund", "rate_limited", "b").unwrap(), "");
+    }
+
+    // --- m-all -------------------------------------------------------------
+
+    #[test]
+    fn all_groups_by_tool_with_a_counts_line() {
+        let mut grains = vec![
+            grain("refund", Some("rate_limited"), "r1"),
+            grain("refund", None, "r2"),
+            grain("refund", Some("approval_required"), "r3"),
+            grain("log_case", Some("invalid_timestamp"), "l1"),
+        ];
+        grains.push(grain("log_case", None, "l2"));
+        let p = AllProvider::build(grains);
+        assert_eq!(p.label(), "m-all");
+        let out = p.task_start("t").unwrap();
+        assert!(out.starts_with(MEMORY_SECTION_HEADING), "{out:?}");
+        assert!(out.contains("`log_case`: 2 calls, 1 errors"), "{out:?}");
+        assert!(out.contains("`refund`: 3 calls, 2 errors"), "{out:?}");
+        // Failure history only: successes never render as bullets.
+        assert!(!out.contains("succeeded"), "successes leaked: {out:?}");
+        assert!(out.contains("\"r1\"") && out.contains("\"r3\"") && out.contains("\"l1\""));
+        // Grouped: log_case sorts before refund, and its bullets stay with it.
+        let log_at = out.find("`log_case`: 2").unwrap();
+        let refund_at = out.find("`refund`: 3").unwrap();
+        assert!(log_at < out.find("\"l1\"").unwrap());
+        assert!(out.find("\"l1\"").unwrap() < refund_at);
+        // The whole history is at task start, so nothing is injected again.
+        assert_eq!(p.on_tool_error("t", "refund", "rate_limited", "b").unwrap(), "");
+    }
+
+    #[test]
+    fn all_with_no_failures_emits_no_section() {
+        let p = AllProvider::build(vec![grain("refund", None, "ok")]);
+        assert_eq!(p.task_start("t").unwrap(), "");
+    }
+
+    #[test]
+    fn all_caps_and_reports_the_dropped_lines() {
+        let big = "z".repeat(BODY_EXCERPT_CHARS);
+        let grains: Vec<ExperienceGrain> = (0..400)
+            .map(|i| {
+                let mut g = grain("refund", Some("rate_limited"), &format!("g{i}"));
+                g.rendered = render_line("refund", true, Some("rate_limited"), &format!("{i}-{big}"));
+                g
+            })
+            .collect();
+        let out = AllProvider::build(grains).task_start("t").unwrap();
+        assert!(out.chars().count() <= ALL_CAP + MEMORY_SECTION_HEADING.len() + 1);
+        assert!(out.contains("more history lines not shown"), "silent cap: {out:?}");
+        // The counts line survives: the agent still learns the scale it lost.
+        assert!(out.contains("`refund`: 400 calls, 400 errors"), "{out:?}");
+    }
+
+    // --- m-llm -------------------------------------------------------------
+
+    #[test]
+    fn mock_llm_bullets_are_deterministic_sorted_and_free() {
+        let grains = vec![
+            grain("refund", Some("rate_limited"), "a"),
+            grain("log_case", Some("invalid_timestamp"), "b"),
+            grain("refund", Some("rate_limited"), "c"),
+            grain("refund", Some("approval_required"), "d"),
+            grain("refund", None, "e"),
+        ];
+        let p = LlmProvider::build_mock(grains.clone());
+        assert_eq!(p.label(), "m-llm");
+        let out = p.task_start("t").unwrap();
+        assert_eq!(
+            out,
+            format!(
+                "{MEMORY_SECTION_HEADING}\n\
+                 - `log_case` failed 1 times with `invalid_timestamp`\n\
+                 - `refund` failed 1 times with `approval_required`\n\
+                 - `refund` failed 2 times with `rate_limited`\n"
+            ),
+            "one sorted bullet per (tool, code) cluster"
+        );
+        assert_eq!(p.usage().prompt_tokens, 0);
+        assert_eq!(p.usage().completion_tokens, 0);
+        // Same input ⇒ same bytes, and input order must not matter.
+        let mut shuffled = grains;
+        shuffled.reverse();
+        assert_eq!(LlmProvider::build_mock(shuffled).task_start("t").unwrap(), out);
+        assert_eq!(p.on_tool_error("t", "refund", "rate_limited", "b").unwrap(), "");
+    }
+
+    #[test]
+    fn mock_llm_with_no_failures_emits_no_section() {
+        assert_eq!(
+            LlmProvider::build_mock(vec![grain("refund", None, "ok")])
+                .task_start("t")
+                .unwrap(),
+            ""
+        );
+    }
+
+    #[test]
+    fn summarizer_input_carries_counts_and_every_error_line() {
+        let input = summarizer_input(&[
+            grain("refund", Some("rate_limited"), "a"),
+            grain("refund", None, "b"),
+            grain("log_case", Some("invalid_timestamp"), "c"),
+        ]);
+        assert!(input.contains("`refund`: 2 calls, 1 errors"), "{input:?}");
+        assert!(input.contains("`log_case`: 1 calls, 1 errors"), "{input:?}");
+        assert!(input.contains("\"a\"") && input.contains("\"c\""));
+        assert!(!input.contains("succeeded"), "successes are not summarized: {input:?}");
+    }
+
+    #[test]
+    fn notes_cap_is_announced_not_silent() {
+        let short = cap_notes("- one\n- two");
+        assert_eq!(short, "- one\n- two");
+        let long = cap_notes(&"q".repeat(LLM_NOTES_CAP * 2));
+        assert!(long.chars().count() <= LLM_NOTES_CAP, "{}", long.chars().count());
+        assert!(long.contains("notes truncated"), "silent cap");
+    }
+
+    // Subprocess round-trips need a POSIX `sh` (the protocol's own contract);
+    // every other arm above covers all platforms.
+    #[cfg(unix)]
+    mod subprocess {
+        use super::*;
+
+        /// Echo provider: acks ingest, then answers each context call with a
+        /// line naming the stage and echoing the request back.
+        const ECHO: &str = r#"python3 -c 'import sys,json
+first = json.loads(sys.stdin.readline())
+assert first["op"] == "ingest" and first["selfimprove"] == 1, first
+n = len(first["grains"])
+sys.stdout.write(json.dumps({"ok": True}) + "\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    if req["stage"] == "task_start":
+        ctx = "- ingested %d grains for: %s" % (n, req["task_prompt"])
+    else:
+        ctx = "- saw %s/%s body=%s" % (req["tool"], req["code"], req["body"])
+    sys.stdout.write(json.dumps({"context": ctx}) + "\n"); sys.stdout.flush()'"#;
+
+        #[test]
+        fn cmd_provider_round_trips_an_echo_provider() {
+            let grains = vec![
+                grain("refund", Some("rate_limited"), "a"),
+                grain("refund", None, "b"),
+            ];
+            let p = CmdProvider::spawn(ECHO, &grains).expect("spawn + ingest ack");
+            assert_eq!(p.label(), "m-cmd");
+
+            let start = p.task_start("refund cus_1").unwrap();
+            assert_eq!(
+                start,
+                format!("{MEMORY_SECTION_HEADING}\n- ingested 2 grains for: refund cus_1")
+            );
+
+            let hit = p.on_tool_error("refund cus_1", "refund", "rate_limited", "429").unwrap();
+            assert_eq!(
+                hit,
+                format!("{MEMORY_INJECTION_PREFIX}\n- saw refund/rate_limited body=429")
+            );
+
+            // The process is persistent: a second call reuses it, and the
+            // ingest count proves the state from spawn is still there.
+            let again = p.task_start("second task").unwrap();
+            assert!(again.contains("ingested 2 grains for: second task"), "{again:?}");
+        }
+
+        #[test]
+        fn cmd_provider_returns_empty_when_the_provider_has_nothing() {
+            let cmd = r#"python3 -c 'import sys,json
+sys.stdin.readline()
+sys.stdout.write(json.dumps({"ok": True}) + "\n"); sys.stdout.flush()
+for line in sys.stdin:
+    sys.stdout.write(json.dumps({"context": ""}) + "\n"); sys.stdout.flush()'"#;
+            let p = CmdProvider::spawn(cmd, &[]).expect("spawn");
+            assert_eq!(p.task_start("t").unwrap(), "", "empty ⇒ no section at all");
+            assert_eq!(p.on_tool_error("t", "refund", "x", "b").unwrap(), "");
+        }
+
+        #[test]
+        fn cmd_provider_refuses_a_missing_ingest_ack() {
+            let cmd = r#"python3 -c 'import sys,json
+sys.stdin.readline()
+sys.stdout.write(json.dumps({"ok": False, "why": "nope"}) + "\n"); sys.stdout.flush()
+for line in sys.stdin:
+    pass'"#;
+            let err = CmdProvider::spawn(cmd, &[]).unwrap_err();
+            assert!(err.contains("did not ack ingest"), "{err}");
+        }
+
+        #[test]
+        fn cmd_provider_errors_when_the_provider_dies() {
+            // Acks, then exits: the next call must fail, not hang or return "".
+            let cmd = r#"python3 -c 'import sys,json
+sys.stdin.readline()
+sys.stdout.write(json.dumps({"ok": True}) + "\n"); sys.stdout.flush()'"#;
+            let p = CmdProvider::spawn(cmd, &[]).expect("ingest ack");
+            let err = p.task_start("t").unwrap_err();
+            // Whether the write (EPIPE) or the read (EOF) notices the death
+            // first is a race with the child's exit — under load the write
+            // wins, on an idle machine the read usually does. Both paths must
+            // say "died", so this assertion is scheduling-independent.
+            assert!(
+                err.contains("exited") || err.contains("closed its std"),
+                "a dead provider must report death: {err}"
+            );
+        }
+
+        #[test]
+        fn cmd_provider_reports_death_when_the_write_loses_the_race() {
+            // The other death test races the child's exit; this one removes
+            // the race by guaranteeing the process is gone before the first
+            // context call, so the EPIPE-on-write path is always the one
+            // exercised. Both paths must produce the same class of message.
+            let cmd = r#"python3 -c 'import sys,json
+sys.stdin.readline()
+sys.stdout.write(json.dumps({"ok": True}) + "\n"); sys.stdout.flush()'"#;
+            let p = CmdProvider::spawn(cmd, &[]).expect("ingest ack");
+            // Wait for the child to actually exit before calling.
+            for _ in 0..200 {
+                if p.io.lock().unwrap().child.try_wait().ok().flatten().is_some() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            let err = p.task_start("t").unwrap_err();
+            assert!(
+                err.contains("exited") || err.contains("closed its std"),
+                "a provider dead before the call must report death: {err}"
+            );
+        }
+
+        #[test]
+        fn cmd_provider_errors_on_a_garbled_response() {
+            let cmd = r#"python3 -c 'import sys
+sys.stdin.readline()
+sys.stdout.write("{\"ok\": true}\n"); sys.stdout.flush()
+for line in sys.stdin:
+    sys.stdout.write("not-json\n"); sys.stdout.flush()'"#;
+            let p = CmdProvider::spawn(cmd, &[]).expect("ingest ack");
+            let err = p.task_start("t").unwrap_err();
+            assert!(err.contains("unparseable JSON"), "{err}");
+        }
+
+        #[test]
+        fn cmd_provider_refuses_a_command_that_cannot_start() {
+            let err = CmdProvider::spawn("exit 7", &[]).unwrap_err();
+            assert!(err.contains("exited") || err.contains("closed"), "{err}");
+        }
+
+        /// The live `m-llm` path over the agent chat-adapter protocol: one
+        /// call, notes cached, usage retained for the cost column.
+        #[test]
+        fn llm_provider_makes_one_summarizer_call_and_keeps_its_usage() {
+            let cmd = r#"python3 -c 'import sys,json
+req = json.loads(sys.stdin.readline())
+assert req["op"] == "chat" and req["model"] == "" and req["temperature"] == 0, req
+assert req["tools"] == [], req
+sys.stdout.write(json.dumps({"message": {"role": "assistant", "content": "- refund rate limits: wait first\nSAW:" + str(len(req["messages"]))}, "usage": {"prompt_tokens": 900, "completion_tokens": 30}}))'"#;
+            let p = LlmProvider::build(cmd, vec![grain("refund", Some("rate_limited"), "a")])
+                .expect("summarizer");
+            let out = p.task_start("t").unwrap();
+            assert!(out.starts_with(MEMORY_SECTION_HEADING), "{out:?}");
+            assert!(out.contains("- refund rate limits: wait first"), "{out:?}");
+            assert!(out.contains("SAW:2"), "system + user message: {out:?}");
+            assert_eq!(p.usage().prompt_tokens, 900);
+            assert_eq!(p.usage().completion_tokens, 30);
+        }
+
+        #[test]
+        fn llm_provider_reports_a_broken_summarizer() {
+            let err = LlmProvider::build("echo not-json", vec![]).unwrap_err();
+            assert!(err.starts_with("m-llm summarizer:"), "{err}");
+        }
+    }
+}

--- a/crates/areev-bench/src/selfimprove/memory.rs
+++ b/crates/areev-bench/src/selfimprove/memory.rs
@@ -51,6 +51,17 @@ fn review_action(origin: &Origin, proposal: &Proposal, destructive: bool) -> Rev
     }
 }
 
+/// The frozen error code out of a tool-result body (mod.rs: tool errors are
+/// `{"error":{"code":C,…}}`). `None` when the body is not that shape — a
+/// backend flake is not a hidden-rule failure and must not cluster as one.
+fn error_code(body: &str) -> Option<String> {
+    serde_json::from_str::<Value>(body)
+        .ok()?
+        .pointer("/error/code")?
+        .as_str()
+        .map(str::to_string)
+}
+
 /// The Areev bridge for the selfimprove benches.
 pub struct Memory {
     facade: AreevFacade,
@@ -271,6 +282,70 @@ impl Memory {
                 .map_err(|e| format!("rollback {hash}: {e}"))?;
         }
         Ok(())
+    }
+
+    /// Every experience-phase tool call as the passive-memory arms see it, in
+    /// stable recording order.
+    ///
+    /// This is the ONLY thing the M arms read. It is deliberately Tool grains
+    /// only: lessons live as Facts, so no governed lesson can leak into an arm
+    /// that is supposed to be the loop turned OFF.
+    ///
+    /// Ordering is `created_at_ms` then `hash` — the only keys `GrainRecord`
+    /// exposes (there is no seq). Calls recorded inside one millisecond fall
+    /// back to hash order: deterministic, and stable across runs, which is what
+    /// the prompt bytes need; "most recent first" then holds at the granularity
+    /// that matters (across tasks), not within a single burst.
+    pub fn experience_grains(&self) -> Result<Vec<super::context::ExperienceGrain>, String> {
+        let sub = BorrowedSubstrate::new(&self.facade);
+        // ReadOpts::default() is live_only — same read the lesson renderer uses.
+        let mut grains = sub
+            .grains_of_type("tool", Some(&self.ns), ReadOpts::default())
+            .map_err(|e| format!("read tool grains: {e}"))?;
+        grains.sort_by(|a, b| {
+            a.created_at_ms
+                .cmp(&b.created_at_ms)
+                .then_with(|| a.hash.cmp(&b.hash))
+        });
+        Ok(grains
+            .iter()
+            .map(|g| {
+                let tool = g.tool_name().unwrap_or("unknown").to_string();
+                let is_error = g.is_error();
+                let output_json = g.tool_content().unwrap_or("").to_string();
+                let code = if is_error {
+                    error_code(&output_json)
+                } else {
+                    None
+                };
+                super::context::ExperienceGrain {
+                    // `record_tool_call` writes the thread under `session_id`;
+                    // `parent_task_id` is the OMS-native alias other writers use.
+                    task_id: g
+                        .str_field("session_id")
+                        .or_else(|| g.str_field("parent_task_id"))
+                        .unwrap_or("")
+                        .to_string(),
+                    rendered: super::context::render_line(
+                        &tool,
+                        is_error,
+                        code.as_deref(),
+                        &output_json,
+                    ),
+                    tool,
+                    // `input` round-trips as parsed JSON, not the string that
+                    // was handed in.
+                    input_json: g
+                        .fields
+                        .get("input")
+                        .map(Value::to_string)
+                        .unwrap_or_default(),
+                    output_json,
+                    is_error,
+                    code,
+                }
+            })
+            .collect())
     }
 
     /// The LESSONS prompt section, rendered from LIVE `fails_with` facts in
@@ -507,6 +582,77 @@ mod tests {
         assert_eq!(review_action(&Origin::Builtin, &data, false), ReviewAction::Advisory);
         assert_eq!(review_action(&Origin::Builtin, &cal, true), ReviewAction::Reject);
         assert_eq!(review_action(&Origin::Builtin, &cal, false), ReviewAction::ApproveApply);
+    }
+
+    /// The passive-memory arms' input round-trips through the store: order,
+    /// error-code parsing, is_error, the rendered line, and the task join.
+    #[test]
+    fn experience_grains_round_trip_the_recorded_calls() {
+        let dir = TempDir::new().unwrap();
+        let mem = Memory::create(dir.path()).unwrap();
+        assert!(
+            mem.experience_grains().unwrap().is_empty(),
+            "no experience yet ⇒ the arms have nothing to offer"
+        );
+
+        mem.record_task(&failing_task("refund", "approval_required", 2))
+            .unwrap();
+
+        let grains = mem.experience_grains().unwrap();
+        assert_eq!(grains.len(), 3, "2 failures + 1 success: {grains:?}");
+        assert!(grains.iter().all(|g| g.tool == "refund"));
+        assert!(grains.iter().all(|g| g.task_id == "task-exp-1"), "{grains:?}");
+
+        let errors: Vec<_> = grains.iter().filter(|g| g.is_error).collect();
+        assert_eq!(errors.len(), 2);
+        assert!(
+            errors
+                .iter()
+                .all(|g| g.code.as_deref() == Some("approval_required")),
+            "the frozen code must parse out of the body: {errors:?}"
+        );
+        assert!(
+            errors[0].rendered
+                == "- `refund` call failed with `approval_required`: \
+                    {\"error\":{\"code\":\"approval_required\",\"message\":\"blocked by hidden rule\"}}",
+            "rendered: {:?}",
+            errors[0].rendered
+        );
+
+        let ok: Vec<_> = grains.iter().filter(|g| !g.is_error).collect();
+        assert_eq!(ok.len(), 1);
+        assert_eq!(ok[0].code, None, "a success carries no code");
+        assert_eq!(ok[0].rendered, "- `refund` call succeeded");
+        assert!(ok[0].output_json.contains("rf_1"), "{:?}", ok[0].output_json);
+        assert!(
+            ok[0].input_json.contains("\"amount\":50"),
+            "input round-trips as JSON: {:?}",
+            ok[0].input_json
+        );
+
+        // Stable across reads — the prompt bytes depend on it.
+        assert_eq!(grains, mem.experience_grains().unwrap());
+    }
+
+    /// Lessons are Facts; the arms read Tool grains. A governed lesson must
+    /// never reach an arm that is supposed to be the loop turned OFF.
+    #[test]
+    fn experience_grains_never_carry_a_lesson() {
+        let dir = TempDir::new().unwrap();
+        let mem = Memory::create(dir.path()).unwrap();
+        mem.record_task(&failing_task("refund", "approval_required", 6))
+            .unwrap();
+        let before = mem.experience_grains().unwrap();
+        let (_, applied) = mem.learn(None, None, T1).unwrap();
+        assert!(!applied.is_empty());
+        assert!(!mem.lessons_markdown().unwrap().is_empty());
+
+        let after = mem.experience_grains().unwrap();
+        assert_eq!(before, after, "applying a lesson must not change the arms' input");
+        assert!(
+            after.iter().all(|g| g.tool == "refund"),
+            "only Tool grains: {after:?}"
+        );
     }
 
     /// A leftover memory file must refuse, not silently resume: lessons from

--- a/crates/areev-bench/src/selfimprove/mod.rs
+++ b/crates/areev-bench/src/selfimprove/mod.rs
@@ -45,6 +45,7 @@
 //! lesson (or an LLM finding grounded in one) surfaces them.
 
 pub mod agent;
+pub mod context;
 pub mod env;
 pub mod memory;
 pub mod report;


### PR DESCRIPTION
The A/B/A/B pilot (#136) proved the applied lesson **caused** its gain, but its baseline is an unaided agent — A0 runs a bare system prompt while the experience sits unused in the memory file. It never answered the obvious rebuttal: *"a plain memory store would retrieve that history and do the same."* This adds the arms that answer it, plus two corrections to claims already merged.

## The framing (this is the load-bearing decision)

An arm is **the same store with the loop OFF** — not a reimplementation of anyone's product. Identical capture, identical held-out set, identical renderer; LESSONS empty and a `ContextProvider` in its place. The delta isolates the loop, and nobody can allege we hobbled a competitor's retrieval because there is no competitor implementation in the tree.

| arm | what reaches the prompt | objection it answers |
|---|---|---|
| `m-steel` | per-error retrieval **at the decision point** — on failure, past grains matching that exact (tool, code) | "retrieval with the right hook would catch it" |
| `m-all` | the entire failure history at task start, 24k budget | "you under-retrieved" |
| `m-llm` | history summarized once into operator notes, token cost recorded | the extraction-at-write-time shape |
| `--context-cmd` | **a seam, not an implementation** — any vendor plugs their own memory in over a JSON protocol | "your version of our product was rigged" |

**Tilted toward retrieval on purpose.** Each arm renders a grain as ``- `refund` call failed with `rate_limited`: {body ≤160 chars}``, preserving the whole error object including `retry_after_s` — strictly *more* raw detail than the governed lesson's single summarizing line. A win under those conditions means something.

## Pre-registered interpretation

Written into `SELFIMPROVE.md` **before any arm ran**, for all three outcomes — including `B ≈ M` (the loop's value is cost, determinism, governance — published with those numbers) and `B < m-all` (the lesson rendering leaves information on the table). Committing to publish the unflattering branches is what makes the flattering one worth reading.

## Two corrections to already-merged claims

The README said *"a memory system without governance cannot run this experiment at all."* Too strong — any store with a delete API can mechanically remove and re-add an additive lesson, and a claim that loses its first argument discredits the solid ones beside it. Replaced with the two properties that do hold and that the pilot's own artifacts demonstrate: learning is **separate from storage** (A1 removes the lesson while all 772 experience grains stay, so it ablates the *learning*, not the memory — a write path that *is* the learning has nothing to subtract), and re-application is **deterministic** (both ledger rows carry identical lesson content from the same evidence, so B2 restores the same state rather than a paraphrase).

## Attributability, enforced rather than assumed

- Providers read **only Tool grains**, so the applied lesson Facts living in the same file cannot leak into an M prompt.
- `--workers N` is byte-identical at any N: workers only buffer, the main thread writes transcripts in task order and stays the sole writer of the single-writer store. Verified — all seven transcripts and every report eval compare equal at 1 vs 4 workers.

## Two hazards closed during integration

- A mock M row now carries **"⚠ plumbing only" in the row itself**. The mock complies with any context by construction, so more context always wins (M-all 50.0% vs B 36.7% in mock) — and a table outlives the caveat printed beneath it.
- `CmdProvider` now reports provider death identically whether the **write** catches EPIPE or the **read** catches EOF. Which notices first is a race with the child's exit — rare on a fast laptop, not rare on a CI runner. A new test removes the race and pins both paths.

## Verification

Full workspace suite (125 suites, 0 failures), workspace clippy `-D warnings` clean, repo-stats gate current, both mock gates exit 0, and CI's `selfimprove` job extended to `--arms m-steel,m-all,m-llm --workers 4` (keyless).

Next: the 3-seed live run at 300 experience / 100 held-out tasks, published with per-arm success, recurrence, and token/cost columns.