### PR TITLE
readme: the A/B/A/B chart is the visual, the README is the text

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ this repo — click through:
 ### Does the learning actually work? — take it away and see
 
 Anyone can show a number going up. The honest test is whether the *learning*
-caused it, so we remove what was learned and watch what happens.
-
-One frozen model, 100 held-out tasks it has never seen, three seeds,
-temperature 0. The only thing that changes between rows is whether the lessons
-Areev learned are switched on:
+caused it — so we remove what was learned and watch the gain leave, then put
+it back and watch it return. One frozen model at temperature 0, three seeded
+runs over 100 held-out tasks each (n=300) the agent has never seen; the only
+thing that changes between bars is whether the lessons Areev learned from
+the agent's own failures are in its prompt:
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/aba-selfimprove-dark.svg">
   <img src="docs/assets/aba-selfimprove-light.svg" width="860"
-       alt="Bar chart of an AI agent improving itself from its own experience, measured on 300 held-out tasks with a frozen model at temperature 0. A0 before learning: 39.0%, 117 of 300 tasks passed. B lessons applied: 59.7%, 179 of 300 — up 20.7 points, paired McNemar p below 0.0001. A1 lessons rolled back: 37.7%, 113 of 300 — down 22.0 points, p below 0.0001. B2 lessons re-applied: 56.3%, 169 of 300 — up 18.7 points, p below 0.0001. The two lessons-off states are statistically indistinguishable from each other, so the swing tracks the applied lessons and nothing else.">
+       alt="A/B/A/B self-improvement bar chart: 39.0% of held-out tasks passed before learning, 59.7% with lessons applied, 37.7% with lessons rolled back, 56.3% re-applied — the gain follows the lessons in both directions, every transition paired McNemar p < 0.0001">
 </picture>
 
 | what the memory holds | tasks passed | |
@@ -106,53 +106,30 @@ Areev learned are switched on:
 | the lessons, rolled back | 37.7% ▼ | **the proof** — take them away and the gain leaves with them |
 | the lessons, re-applied | **56.3%** ▲ | put them back and it returns |
 
-Every one of those transitions is significant at **p < 0.0001** (paired
-McNemar, n=300, and independently significant in each of the three runs —
-which span two distinct task sets, not three; see
-[RESULTS.md](crates/areev-bench/RESULTS.md)), while the two "nothing learned"
-rows are statistically indistinguishable from each other. The swing tracks the
-lessons and nothing else.
+Every transition is significant at **p < 0.0001** (paired McNemar, n=300);
+the two lessons-off states are statistically indistinguishable. There is no
+benchmark mode: the prompt is assembled from live memory on every run, so
+rolling the lessons back empties it structurally. Three results behind the
+chart:
 
-**It learned for free.** The lessons came from deterministic clustering over
-the agent's own tool calls — **zero model calls**, no tokens, no extraction
-step. Each one cites the failures it was computed from, by hash.
+- **It learned for free.** The lessons come from deterministic clustering
+  over the agent's own tool calls — **zero model calls** — and each one
+  cites the failures it was computed from, by hash.
+- **It improved without regressing.** Every hidden rule the loop touched got
+  better, none got worse.
+  [The per-rule numbers →](crates/areev-bench/RESULTS.md#it-improves-without-regressing)
+- **Retrieval alone couldn't beat it.** The same store with the loop *off* —
+  raw failure history retrieved into the prompt three different ways — never
+  significantly won, and one variant burned **6.2× the prompt tokens to
+  score lower**.
+  [The baselines →](crates/areev-bench/RESULTS.md#does-the-loop-beat-the-store--the-passive-memory-arms)
 
-**It improved without regressing.** Every hidden rule the loop touched got
-better, and none got worse:
-
-| the mistake the agent kept making | before | after |
-|---|:---:|:---:|
-| cancelling a subscription before refunding it | 45% of chances | **5%** |
-| sending timestamps in local time, not UTC | 39% | **20%** |
-| giving up after a rate limit instead of retrying | 91% | **76%** |
-
-**We tried hard to beat it.** The same store with the loop switched *off* —
-raw failure history retrieved into the prompt three different ways, including
-one deliberately given a better hook than semantic search would get — matched
-it but never significantly beat it, while one variant burned **6.2× the
-prompt tokens to score lower**. The retrieval that scored best also *doubled*
-the ordering mistakes above, because it can only fire after a failure it
-needed to prevent.
-
-There is no benchmark mode here. The prompt is assembled from live memory on
-every run, so rolling the lessons back empties it structurally. Two properties
-of the architecture make the round trip possible: learning is **separate from
-storage**, so a lesson can be removed *while the experience stays* — a system
-whose write path *is* its learning has nothing to ablate without also losing
-the memory — and re-applying re-derives the lesson **deterministically from
-the same evidence**, which a model in the write path cannot guarantee.
-
-<sub><b>What bounds this:</b> one synthetic workload — six rules the agent is
-never told, scored by a programmatic predicate with no LLM judge — built to
-make learning <i>measurable</i>, not to be representative of production
-traffic. We wrote the test and passed it, so re-run it yourself: the whole
-three-seed comparison costs about <b>$2.30</b> and one seed of the four states
-above about <b>$0.53</b>, on a small open-weights model, with every task and
-model call committed. <b>More benchmarks are coming</b> — a learning curve
-over accumulating experience, an adversarial-experience arm, and a public
-agent-trajectory benchmark. Numbers, per-seed results, significance tests,
-dataset, rerun instructions and the full caveat list:
-<a href="crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof"><b>the A/B/A/B causal proof →</b></a></sub>
+One synthetic workload, built to make learning *measurable* rather than to
+mimic production traffic — and we wrote the test, so re-run it yourself: the
+whole three-seed comparison costs about **$2.30**.
+[Full results & caveats →](crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof) ·
+[Reproduce it →](crates/areev-bench/SELFIMPROVE.md#reproduce) ·
+[How the loop works →](docs/loop.md)
 
 ---
 

--- a/crates/areev-bench/RESULTS.md
+++ b/crates/areev-bench/RESULTS.md
@@ -630,10 +630,11 @@ LESSONS section structurally. There is no harness flag that changes behaviour.
 Regenerate with `python3 crates/areev-bench/scripts/aba_chart.py
 docs/assets/aba-selfimprove <run-dir>` — rates come from `report.json` and the
 p-values from `aba_stats.py`, imported rather than recomputed, so the picture
-cannot drift from the tables below. Every value is also plain `<text>` inside
-the SVG, under a `<title>` and `<desc>` carrying the full result: a crawler,
-a screen reader, or a model reading the file gets the finding without
-rendering the bars.
+cannot drift from the tables below. The visible SVG is deliberately the chart
+alone — the narrative lives as real text here and in the README — but its
+`<title>` and `<desc>` still carry the full result (rates, deltas, McNemar
+rows), so a crawler, a screen reader, or a model reading the file gets the
+finding without rendering the bars.
 
 | state | seed 1 | seed 2 | seed 3 | mean | avg prompt tokens |
 |---|---|---|---|---|---|

--- a/crates/areev-bench/scripts/aba_chart.py
+++ b/crates/areev-bench/scripts/aba_chart.py
@@ -17,10 +17,13 @@ The brackets between bars carry the transition: the change in points and its
 paired McNemar p. That is the part a reader should take away, so it is drawn
 rather than left in a table.
 
-**Every number in the picture is also plain `<text>` in the file**, under a
-`<title>` and `<desc>` that state the finding in full. An SVG's text is real
-text: a search crawler, a screen reader, `grep`, or a model reading the file
-gets the result without rendering the bars.
+**The visible SVG is the chart and nothing else** — no headline, no prose, no
+stats table. The narrative lives once, as real text in the README and
+RESULTS.md, where search engines index it; drawing it here too made the two
+drift and the page noisy. The full finding (rates, deltas, McNemar rows) is
+still stated in the SVG's `<title>` and `<desc>`, which never render: a
+screen reader, a crawler, or `grep` on the file gets the result without the
+bars, at zero visual cost.
 
 Numbers come from `report.json` (rates) and `aba_stats.py` (paired McNemar),
 imported rather than reimplemented so this chart cannot disagree with the tool
@@ -131,10 +134,10 @@ def bar(x, y, w, h, fill):
 def render(theme, rates, stats, n_seeds, headline):
     c = THEMES[theme]
     W = 860
-    plot_x, plot_y, plot_w, plot_h = 74, 148, 640, 196
+    plot_x, plot_y, plot_w, plot_h = 74, 64, 756, 196
     y_max = 0.85
     group_w = plot_w / len(STATES)
-    bar_w = 74.0
+    bar_w = 84.0
 
     n_total = rates["B"][2]
     seeds = f"{n_seeds} seeded runs" if n_seeds > 1 else "1 run"
@@ -161,8 +164,8 @@ def render(theme, rates, stats, n_seeds, headline):
                 f"{fmt_p(p).replace('&lt;', '<')}, b={b} c={cc} n={n}"
             )
 
-    stats_top = plot_y + plot_h + 74
-    height = int(stats_top + 18 + len(stat_rows) * 15 + 18)
+    # Chart only: legend, bars, brackets. Height ends at the bar sublabels.
+    height = int(plot_y + plot_h + 50 + 22)
 
     o = []
     a = o.append
@@ -183,19 +186,11 @@ def render(theme, rates, stats, n_seeds, headline):
       f'c = the reverse.</desc>')
     a(f'<rect width="{W}" height="{height}" fill="{c["bg"]}"/>')
 
-    a(f'<text x="28" y="36" font-size="17" font-weight="600" fill="{c["fg"]}">'
-      f"{esc(headline)}</text>")
-    a(f'<text x="28" y="60" font-size="12.5" fill="{c["muted"]}">'
-      f"Same model, same prompts, same {n_total} held-out tasks it has never seen. "
-      f"The only variable: whether the lessons</text>")
-    a(f'<text x="28" y="78" font-size="12.5" fill="{c["muted"]}">'
-      f"the agent learned from its own failures are in its prompt.</text>")
-
     # Legend — identity is a condition, not a run.
     for i, (key, label) in enumerate((("off", "lessons OFF"), ("on", "lessons ON"))):
-        lx = 28 + i * 150
-        a(f'<rect x="{lx}" y="{100}" width="11" height="11" rx="2" fill="{c[key]}"/>')
-        a(f'<text x="{lx + 17}" y="{110}" font-size="12" fill="{c["fg"]}">'
+        lx = plot_x + i * 150
+        a(f'<rect x="{lx}" y="{18}" width="11" height="11" rx="2" fill="{c[key]}"/>')
+        a(f'<text x="{lx + 17}" y="{28}" font-size="12" fill="{c["fg"]}">'
           f"{esc(label)}</text>")
 
     for frac in (0.0, 0.2, 0.4, 0.6, 0.8):
@@ -247,15 +242,6 @@ def render(theme, rates, stats, n_seeds, headline):
         a(f'<text x="{(x1 + x2) / 2:.1f}" y="{by - 3:.1f}" font-size="10" '
           f'text-anchor="middle" fill="{c["muted"]}">{esc(verb)} · {fmt_p(p)}</text>')
 
-    # The plain-text legend: the same finding, readable without the picture.
-    ty = stats_top
-    a(f'<text x="28" y="{ty}" font-size="11.5" font-weight="600" fill="{c["fg"]}">'
-      f"Paired exact McNemar over the same held-out tasks "
-      f"(b = failed then passed, c = the reverse)</text>")
-    for i, line in enumerate(stat_rows):
-        a(f'<text x="28" y="{ty + 19 + i * 15}" font-size="11" '
-          f'font-family="ui-monospace,SFMono-Regular,Menlo,monospace" '
-          f'fill="{c["muted"]}">{esc(line)}</text>')
     a("</svg>")
     return "\n".join(o)
 

--- a/docs/assets/aba-selfimprove-dark.svg
+++ b/docs/assets/aba-selfimprove-dark.svg
@@ -1,58 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="529" viewBox="0 0 860 529" role="img" aria-labelledby="aba-title aba-desc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="332" viewBox="0 0 860 332" role="img" aria-labelledby="aba-title aba-desc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
 <title id="aba-title">An AI agent that learns from its own mistakes: +20.7 points on held-out tasks, and it disappears when you remove what it learned</title>
 <desc id="aba-desc">Areev governed self-improvement benchmark: an AI agent learns from its own tool-use failures, and the learned lessons are applied, rolled back, and re-applied while everything else — model, prompts, tools, and the 300 held-out tasks — is held fixed. A0 before learning: 39.0% (117/300 tasks passed); B lessons applied: 59.7% (179/300 tasks passed); A1 lessons rolled back: 37.7% (113/300 tasks passed); B2 lessons re-applied: 56.3% (169/300 tasks passed). Paired exact McNemar over the same tasks: apply (A0-&gt;B): +20.7 pts, p &lt; 0.0001, b=70 c=8 n=300; roll back (B-&gt;A1): -22.0 pts, p &lt; 0.0001, b=8 c=74 n=300; re-apply (A1-&gt;B2): +18.7 pts, p &lt; 0.0001, b=65 c=9 n=300; control A0-&gt;A1 (same condition, expect no change): p = 0.289, b=2 c=6 n=300; control B-&gt;B2 (same condition, expect no change): p = 0.11, b=11 c=21 n=300. Removing the lessons removes the gain and restoring them brings it back, which is what makes the improvement causal rather than correlational. Measured over 3 seeded runs at temperature zero; b = tasks that failed in the first state and passed in the second, c = the reverse.</desc>
-<rect width="860" height="529" fill="#0d1117"/>
-<text x="28" y="36" font-size="17" font-weight="600" fill="#e6edf3">An AI agent that learns from its own mistakes: +20.7 points on held-out tasks, and it disappears when you remove what it learned</text>
-<text x="28" y="60" font-size="12.5" fill="#8b949e">Same model, same prompts, same 300 held-out tasks it has never seen. The only variable: whether the lessons</text>
-<text x="28" y="78" font-size="12.5" fill="#8b949e">the agent learned from its own failures are in its prompt.</text>
-<rect x="28" y="100" width="11" height="11" rx="2" fill="#d95926"/>
-<text x="45" y="110" font-size="12" fill="#e6edf3">lessons OFF</text>
-<rect x="178" y="100" width="11" height="11" rx="2" fill="#3987e5"/>
-<text x="195" y="110" font-size="12" fill="#e6edf3">lessons ON</text>
-<line x1="74" y1="344.0" x2="714" y2="344.0" stroke="#30363d" stroke-width="1"/>
-<text x="62" y="348.0" font-size="11" text-anchor="end" fill="#8b949e">0%</text>
-<line x1="74" y1="297.9" x2="714" y2="297.9" stroke="#30363d" stroke-width="1"/>
-<text x="62" y="301.9" font-size="11" text-anchor="end" fill="#8b949e">20%</text>
-<line x1="74" y1="251.8" x2="714" y2="251.8" stroke="#30363d" stroke-width="1"/>
-<text x="62" y="255.8" font-size="11" text-anchor="end" fill="#8b949e">40%</text>
-<line x1="74" y1="205.6" x2="714" y2="205.6" stroke="#30363d" stroke-width="1"/>
-<text x="62" y="209.6" font-size="11" text-anchor="end" fill="#8b949e">60%</text>
-<line x1="74" y1="159.5" x2="714" y2="159.5" stroke="#30363d" stroke-width="1"/>
-<text x="62" y="163.5" font-size="11" text-anchor="end" fill="#8b949e">80%</text>
-<path d="M117.0,344.0 L117.0,258.1 Q117.0,254.1 121.0,254.1 L187.0,254.1 Q191.0,254.1 191.0,258.1 L191.0,344.0 Z" fill="#d95926"/>
-<text x="154.0" y="246.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">39.0%</text>
-<text x="154.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">A0</text>
-<text x="154.0" y="379.0" font-size="11" text-anchor="middle" fill="#8b949e">before learning</text>
-<text x="154.0" y="394.0" font-size="10" text-anchor="middle" fill="#8b949e">117/300 passed</text>
-<path d="M277.0,344.0 L277.0,210.4 Q277.0,206.4 281.0,206.4 L347.0,206.4 Q351.0,206.4 351.0,210.4 L351.0,344.0 Z" fill="#3987e5"/>
-<text x="314.0" y="198.4" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">59.7%</text>
-<text x="314.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">B</text>
-<text x="314.0" y="379.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons applied</text>
-<text x="314.0" y="394.0" font-size="10" text-anchor="middle" fill="#8b949e">179/300 passed</text>
-<path d="M437.0,344.0 L437.0,261.1 Q437.0,257.1 441.0,257.1 L507.0,257.1 Q511.0,257.1 511.0,261.1 L511.0,344.0 Z" fill="#d95926"/>
-<text x="474.0" y="249.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">37.7%</text>
-<text x="474.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">A1</text>
-<text x="474.0" y="379.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons rolled back</text>
-<text x="474.0" y="394.0" font-size="10" text-anchor="middle" fill="#8b949e">113/300 passed</text>
-<path d="M597.0,344.0 L597.0,218.1 Q597.0,214.1 601.0,214.1 L667.0,214.1 Q671.0,214.1 671.0,218.1 L671.0,344.0 Z" fill="#3987e5"/>
-<text x="634.0" y="206.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">56.3%</text>
-<text x="634.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">B2</text>
-<text x="634.0" y="379.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons re-applied</text>
-<text x="634.0" y="394.0" font-size="10" text-anchor="middle" fill="#8b949e">169/300 passed</text>
-<line x1="74" y1="344" x2="714" y2="344" stroke="#8b949e" stroke-width="1"/>
-<path d="M154.0,181.4 L154.0,172.4 L314.0,172.4 L314.0,181.4" fill="none" stroke="#8b949e" stroke-width="1"/>
-<text x="234.0" y="158.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+20.7 pts</text>
-<text x="234.0" y="169.4" font-size="10" text-anchor="middle" fill="#8b949e">apply · p &lt; 0.0001</text>
-<path d="M314.0,181.4 L314.0,172.4 L474.0,172.4 L474.0,181.4" fill="none" stroke="#8b949e" stroke-width="1"/>
-<text x="394.0" y="158.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">-22.0 pts</text>
-<text x="394.0" y="169.4" font-size="10" text-anchor="middle" fill="#8b949e">roll back · p &lt; 0.0001</text>
-<path d="M474.0,189.1 L474.0,180.1 L634.0,180.1 L634.0,189.1" fill="none" stroke="#8b949e" stroke-width="1"/>
-<text x="554.0" y="166.1" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+18.7 pts</text>
-<text x="554.0" y="177.1" font-size="10" text-anchor="middle" fill="#8b949e">re-apply · p &lt; 0.0001</text>
-<text x="28" y="418" font-size="11.5" font-weight="600" fill="#e6edf3">Paired exact McNemar over the same held-out tasks (b = failed then passed, c = the reverse)</text>
-<text x="28" y="437" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#8b949e">apply (A0-&gt;B): +20.7 pts, p &lt; 0.0001, b=70 c=8 n=300</text>
-<text x="28" y="452" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#8b949e">roll back (B-&gt;A1): -22.0 pts, p &lt; 0.0001, b=8 c=74 n=300</text>
-<text x="28" y="467" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#8b949e">re-apply (A1-&gt;B2): +18.7 pts, p &lt; 0.0001, b=65 c=9 n=300</text>
-<text x="28" y="482" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#8b949e">control A0-&gt;A1 (same condition, expect no change): p = 0.289, b=2 c=6 n=300</text>
-<text x="28" y="497" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#8b949e">control B-&gt;B2 (same condition, expect no change): p = 0.11, b=11 c=21 n=300</text>
+<rect width="860" height="332" fill="#0d1117"/>
+<rect x="74" y="18" width="11" height="11" rx="2" fill="#d95926"/>
+<text x="91" y="28" font-size="12" fill="#e6edf3">lessons OFF</text>
+<rect x="224" y="18" width="11" height="11" rx="2" fill="#3987e5"/>
+<text x="241" y="28" font-size="12" fill="#e6edf3">lessons ON</text>
+<line x1="74" y1="260.0" x2="830" y2="260.0" stroke="#30363d" stroke-width="1"/>
+<text x="62" y="264.0" font-size="11" text-anchor="end" fill="#8b949e">0%</text>
+<line x1="74" y1="213.9" x2="830" y2="213.9" stroke="#30363d" stroke-width="1"/>
+<text x="62" y="217.9" font-size="11" text-anchor="end" fill="#8b949e">20%</text>
+<line x1="74" y1="167.8" x2="830" y2="167.8" stroke="#30363d" stroke-width="1"/>
+<text x="62" y="171.8" font-size="11" text-anchor="end" fill="#8b949e">40%</text>
+<line x1="74" y1="121.6" x2="830" y2="121.6" stroke="#30363d" stroke-width="1"/>
+<text x="62" y="125.6" font-size="11" text-anchor="end" fill="#8b949e">60%</text>
+<line x1="74" y1="75.5" x2="830" y2="75.5" stroke="#30363d" stroke-width="1"/>
+<text x="62" y="79.5" font-size="11" text-anchor="end" fill="#8b949e">80%</text>
+<path d="M126.5,260.0 L126.5,174.1 Q126.5,170.1 130.5,170.1 L206.5,170.1 Q210.5,170.1 210.5,174.1 L210.5,260.0 Z" fill="#d95926"/>
+<text x="168.5" y="162.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">39.0%</text>
+<text x="168.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">A0</text>
+<text x="168.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">before learning</text>
+<text x="168.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">117/300 passed</text>
+<path d="M315.5,260.0 L315.5,126.4 Q315.5,122.4 319.5,122.4 L395.5,122.4 Q399.5,122.4 399.5,126.4 L399.5,260.0 Z" fill="#3987e5"/>
+<text x="357.5" y="114.4" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">59.7%</text>
+<text x="357.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">B</text>
+<text x="357.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons applied</text>
+<text x="357.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">179/300 passed</text>
+<path d="M504.5,260.0 L504.5,177.1 Q504.5,173.1 508.5,173.1 L584.5,173.1 Q588.5,173.1 588.5,177.1 L588.5,260.0 Z" fill="#d95926"/>
+<text x="546.5" y="165.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">37.7%</text>
+<text x="546.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">A1</text>
+<text x="546.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons rolled back</text>
+<text x="546.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">113/300 passed</text>
+<path d="M693.5,260.0 L693.5,134.1 Q693.5,130.1 697.5,130.1 L773.5,130.1 Q777.5,130.1 777.5,134.1 L777.5,260.0 Z" fill="#3987e5"/>
+<text x="735.5" y="122.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">56.3%</text>
+<text x="735.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">B2</text>
+<text x="735.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons re-applied</text>
+<text x="735.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">169/300 passed</text>
+<line x1="74" y1="260" x2="830" y2="260" stroke="#8b949e" stroke-width="1"/>
+<path d="M168.5,97.4 L168.5,88.4 L357.5,88.4 L357.5,97.4" fill="none" stroke="#8b949e" stroke-width="1"/>
+<text x="263.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+20.7 pts</text>
+<text x="263.0" y="85.4" font-size="10" text-anchor="middle" fill="#8b949e">apply · p &lt; 0.0001</text>
+<path d="M357.5,97.4 L357.5,88.4 L546.5,88.4 L546.5,97.4" fill="none" stroke="#8b949e" stroke-width="1"/>
+<text x="452.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">-22.0 pts</text>
+<text x="452.0" y="85.4" font-size="10" text-anchor="middle" fill="#8b949e">roll back · p &lt; 0.0001</text>
+<path d="M546.5,105.1 L546.5,96.1 L735.5,96.1 L735.5,105.1" fill="none" stroke="#8b949e" stroke-width="1"/>
+<text x="641.0" y="82.1" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+18.7 pts</text>
+<text x="641.0" y="93.1" font-size="10" text-anchor="middle" fill="#8b949e">re-apply · p &lt; 0.0001</text>
 </svg>

--- a/docs/assets/aba-selfimprove-light.svg
+++ b/docs/assets/aba-selfimprove-light.svg
@@ -1,58 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="860" height="529" viewBox="0 0 860 529" role="img" aria-labelledby="aba-title aba-desc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="332" viewBox="0 0 860 332" role="img" aria-labelledby="aba-title aba-desc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
 <title id="aba-title">An AI agent that learns from its own mistakes: +20.7 points on held-out tasks, and it disappears when you remove what it learned</title>
 <desc id="aba-desc">Areev governed self-improvement benchmark: an AI agent learns from its own tool-use failures, and the learned lessons are applied, rolled back, and re-applied while everything else — model, prompts, tools, and the 300 held-out tasks — is held fixed. A0 before learning: 39.0% (117/300 tasks passed); B lessons applied: 59.7% (179/300 tasks passed); A1 lessons rolled back: 37.7% (113/300 tasks passed); B2 lessons re-applied: 56.3% (169/300 tasks passed). Paired exact McNemar over the same tasks: apply (A0-&gt;B): +20.7 pts, p &lt; 0.0001, b=70 c=8 n=300; roll back (B-&gt;A1): -22.0 pts, p &lt; 0.0001, b=8 c=74 n=300; re-apply (A1-&gt;B2): +18.7 pts, p &lt; 0.0001, b=65 c=9 n=300; control A0-&gt;A1 (same condition, expect no change): p = 0.289, b=2 c=6 n=300; control B-&gt;B2 (same condition, expect no change): p = 0.11, b=11 c=21 n=300. Removing the lessons removes the gain and restoring them brings it back, which is what makes the improvement causal rather than correlational. Measured over 3 seeded runs at temperature zero; b = tasks that failed in the first state and passed in the second, c = the reverse.</desc>
-<rect width="860" height="529" fill="#ffffff"/>
-<text x="28" y="36" font-size="17" font-weight="600" fill="#111418">An AI agent that learns from its own mistakes: +20.7 points on held-out tasks, and it disappears when you remove what it learned</text>
-<text x="28" y="60" font-size="12.5" fill="#5b6470">Same model, same prompts, same 300 held-out tasks it has never seen. The only variable: whether the lessons</text>
-<text x="28" y="78" font-size="12.5" fill="#5b6470">the agent learned from its own failures are in its prompt.</text>
-<rect x="28" y="100" width="11" height="11" rx="2" fill="#eb6834"/>
-<text x="45" y="110" font-size="12" fill="#111418">lessons OFF</text>
-<rect x="178" y="100" width="11" height="11" rx="2" fill="#1f6feb"/>
-<text x="195" y="110" font-size="12" fill="#111418">lessons ON</text>
-<line x1="74" y1="344.0" x2="714" y2="344.0" stroke="#dfe3e8" stroke-width="1"/>
-<text x="62" y="348.0" font-size="11" text-anchor="end" fill="#5b6470">0%</text>
-<line x1="74" y1="297.9" x2="714" y2="297.9" stroke="#dfe3e8" stroke-width="1"/>
-<text x="62" y="301.9" font-size="11" text-anchor="end" fill="#5b6470">20%</text>
-<line x1="74" y1="251.8" x2="714" y2="251.8" stroke="#dfe3e8" stroke-width="1"/>
-<text x="62" y="255.8" font-size="11" text-anchor="end" fill="#5b6470">40%</text>
-<line x1="74" y1="205.6" x2="714" y2="205.6" stroke="#dfe3e8" stroke-width="1"/>
-<text x="62" y="209.6" font-size="11" text-anchor="end" fill="#5b6470">60%</text>
-<line x1="74" y1="159.5" x2="714" y2="159.5" stroke="#dfe3e8" stroke-width="1"/>
-<text x="62" y="163.5" font-size="11" text-anchor="end" fill="#5b6470">80%</text>
-<path d="M117.0,344.0 L117.0,258.1 Q117.0,254.1 121.0,254.1 L187.0,254.1 Q191.0,254.1 191.0,258.1 L191.0,344.0 Z" fill="#eb6834"/>
-<text x="154.0" y="246.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">39.0%</text>
-<text x="154.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">A0</text>
-<text x="154.0" y="379.0" font-size="11" text-anchor="middle" fill="#5b6470">before learning</text>
-<text x="154.0" y="394.0" font-size="10" text-anchor="middle" fill="#5b6470">117/300 passed</text>
-<path d="M277.0,344.0 L277.0,210.4 Q277.0,206.4 281.0,206.4 L347.0,206.4 Q351.0,206.4 351.0,210.4 L351.0,344.0 Z" fill="#1f6feb"/>
-<text x="314.0" y="198.4" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">59.7%</text>
-<text x="314.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">B</text>
-<text x="314.0" y="379.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons applied</text>
-<text x="314.0" y="394.0" font-size="10" text-anchor="middle" fill="#5b6470">179/300 passed</text>
-<path d="M437.0,344.0 L437.0,261.1 Q437.0,257.1 441.0,257.1 L507.0,257.1 Q511.0,257.1 511.0,261.1 L511.0,344.0 Z" fill="#eb6834"/>
-<text x="474.0" y="249.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">37.7%</text>
-<text x="474.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">A1</text>
-<text x="474.0" y="379.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons rolled back</text>
-<text x="474.0" y="394.0" font-size="10" text-anchor="middle" fill="#5b6470">113/300 passed</text>
-<path d="M597.0,344.0 L597.0,218.1 Q597.0,214.1 601.0,214.1 L667.0,214.1 Q671.0,214.1 671.0,218.1 L671.0,344.0 Z" fill="#1f6feb"/>
-<text x="634.0" y="206.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">56.3%</text>
-<text x="634.0" y="363.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">B2</text>
-<text x="634.0" y="379.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons re-applied</text>
-<text x="634.0" y="394.0" font-size="10" text-anchor="middle" fill="#5b6470">169/300 passed</text>
-<line x1="74" y1="344" x2="714" y2="344" stroke="#5b6470" stroke-width="1"/>
-<path d="M154.0,181.4 L154.0,172.4 L314.0,172.4 L314.0,181.4" fill="none" stroke="#5b6470" stroke-width="1"/>
-<text x="234.0" y="158.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+20.7 pts</text>
-<text x="234.0" y="169.4" font-size="10" text-anchor="middle" fill="#5b6470">apply · p &lt; 0.0001</text>
-<path d="M314.0,181.4 L314.0,172.4 L474.0,172.4 L474.0,181.4" fill="none" stroke="#5b6470" stroke-width="1"/>
-<text x="394.0" y="158.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">-22.0 pts</text>
-<text x="394.0" y="169.4" font-size="10" text-anchor="middle" fill="#5b6470">roll back · p &lt; 0.0001</text>
-<path d="M474.0,189.1 L474.0,180.1 L634.0,180.1 L634.0,189.1" fill="none" stroke="#5b6470" stroke-width="1"/>
-<text x="554.0" y="166.1" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+18.7 pts</text>
-<text x="554.0" y="177.1" font-size="10" text-anchor="middle" fill="#5b6470">re-apply · p &lt; 0.0001</text>
-<text x="28" y="418" font-size="11.5" font-weight="600" fill="#111418">Paired exact McNemar over the same held-out tasks (b = failed then passed, c = the reverse)</text>
-<text x="28" y="437" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#5b6470">apply (A0-&gt;B): +20.7 pts, p &lt; 0.0001, b=70 c=8 n=300</text>
-<text x="28" y="452" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#5b6470">roll back (B-&gt;A1): -22.0 pts, p &lt; 0.0001, b=8 c=74 n=300</text>
-<text x="28" y="467" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#5b6470">re-apply (A1-&gt;B2): +18.7 pts, p &lt; 0.0001, b=65 c=9 n=300</text>
-<text x="28" y="482" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#5b6470">control A0-&gt;A1 (same condition, expect no change): p = 0.289, b=2 c=6 n=300</text>
-<text x="28" y="497" font-size="11" font-family="ui-monospace,SFMono-Regular,Menlo,monospace" fill="#5b6470">control B-&gt;B2 (same condition, expect no change): p = 0.11, b=11 c=21 n=300</text>
+<rect width="860" height="332" fill="#ffffff"/>
+<rect x="74" y="18" width="11" height="11" rx="2" fill="#eb6834"/>
+<text x="91" y="28" font-size="12" fill="#111418">lessons OFF</text>
+<rect x="224" y="18" width="11" height="11" rx="2" fill="#1f6feb"/>
+<text x="241" y="28" font-size="12" fill="#111418">lessons ON</text>
+<line x1="74" y1="260.0" x2="830" y2="260.0" stroke="#dfe3e8" stroke-width="1"/>
+<text x="62" y="264.0" font-size="11" text-anchor="end" fill="#5b6470">0%</text>
+<line x1="74" y1="213.9" x2="830" y2="213.9" stroke="#dfe3e8" stroke-width="1"/>
+<text x="62" y="217.9" font-size="11" text-anchor="end" fill="#5b6470">20%</text>
+<line x1="74" y1="167.8" x2="830" y2="167.8" stroke="#dfe3e8" stroke-width="1"/>
+<text x="62" y="171.8" font-size="11" text-anchor="end" fill="#5b6470">40%</text>
+<line x1="74" y1="121.6" x2="830" y2="121.6" stroke="#dfe3e8" stroke-width="1"/>
+<text x="62" y="125.6" font-size="11" text-anchor="end" fill="#5b6470">60%</text>
+<line x1="74" y1="75.5" x2="830" y2="75.5" stroke="#dfe3e8" stroke-width="1"/>
+<text x="62" y="79.5" font-size="11" text-anchor="end" fill="#5b6470">80%</text>
+<path d="M126.5,260.0 L126.5,174.1 Q126.5,170.1 130.5,170.1 L206.5,170.1 Q210.5,170.1 210.5,174.1 L210.5,260.0 Z" fill="#eb6834"/>
+<text x="168.5" y="162.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">39.0%</text>
+<text x="168.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">A0</text>
+<text x="168.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">before learning</text>
+<text x="168.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">117/300 passed</text>
+<path d="M315.5,260.0 L315.5,126.4 Q315.5,122.4 319.5,122.4 L395.5,122.4 Q399.5,122.4 399.5,126.4 L399.5,260.0 Z" fill="#1f6feb"/>
+<text x="357.5" y="114.4" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">59.7%</text>
+<text x="357.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">B</text>
+<text x="357.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons applied</text>
+<text x="357.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">179/300 passed</text>
+<path d="M504.5,260.0 L504.5,177.1 Q504.5,173.1 508.5,173.1 L584.5,173.1 Q588.5,173.1 588.5,177.1 L588.5,260.0 Z" fill="#eb6834"/>
+<text x="546.5" y="165.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">37.7%</text>
+<text x="546.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">A1</text>
+<text x="546.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons rolled back</text>
+<text x="546.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">113/300 passed</text>
+<path d="M693.5,260.0 L693.5,134.1 Q693.5,130.1 697.5,130.1 L773.5,130.1 Q777.5,130.1 777.5,134.1 L777.5,260.0 Z" fill="#1f6feb"/>
+<text x="735.5" y="122.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">56.3%</text>
+<text x="735.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">B2</text>
+<text x="735.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons re-applied</text>
+<text x="735.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">169/300 passed</text>
+<line x1="74" y1="260" x2="830" y2="260" stroke="#5b6470" stroke-width="1"/>
+<path d="M168.5,97.4 L168.5,88.4 L357.5,88.4 L357.5,97.4" fill="none" stroke="#5b6470" stroke-width="1"/>
+<text x="263.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+20.7 pts</text>
+<text x="263.0" y="85.4" font-size="10" text-anchor="middle" fill="#5b6470">apply · p &lt; 0.0001</text>
+<path d="M357.5,97.4 L357.5,88.4 L546.5,88.4 L546.5,97.4" fill="none" stroke="#5b6470" stroke-width="1"/>
+<text x="452.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">-22.0 pts</text>
+<text x="452.0" y="85.4" font-size="10" text-anchor="middle" fill="#5b6470">roll back · p &lt; 0.0001</text>
+<path d="M546.5,105.1 L546.5,96.1 L735.5,96.1 L735.5,105.1" fill="none" stroke="#5b6470" stroke-width="1"/>
+<text x="641.0" y="82.1" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+18.7 pts</text>
+<text x="641.0" y="93.1" font-size="10" text-anchor="middle" fill="#5b6470">re-apply · p &lt; 0.0001</text>
 </svg>


### PR DESCRIPTION
The self-improvement SVG carried a headline, an explainer, and a five-row McNemar stats block inside the image, and the README repeated the same numbers again in prose — redundant, and the landing page read as noise.

This splits the roles cleanly:

- **`aba_chart.py` / both SVGs**: the visible image is now the chart alone — legend, four bars, transition brackets (529px → 332px tall). The full finding stays in the SVG's `<title>`/`<desc>`, which never render, so screen readers and crawlers reading the file lose nothing.
- **README**: the section collapses to one framing sentence, the chart, the four states once in crawlable text, one significance line, and three one-line results ("learned for free", "no regressions", "retrieval couldn't beat it") that deep-link into `RESULTS.md#it-improves-without-regressing`, `RESULTS.md#does-the-loop-beat-the-store…`, `SELFIMPROVE.md#reproduce`, and `docs/loop.md` instead of carrying their own paragraphs and tables. Also fixes the setup line: three seeded runs of 100 held-out tasks each (n=300), not "300 held-out tasks".
- **RESULTS.md**: the paragraph describing the SVG's embedded text updated to match.

Verified: both SVGs re-rendered from the published run dir and eyeballed light+dark; `scripts/repo_stats.py --check` passes; no CI/test pins on the chart beyond the docs updated here.