### PR TITLE
readme: lead the baselines bullet with the win the data supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,11 @@ chart:
 - **It improved without regressing.** Every hidden rule the loop touched got
   better, none got worse.
   [The per-rule numbers →](crates/areev-bench/RESULTS.md#it-improves-without-regressing)
-- **Retrieval alone couldn't beat it.** The same store with the loop *off* —
-  raw failure history retrieved into the prompt three different ways — never
-  significantly won, and one variant burned **6.2× the prompt tokens to
-  score lower**.
+- **It matches heavyweight retrieval at a fraction of the cost.** The same
+  store with the loop *off* — raw failure history retrieved into the prompt
+  three different ways — never significantly outscored the lessons, paid
+  **1.3–6.2× the prompt tokens** every turn doing it, and its best-scoring
+  variant doubled a class of mistakes the loop had eliminated.
   [The baselines →](crates/areev-bench/RESULTS.md#does-the-loop-beat-the-store--the-passive-memory-arms)
 
 One synthetic workload, built to make learning *measurable* rather than to


### PR DESCRIPTION
Reframes the third results bullet from the defensive "Retrieval alone couldn't beat it" to "**It matches heavyweight retrieval at a fraction of the cost**" — accuracy parity is the pre-registered honest reading, and the genuine wins at parity are the 1.3–6.2× per-turn token cost and that the best-scoring baseline doubled a mistake class the loop eliminated. Same numbers, same RESULTS.md link.