### PR TITLE
bench: the loop+LLM arm — authored lessons through the same scripted review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,16 @@ jobs:
         run: |
           cargo run -p areev-bench --bin selfimprove_aba -- \
             --workdir "$RUNNER_TEMP/aba-governed" --seed 1 --mock --assert-shape
+      # The loop+LLM arm: the canned loop-LLM authors a lesson, the scripted
+      # review applies it, rollback removes it, re-apply restores it — the
+      # authored-lesson lifecycle asserted keylessly (the shape floor, never
+      # a learning claim; the canned lesson deliberately cannot move the
+      # mock agent's rates).
+      - name: The loop+LLM arm applies and restores an authored lesson
+        run: |
+          cargo run -p areev-bench --bin selfimprove_aba -- \
+            --workdir "$RUNNER_TEMP/aba-llm" --seed 1 --mock --mock-llm \
+            --llm-lessons --assert-shape
       # The committed runs are evidence, not decoration: every number in
       # RESULTS.md is recomputed from the transcripts that shipped with it,
       # and MANIFEST.md's checksums are re-derived, so a published file that

--- a/crates/areev-bench/SELFIMPROVE.md
+++ b/crates/areev-bench/SELFIMPROVE.md
@@ -339,19 +339,20 @@ context it is given", so mock M arms prove plumbing, never a comparison.
 - deterministic-analyzer showcase — same A/B/A shape with `--llm-cmd` absent:
   what do contradiction/duplicate/staleness lessons alone buy? (The engine
   closes with zero model calls; this bench prices that floor.)
-- **LLM-authored executable lessons** (engine feature, not a bench):
-  **landed.** A DISCOVER draft may author a `lesson` (one capped imperative
-  line); a lesson-bearing draft that survives GROUND/VERIFY stamps as an
-  applicable, rollbackable `ADD fact` proposal (`relation = "lesson"`,
-  namespace from the cited evidence) — human-applied only, auto-apply stays
-  structurally closed to `origin=llm` (`docs/loop.md`, DISCOVER). What the
-  bench still needs before a `loop+LLM` arm can run: (a) `review_action`
-  (memory.rs) routes ALL llm-origin recommendations to advisory — the arm
-  needs a deliberate switch to approve applicable llm lessons through the
-  same scripted review, and (b) `lessons_markdown` renders only
-  `fails_with` facts — the arm must render `relation = "lesson"` lines into
-  the LESSONS section too. Both are arm-gated bench changes, not engine
-  work.
+- **LLM-authored executable lessons**: **landed end-to-end.** Engine: a
+  DISCOVER draft may author a `lesson` (one capped imperative line); a
+  lesson-bearing draft that survives GROUND/VERIFY stamps as an applicable,
+  rollbackable `ADD fact` proposal (`relation = "lesson"`, namespace from
+  the cited evidence) — human-applied only, auto-apply stays structurally
+  closed to `origin=llm` (`docs/loop.md`, DISCOVER). Bench: `--llm-lessons`
+  is the arm switch (scripted review approves + applies authored lessons;
+  `lessons_markdown` renders them as a "Rules learned" block), `--mock-llm`
+  is its keyless canned backend, and CI asserts the full authored-lesson
+  lifecycle (`apply → render → rollback-empties → re-apply restores`) on
+  every push. The default path — no `--llm-lessons` — reproduces the
+  published runs' review policy and prompt bytes exactly. Live numbers for
+  this arm are not yet published; the roadmap entry for them is the
+  `selfimprove_curve` `loop+LLM` arm above.
 
 ## Determinism & stats rules (areev-testing applies)
 
@@ -368,7 +369,8 @@ context it is given", so mock M arms prove plumbing, never a comparison.
 - `report.json` carries config + git rev; the transcripts carry the run's
   behaviour, with the limits stated below.
 - CI is keyless throughout — no live keys, no live numbers asserted. It runs
-  `--mock --assert-shape` twice (with the arms and governed-only) and
+  `--mock --assert-shape` three times (with the arms, governed-only, and
+  `--mock-llm --llm-lessons` for the authored-lesson lifecycle) and
   `verify_run.py` over the committed results; the reproducibility pins run
   with the ordinary test suite.
 
@@ -449,6 +451,8 @@ the prompt to re-run.
 | `--seed N` `--experience N` `--eval N` | task generation; `--seed` reproduces the task sets exactly |
 | `--mock` \| `--agent-cmd 'CMD'` | exactly one: the deterministic keyless agent, or a chat adapter |
 | `--llm-cmd` / `--ground-cmd 'CMD'` | the loop's DISCOVER/VERIFY and GROUND backends (**loop** protocol) |
+| `--mock-llm` | keyless canned loop-LLM (authors one fixed lesson) in place of `--llm-cmd`; the two are mutually exclusive |
+| `--llm-lessons` | the **loop+LLM arm**: the scripted review also approves + applies LLM-authored lessons, and they render into LESSONS. Requires `--llm-cmd` or `--mock-llm`. Off = the published-run review policy, byte-for-byte |
 | `--arms LIST` | comma list of `m-steel,m-all,m-llm,m-cmd`; empty = governed states only |
 | `--context-cmd 'CMD'` | the external context provider; required by (and only by) `m-cmd` |
 | `--mllm-cmd 'CMD'` | chat adapter for the `m-llm` summarizer; defaults to `--agent-cmd`, unused under `--mock` |

--- a/crates/areev-bench/src/bin/selfimprove_aba.rs
+++ b/crates/areev-bench/src/bin/selfimprove_aba.rs
@@ -42,7 +42,8 @@
 //! one thread.
 
 use areev_bench::selfimprove::context::{ContextProvider, ExperienceGrain};
-use areev_bench::selfimprove::memory::Memory;
+use areev_bench::selfimprove::memory::{Memory, MockLoopLlm};
+use areev_loop::{CommandLlm, LlmBackend};
 use areev_bench::selfimprove::{agent, context, env, report::Reporter};
 use areev_bench::selfimprove::{EvalSummary, Ledger, RuleId, RuleStat, TaskRunRecord, Usage};
 use serde_json::{json, Value};
@@ -69,6 +70,11 @@ struct Args {
     agent_cmd: Option<String>,
     llm_cmd: Option<String>,
     ground_cmd: Option<String>,
+    /// The `loop+LLM` arm: the scripted review also approves + applies
+    /// LLM-authored lessons. Off = the published-run review policy.
+    llm_lessons: bool,
+    /// Keyless canned loop-LLM (shape runs) in place of `--llm-cmd`.
+    mock_llm: bool,
     /// Requested passive arms, deduped, in the order given (empty = the
     /// A/B/A/B states only, i.e. exactly the pre-arms behavior).
     arms: Vec<String>,
@@ -112,7 +118,8 @@ fn usage() -> ! {
     eprintln!(
         "usage: selfimprove_aba --workdir PATH (--mock | --agent-cmd 'CMD')\n\
          \x20                       [--seed N] [--experience N] [--eval N]\n\
-         \x20                       [--llm-cmd 'CMD'] [--ground-cmd 'CMD']\n\
+         \x20                       [--llm-cmd 'CMD' | --mock-llm] [--ground-cmd 'CMD']\n\
+         \x20                       [--llm-lessons]\n\
          \x20                       [--arms m-steel,m-all,m-llm,m-cmd]\n\
          \x20                       [--context-cmd 'CMD'] [--mllm-cmd 'CMD']\n\
          \x20                       [--workers N] [--max-turns N] [--assert-shape]"
@@ -160,6 +167,8 @@ fn parse_args() -> Args {
     let mut workers: usize = 4;
     let mut max_turns: u32 = 24;
     let mut assert_shape = false;
+    let mut llm_lessons = false;
+    let mut mock_llm = false;
 
     let mut i = 0;
     while i < argv.len() {
@@ -170,6 +179,14 @@ fn parse_args() -> Args {
             }
             "--assert-shape" => {
                 assert_shape = true;
+                i += 1;
+            }
+            "--llm-lessons" => {
+                llm_lessons = true;
+                i += 1;
+            }
+            "--mock-llm" => {
+                mock_llm = true;
                 i += 1;
             }
             flag => {
@@ -215,6 +232,19 @@ fn parse_args() -> Args {
         );
         usage()
     }
+    // One loop-LLM source: the canned mock is for keyless shape runs, a
+    // command produces numbers — same reasoning as --mock / --agent-cmd.
+    if mock_llm && llm_cmd.is_some() {
+        eprintln!("selfimprove_aba: --mock-llm and --llm-cmd are mutually exclusive");
+        usage()
+    }
+    // The arm switch changes the review policy; without an LLM there is
+    // nothing for it to admit, and a silently ignored flag would label the
+    // run as an arm it never ran.
+    if llm_lessons && llm_cmd.is_none() && !mock_llm {
+        eprintln!("selfimprove_aba: --llm-lessons requires --llm-cmd or --mock-llm");
+        usage()
+    }
     Args {
         workdir,
         seed,
@@ -224,6 +254,8 @@ fn parse_args() -> Args {
         agent_cmd,
         llm_cmd,
         ground_cmd,
+        llm_lessons,
+        mock_llm,
         arms,
         context_cmd,
         mllm_cmd,
@@ -231,6 +263,27 @@ fn parse_args() -> Args {
         max_turns,
         assert_shape,
     }
+}
+
+/// An optional boxed loop backend — the shape `Memory::learn_with` takes.
+type LoopBackend = Option<Box<dyn LlmBackend>>;
+
+/// The loop-LLM backends for one learn pass, built fresh per pass (CommandLlm
+/// probes at construction — fail loud, and before any state was written).
+fn loop_llm_backends(args: &Args) -> (LoopBackend, LoopBackend) {
+    let llm: LoopBackend = if args.mock_llm {
+        Some(Box::new(MockLoopLlm))
+    } else {
+        args.llm_cmd.as_deref().map(|cmd| {
+            Box::new(CommandLlm::new(cmd, None).unwrap_or_else(|e| die(&format!("--llm-cmd: {e}"))))
+                as Box<dyn LlmBackend>
+        })
+    };
+    let ground: LoopBackend = args.ground_cmd.as_deref().map(|cmd| {
+        Box::new(CommandLlm::new(cmd, None).unwrap_or_else(|e| die(&format!("--ground-cmd: {e}"))))
+            as Box<dyn LlmBackend>
+    });
+    (llm, ground)
 }
 
 /// Fresh backend per task: the mock must not leak state across tasks, and a
@@ -621,7 +674,13 @@ fn applied_signatures(ledger: &Ledger) -> Vec<String> {
 /// would still clear every rate threshold above while making the run
 /// incomparable to the published ones — `tests/reproducibility.rs` pins the
 /// exact lesson text at a fixed seed; these pin the invariants at any seed.
-fn check_shape(evals: &[EvalSummary], eval_n: u32, applied1: &[String], applied2: &[String]) {
+fn check_shape(
+    evals: &[EvalSummary],
+    eval_n: u32,
+    applied1: &[String],
+    applied2: &[String],
+    llm_lessons: bool,
+) {
     let (a0, b, a1, b2) = (&evals[0], &evals[1], &evals[2], &evals[3]);
     let mut fails = Vec::new();
 
@@ -641,15 +700,27 @@ fn check_shape(evals: &[EvalSummary], eval_n: u32, applied1: &[String], applied2
             ));
         }
     }
-    // LLM findings are advisory by design (`stamp_llm` emits `Proposal::Data`,
-    // apply refuses). If one ever applies, the causal arm silently starts
-    // measuring an LLM-authored lesson and SELFIMPROVE.md's honesty note goes
-    // stale in the same moment.
-    for sig in applied1.iter().chain(applied2) {
-        if !sig.starts_with("loop.") {
-            fails.push(format!(
-                "applied a non-analyzer lesson ({sig}) — LLM findings are advisory by design"
-            ));
+    // Which origins may apply is the ARM DEFINITION. Governed-only: analyzer
+    // lessons exclusively — if an LLM lesson applies, the run silently starts
+    // measuring the loop+LLM arm under the governed-only label. loop+LLM
+    // (--llm-lessons): authored lessons are the point, so at least one must
+    // apply — an arm that admitted nothing new measured the governed states
+    // twice under a different name.
+    if llm_lessons {
+        if !applied1.iter().any(|sig| sig.starts_with("llm :: ")) {
+            fails.push(
+                "--llm-lessons applied no LLM-authored lesson — the arm measured nothing new"
+                    .to_string(),
+            );
+        }
+    } else {
+        for sig in applied1.iter().chain(applied2) {
+            if !sig.starts_with("loop.") {
+                fails.push(format!(
+                    "applied a non-analyzer lesson ({sig}) — LLM findings stay advisory \
+                     outside --llm-lessons"
+                ));
+            }
         }
     }
     if b.success_rate() <= a0.success_rate() + 0.1 {
@@ -694,8 +765,14 @@ fn check_shape(evals: &[EvalSummary], eval_n: u32, applied1: &[String], applied2
     }
     if fails.is_empty() {
         println!("\nassert-shape: PASS (B > A0 + 0.10, |A1−A0| ≤ 0.05, |B2−B| ≤ 0.05, A1 lessons empty)");
+        let llm_applied = applied1.iter().filter(|s| s.starts_with("llm :: ")).count();
+        let origins = if llm_lessons {
+            format!("{} analyzer + {llm_applied} llm-authored", applied1.len() - llm_applied)
+        } else {
+            "all analyzer-origin".to_string()
+        };
         println!(
-            "assert-shape: PASS ledger ({} lesson(s) applied, all analyzer-origin, all restored in B2)",
+            "assert-shape: PASS ledger ({} lesson(s) applied, {origins}, all restored in B2)",
             applied1.len()
         );
         if !arms.is_empty() {
@@ -757,8 +834,9 @@ fn main() {
 
     // 3 LEARN → apply (scripted review: executable non-destructive approved
     // + applied, destructive rejected, advisory ledgered) → eval B.
+    let (llm, ground) = loop_llm_backends(&args);
     let (ledger1, applied1) = mem
-        .learn(args.llm_cmd.as_deref(), args.ground_cmd.as_deref(), t_learn1)
+        .learn_with(llm, ground, args.llm_lessons, t_learn1)
         .unwrap_or_else(|e| die(&e));
     eprintln!(
         "learn 1: {} ledger rows, {} applied",
@@ -780,8 +858,9 @@ fn main() {
 
     // 5 RE-APPLY → eval B2. RolledBack is terminal per hash, so this is the
     // whole governed path a second time: re-propose → approve → apply.
+    let (llm, ground) = loop_llm_backends(&args);
     let (ledger2, applied2) = mem
-        .learn(args.llm_cmd.as_deref(), args.ground_cmd.as_deref(), t_learn2)
+        .learn_with(llm, ground, args.llm_lessons, t_learn2)
         .unwrap_or_else(|e| die(&e));
     eprintln!(
         "learn 2: {} ledger rows, {} applied",
@@ -847,6 +926,8 @@ fn main() {
         "agent_cmd": args.agent_cmd,
         "llm_cmd": args.llm_cmd,
         "ground_cmd": args.ground_cmd,
+        "llm_lessons": args.llm_lessons,
+        "mock_llm": args.mock_llm,
         "arms": args.arms,
         "context_cmd": args.context_cmd,
         "mllm_cmd": args.wants("m-llm").then(|| args.mllm_cmd()).flatten(),
@@ -865,7 +946,7 @@ fn main() {
     print_results(&args, &evals, &ledger, applied1.len(), applied2.len());
 
     if args.assert_shape {
-        check_shape(&evals, args.eval as u32, &applied_sig1, &applied_sig2);
+        check_shape(&evals, args.eval as u32, &applied_sig1, &applied_sig2, args.llm_lessons);
     }
 }
 
@@ -884,6 +965,8 @@ mod tests {
             agent_cmd: None,
             llm_cmd: None,
             ground_cmd: None,
+            llm_lessons: false,
+            mock_llm: false,
             arms: vec![],
             context_cmd: None,
             mllm_cmd: None,
@@ -1029,7 +1112,26 @@ mod tests {
             summary("M-all", 10, 8),
         ];
         let applied = vec!["loop.tool_failure/1 :: Tool \"refund\" failed".to_string()];
-        check_shape(&evals, 10, &applied, &applied);
+        check_shape(&evals, 10, &applied, &applied, false);
+    }
+
+    /// The loop+LLM arm's passing shape: an llm-authored signature applied
+    /// alongside the analyzer lessons is accepted (it would fail the
+    /// governed-only origin check), and its restoration is asserted through
+    /// the same signature comparison.
+    #[test]
+    fn check_shape_accepts_llm_authored_lessons_under_the_arm() {
+        let evals = vec![
+            summary("A0", 10, 3),
+            summary("B", 10, 9),
+            summary("A1", 10, 3),
+            summary("B2", 10, 9),
+        ];
+        let applied = vec![
+            "llm :: the same tool failure keeps recurring — record lesson: \"...\"".to_string(),
+            "loop.tool_failure/1 :: Tool \"refund\" failed".to_string(),
+        ];
+        check_shape(&evals, 10, &applied, &applied, true);
     }
 
     /// The signature list is what makes the restoration check possible across

--- a/crates/areev-bench/src/selfimprove/memory.rs
+++ b/crates/areev-bench/src/selfimprove/memory.rs
@@ -10,8 +10,8 @@
 use super::{Ledger, LedgerEntry, TaskRunRecord};
 use areev_cal::AreevFacade;
 use areev_loop::{
-    CommandLlm, Decision, Engine, ObserverType, Origin, Proposal, ReadOpts, RecStatus,
-    Recommendation, RunOptions, ScopeSet, SubstrateRead,
+    CommandLlm, Decision, Engine, LlmBackend, ObserverType, Origin, Proposal, ReadOpts,
+    RecStatus, Recommendation, RunOptions, ScopeSet, SubstrateRead,
 };
 use areev_loop_adapter::BorrowedSubstrate;
 use areev_store::Areev;
@@ -29,8 +29,8 @@ const BECAUSE_ROLLBACK: &str = "bench: A/B/A rollback";
 /// out of [`Memory::learn`] so the policy is unit-testable without an engine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReviewAction {
-    /// Not executable by design (LLM DISCOVER findings are `Proposal::Data`;
-    /// flag-kind analyzer findings likewise) — ledgered, left pending.
+    /// Not executable, or executable-but-out-of-arm (LLM-authored lessons
+    /// with `llm_lessons` off) — ledgered, left pending.
     Advisory,
     /// Destructive (FORGET has no inverse) — rejected, never applied.
     Reject,
@@ -38,16 +38,91 @@ enum ReviewAction {
     ApproveApply,
 }
 
-/// The scripted review policy. Order matters: an LLM finding is advisory even
-/// when its proposal LOOKS executable (apply refuses `origin = llm` data), and
-/// a `Proposal::Data` is advisory whatever authored it.
-fn review_action(origin: &Origin, proposal: &Proposal, destructive: bool) -> ReviewAction {
-    if matches!(origin, Origin::Llm { .. }) || matches!(proposal, Proposal::Data { .. }) {
+/// The scripted review policy. Order matters: a `Proposal::Data` is advisory
+/// whatever authored it, and an LLM finding — even an executable authored
+/// lesson (`Proposal::Cal`) — stays advisory unless the run deliberately
+/// opted into the `loop+LLM` arm (`llm_lessons`). The published governed runs
+/// predate that arm, so the default keeps their review policy byte-for-byte.
+fn review_action(
+    origin: &Origin,
+    proposal: &Proposal,
+    destructive: bool,
+    llm_lessons: bool,
+) -> ReviewAction {
+    if matches!(proposal, Proposal::Data { .. })
+        || (matches!(origin, Origin::Llm { .. }) && !llm_lessons)
+    {
         ReviewAction::Advisory
     } else if destructive {
         ReviewAction::Reject
     } else {
         ReviewAction::ApproveApply
+    }
+}
+
+/// The lesson the keyless mock loop-LLM authors. Deliberately free of every
+/// env error-code string (`customer_not_found`, `rate_limited`, …): the mock
+/// agent keys its behavior off those substrings, so this lesson exercises
+/// the authored-lesson PLUMBING (stamp → approve → apply → render → rollback)
+/// without moving the mock's success rates.
+pub const MOCK_LLM_LESSON: &str = "Before retrying a failing tool, change the \
+input that caused the recorded failure instead of repeating it unchanged.";
+
+/// The canned loop-LLM for keyless CI (`--mock-llm`): DISCOVER authors one
+/// evidence-cited lesson draft, GROUND supports every claim, VERIFY keeps
+/// everything at 0.9, ENRICH abstains. Deterministic — a pure function of the
+/// request — so the A/B/A/B shape floor can assert the authored-lesson
+/// lifecycle without a key. It answers whatever op it is asked, so it also
+/// serves as its own ground backend.
+pub struct MockLoopLlm;
+
+impl LlmBackend for MockLoopLlm {
+    fn model(&self) -> &str {
+        "mock-loop-llm"
+    }
+
+    fn complete(&self, request: &str) -> areev_loop::Result<String> {
+        let v: Value = serde_json::from_str(request).unwrap_or_default();
+        let n_of = |ptr: &str| v.pointer(ptr).and_then(Value::as_array).map_or(0, Vec::len);
+        let ok = |val: Value| Ok(val.to_string());
+        match v.get("op").and_then(Value::as_str) {
+            Some("discover") => {
+                // Cite the first bundled evidence grain; target the first
+                // deterministic finding's entity (the failure cluster the
+                // lesson is about). No evidence → abstain, the honest answer.
+                let target = v
+                    .pointer("/findings/0/target")
+                    .and_then(Value::as_str)
+                    .filter(|t| t.starts_with("entity:"))
+                    .unwrap_or("entity:lessons/support_desk");
+                match v.pointer("/evidence/0/hash").and_then(Value::as_str) {
+                    Some(h) => ok(serde_json::json!({
+                        "recommendations": [{
+                            "summary": "the same tool failure keeps recurring across tasks",
+                            "target": target,
+                            "guidance": "",
+                            "evidence": [h],
+                            "confidence": 0.9,
+                            "lesson": MOCK_LLM_LESSON,
+                        }]
+                    })),
+                    None => ok(serde_json::json!({ "recommendations": [] })),
+                }
+            }
+            Some("ground") => ok(serde_json::json!({
+                "results": (0..n_of("/claims"))
+                    .map(|id| serde_json::json!({"id": id, "supported": true, "reason": "mock"}))
+                    .collect::<Vec<_>>()
+            })),
+            Some("verify") => ok(serde_json::json!({
+                "results": (0..n_of("/findings"))
+                    .map(|id| {
+                        serde_json::json!({"id": id, "keep": true, "confidence": 0.9, "reason": "mock"})
+                    })
+                    .collect::<Vec<_>>()
+            })),
+            _ => ok(serde_json::json!({ "notes": [] })),
+        }
     }
 }
 
@@ -146,6 +221,9 @@ impl Memory {
     /// the scripted review over every PENDING recommendation. Returns the
     /// ledger rows this pass added and the hashes it applied.
     ///
+    /// The review policy of the PUBLISHED runs: LLM findings stay advisory
+    /// (`llm_lessons = false`). The `loop+LLM` arm opts in via [`learn_with`].
+    ///
     /// `triggering_actor` stays `None` deliberately: with it set, LLM-origin
     /// recommendations would carry a co-creator, and this bench's review is
     /// scripted, not a human session.
@@ -155,16 +233,39 @@ impl Memory {
         ground_cmd: Option<&str>,
         now_ms: i64,
     ) -> Result<(Ledger, Vec<String>), String> {
+        let llm: Option<Box<dyn LlmBackend>> = match llm_cmd {
+            Some(cmd) => Some(Box::new(
+                CommandLlm::new(cmd, None).map_err(|e| format!("--llm-cmd: {e}"))?,
+            )),
+            None => None,
+        };
+        let ground: Option<Box<dyn LlmBackend>> = match ground_cmd {
+            Some(cmd) => Some(Box::new(
+                CommandLlm::new(cmd, None).map_err(|e| format!("--ground-cmd: {e}"))?,
+            )),
+            None => None,
+        };
+        self.learn_with(llm, ground, false, now_ms)
+    }
+
+    /// [`learn`] with pre-built loop backends and the `loop+LLM` arm switch.
+    /// With `llm_lessons` on, the scripted review also approves + applies
+    /// LLM-authored lessons — the applicable, non-destructive `Proposal::Cal`
+    /// recommendations the engine stamps for gate-surviving lesson drafts.
+    /// Advisory LLM `Proposal::Data` findings stay advisory either way.
+    pub fn learn_with(
+        &self,
+        llm: Option<Box<dyn LlmBackend>>,
+        ground: Option<Box<dyn LlmBackend>>,
+        llm_lessons: bool,
+        now_ms: i64,
+    ) -> Result<(Ledger, Vec<String>), String> {
         let mut engine = Engine::with_builtins();
-        if let Some(cmd) = llm_cmd {
-            let backend =
-                CommandLlm::new(cmd, None).map_err(|e| format!("--llm-cmd: {e}"))?;
-            engine = engine.with_llm(Box::new(backend));
+        if let Some(backend) = llm {
+            engine = engine.with_llm(backend);
         }
-        if let Some(cmd) = ground_cmd {
-            let backend =
-                CommandLlm::new(cmd, None).map_err(|e| format!("--ground-cmd: {e}"))?;
-            engine = engine.with_ground_llm(Box::new(backend));
+        if let Some(backend) = ground {
+            engine = engine.with_ground_llm(backend);
         }
 
         let mut sub = BorrowedSubstrate::new(&self.facade);
@@ -185,7 +286,7 @@ impl Memory {
                 r.analyzer.clone()
             };
             let summary = r.summary.render();
-            match review_action(&r.origin, &r.proposal, r.destructive) {
+            match review_action(&r.origin, &r.proposal, r.destructive, llm_lessons) {
                 ReviewAction::Advisory => ledger.entries.push(LedgerEntry {
                     hash: r.hash.clone(),
                     source,
@@ -348,33 +449,44 @@ impl Memory {
             .collect())
     }
 
-    /// The LESSONS prompt section, rendered from LIVE `fails_with` facts in
-    /// the bench namespace. EMPTY STRING when none live — the honesty lever:
-    /// rollback tombstones the lesson grains, which must empty this.
+    /// The LESSONS prompt section, rendered from LIVE lesson facts in the
+    /// bench namespace: `fails_with` (deterministic failure signatures) and
+    /// `lesson` (LLM-authored rules — exist only when a `loop+LLM` arm
+    /// applied them). EMPTY STRING when none live — the honesty lever:
+    /// rollback tombstones the lesson grains, which must empty this. A run
+    /// with no authored lessons renders byte-identically to the published
+    /// governed runs.
     pub fn lessons_markdown(&self) -> Result<String, String> {
         let sub = BorrowedSubstrate::new(&self.facade);
         // ReadOpts::default() is live_only — a tombstoned lesson never renders.
         let grains = sub
             .grains_of_type("fact", Some(&self.ns), ReadOpts::default())
             .map_err(|e| format!("read lessons: {e}"))?;
-        let mut lessons: Vec<(String, String)> = grains
-            .iter()
-            .filter(|g| g.fact_relation() == Some("fails_with"))
-            .filter_map(|g| {
-                Some((g.fact_subject()?.to_string(), g.fact_object()?.to_string()))
-            })
-            .collect();
-        if lessons.is_empty() {
+        let pairs = |relation: &str| -> Vec<(String, String)> {
+            let mut v: Vec<(String, String)> = grains
+                .iter()
+                .filter(|g| g.fact_relation() == Some(relation))
+                .filter_map(|g| {
+                    Some((g.fact_subject()?.to_string(), g.fact_object()?.to_string()))
+                })
+                .collect();
+            // Deterministic prompt bytes: sorted by subject then object.
+            v.sort();
+            v.dedup();
+            v
+        };
+        let lessons = pairs("fails_with");
+        let rules = pairs("lesson");
+        if lessons.is_empty() && rules.is_empty() {
             return Ok(String::new());
         }
-        // Deterministic prompt bytes: sorted by subject then object.
-        lessons.sort();
-        lessons.dedup();
-        let mut out = String::from(
-            "## LESSONS (from prior experience)\n\
-             Recurring tool failures observed in earlier runs. Account for them\n\
-             before and after calling the tool.\n",
-        );
+        let mut out = String::from("## LESSONS (from prior experience)\n");
+        if !lessons.is_empty() {
+            out.push_str(
+                "Recurring tool failures observed in earlier runs. Account for them\n\
+                 before and after calling the tool.\n",
+            );
+        }
         for (subject, object) in &lessons {
             // Render the stored signature legibly: the error code is the part
             // an operator acts on, the rest is its payload. NEVER add the
@@ -397,6 +509,14 @@ impl Memory {
                     ));
                 }
                 None => out.push_str(&format!("- `{subject}` repeatedly failed with: {object}\n")),
+            }
+        }
+        if !rules.is_empty() {
+            // Authored rules ARE the remedy by design — that is the delta the
+            // loop+LLM arm measures against signature-only lessons.
+            out.push_str("Rules learned from earlier runs. Follow them:\n");
+            for (subject, object) in &rules {
+                out.push_str(&format!("- `{subject}`: {object}\n"));
             }
         }
         Ok(out)
@@ -568,20 +688,81 @@ mod tests {
         );
     }
 
-    /// The scripted review policy, pinned per rec shape: LLM origin trumps an
-    /// executable-looking proposal; Data is advisory whoever authored it;
-    /// destructive CAL rejects; non-destructive CAL applies.
+    /// The scripted review policy, pinned per rec shape: Data is advisory
+    /// whoever authored it; LLM origin stays advisory by default and its
+    /// executable authored lessons apply ONLY under the `loop+LLM` arm
+    /// (`llm_lessons`); destructive CAL rejects — llm origin included;
+    /// non-destructive CAL applies.
     #[test]
     fn review_policy_maps_rec_kinds_to_dispositions() {
         let cal = Proposal::Cal { cal: "ADD fact ...".to_string() };
         let data = Proposal::Data { data: Map::new() };
         let llm = Origin::Llm { model: "test-model".to_string() };
 
-        assert_eq!(review_action(&llm, &cal, false), ReviewAction::Advisory);
-        assert_eq!(review_action(&llm, &data, false), ReviewAction::Advisory);
-        assert_eq!(review_action(&Origin::Builtin, &data, false), ReviewAction::Advisory);
-        assert_eq!(review_action(&Origin::Builtin, &cal, true), ReviewAction::Reject);
-        assert_eq!(review_action(&Origin::Builtin, &cal, false), ReviewAction::ApproveApply);
+        // The published-run policy (llm_lessons = false), byte-for-byte.
+        assert_eq!(review_action(&llm, &cal, false, false), ReviewAction::Advisory);
+        assert_eq!(review_action(&llm, &data, false, false), ReviewAction::Advisory);
+        assert_eq!(review_action(&Origin::Builtin, &data, false, false), ReviewAction::Advisory);
+        assert_eq!(review_action(&Origin::Builtin, &cal, true, false), ReviewAction::Reject);
+        assert_eq!(review_action(&Origin::Builtin, &cal, false, false), ReviewAction::ApproveApply);
+
+        // The loop+LLM arm: authored lessons apply; Data stays advisory; a
+        // destructive llm payload (cannot be stamped today) would reject,
+        // never apply.
+        assert_eq!(review_action(&llm, &cal, false, true), ReviewAction::ApproveApply);
+        assert_eq!(review_action(&llm, &data, false, true), ReviewAction::Advisory);
+        assert_eq!(review_action(&llm, &cal, true, true), ReviewAction::Reject);
+        assert_eq!(review_action(&Origin::Builtin, &cal, false, true), ReviewAction::ApproveApply);
+    }
+
+    /// The loop+LLM arm end-to-end at bench level: the mock loop-LLM authors
+    /// a lesson, the scripted review applies it, it renders into LESSONS,
+    /// rollback empties it, and a fresh governed pass restores it. With
+    /// `llm_lessons` off the same backend's lesson stays advisory and the
+    /// rendered prompt is byte-identical to the deterministic-only path.
+    #[test]
+    fn mock_llm_lesson_lifecycle_under_the_arm_switch() {
+        let dir = TempDir::new().unwrap();
+        let mem = Memory::create(dir.path()).unwrap();
+        mem.record_task(&failing_task("stripe_refund", "approval_required", 4)).unwrap();
+
+        // Arm OFF: the authored lesson survives the gates but is ledgered
+        // advisory — nothing llm-origin applies, no rule line renders.
+        let (ledger, applied) = mem
+            .learn_with(Some(Box::new(MockLoopLlm)), None, false, T1)
+            .unwrap();
+        assert!(
+            ledger.entries.iter().any(|e| e.source == "llm" && e.disposition == "advisory"),
+            "authored lesson ledgered advisory with the arm off"
+        );
+        let md = mem.lessons_markdown().unwrap();
+        assert!(!md.contains(MOCK_LLM_LESSON), "arm off ⇒ no authored rule in the prompt");
+        mem.rollback(&applied, T2).unwrap();
+
+        // Arm ON: approved + applied through the same scripted review, and
+        // the rule renders under the LESSONS heading the agent scans.
+        let (ledger, applied) = mem
+            .learn_with(Some(Box::new(MockLoopLlm)), None, true, T3)
+            .unwrap();
+        assert!(
+            ledger.entries.iter().any(|e| e.source == "llm" && e.disposition == "applied"),
+            "authored lesson applied under the arm: {:?}",
+            ledger.entries
+        );
+        let md = mem.lessons_markdown().unwrap();
+        assert!(md.starts_with("## LESSONS (from prior experience)\n"));
+        assert!(md.contains(MOCK_LLM_LESSON), "authored rule renders: {md}");
+
+        // Rollback empties the WHOLE section — authored rules included.
+        mem.rollback(&applied, T3 + HOUR_MS).unwrap();
+        assert_eq!(mem.lessons_markdown().unwrap(), "", "rollback empties authored rules too");
+
+        // Restoration is a fresh governed pass (rolled_back is terminal).
+        let (_, applied2) = mem
+            .learn_with(Some(Box::new(MockLoopLlm)), None, true, T3 + 2 * HOUR_MS)
+            .unwrap();
+        assert!(!applied2.is_empty());
+        assert!(mem.lessons_markdown().unwrap().contains(MOCK_LLM_LESSON));
     }
 
     /// The passive-memory arms' input round-trips through the store: order,


### PR DESCRIPTION
Follows #145 (the engine's LLM-authored lessons): gives the A/B/A/B bench the arm that measures them.

- **`--llm-lessons`** — the arm switch: scripted review also approves + applies LLM-authored lessons; `lessons_markdown` renders them as a "Rules learned" block under the same `## LESSONS` heading. **Off (default) reproduces the published runs' review policy and prompt bytes exactly** — reproducibility pins pass unchanged.
- **`--mock-llm`** — the keyless canned loop-LLM (a pure function of the request; authors one fixed lesson containing none of the env's error-code strings, so the mock agent's rates cannot move). Mutually exclusive with `--llm-cmd`; `--llm-lessons` requires one of them.
- **CI**: a third mock invocation asserts the authored-lesson lifecycle (apply → render → rollback-empties → re-apply restores) on every push. `--assert-shape`'s origin check is now the arm definition: governed-only fails if an llm lesson applies; the arm fails if none does.

Verified locally: all three CI mock invocations PASS (the arm run applies 2 analyzer + 1 llm-authored lesson, all restored in B2); `areev-bench` 84 lib + bin tests; reproducibility pins; clippy clean.