### PR TITLE
loop: render tool grains in the LLM evidence bundle — GROUND was starving

### DIFF
--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -1960,6 +1960,15 @@ fn grain_brief(g: &GrainRecord) -> String {
     if let (Some(s), Some(r), Some(o)) = (g.fact_subject(), g.fact_relation(), g.fact_object()) {
         return format!("{s} {r} {o}");
     }
+    // Tool grains — the evidence most lesson drafts cite. Rendering them
+    // empty starved GROUND of the very facts it exists to check: a correct
+    // lesson would be refused as unverifiable (found live — the gate
+    // rightly rejected a claim over evidence it could not see).
+    if let Some(t) = g.tool_name() {
+        let status = if g.is_error() { "error" } else { "ok" };
+        let out = g.tool_content().unwrap_or("");
+        return format!("tool {t} {status}: {out}");
+    }
     for key in ["content", "body", "text", "summary"] {
         if let Some(v) = g.fields.get(key).and_then(|v| v.as_str()) {
             if !v.is_empty() {

--- a/crates/areev-loop/src/integration.rs
+++ b/crates/areev-loop/src/integration.rs
@@ -623,6 +623,61 @@ fn ground_and_verify_judge_the_lesson_text_not_just_the_summary() {
     }
 }
 
+#[test]
+fn tool_grain_evidence_reaches_the_llm_with_text() {
+    use std::sync::{Arc, Mutex};
+    struct RecordingLlm {
+        inner: MockLlm,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+    impl crate::llm::LlmBackend for RecordingLlm {
+        fn model(&self) -> &str {
+            "recording-mock"
+        }
+        fn complete(&self, request: &str) -> crate::error::Result<String> {
+            self.seen.lock().unwrap().push(request.to_string());
+            self.inner.complete(request)
+        }
+    }
+    let mut sub = TestSubstrate::new();
+    // A dominant failure cluster: the tool_failure candidate cites these tool
+    // grains, which seeds them into the DISCOVER evidence bundle.
+    for _ in 0..5 {
+        sub.add_tool_call("stripe_refund", true, "rate_limited 429");
+    }
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let e = Engine::with_builtins().with_llm(Box::new(RecordingLlm {
+        inner: MockLlm {
+            discover: r#"{"recommendations":[]}"#.to_string(),
+            ground: r#"{"results":[]}"#.to_string(),
+            verify: r#"{"results":[]}"#.to_string(),
+            enrich: r#"{"notes":[]}"#.to_string(),
+        },
+        seen: Arc::clone(&seen),
+    }));
+    e.run(&mut sub.inner, &RunOptions::default(), 10_000).unwrap();
+    let seen = seen.lock().unwrap();
+    let discover = seen
+        .iter()
+        .find(|r| r.contains("\"op\":\"discover\""))
+        .expect("a discover request");
+    let v: serde_json::Value = serde_json::from_str(discover).unwrap();
+    let items = v["evidence"].as_array().expect("evidence array");
+    let tools: Vec<_> =
+        items.iter().filter(|i| i["grain_type"] == "tool").collect();
+    assert!(!tools.is_empty(), "tool grains reach the bundle");
+    for item in tools {
+        let text = item["text"].as_str().unwrap_or("");
+        // Found live: tool grains rendered as EMPTY text, so GROUND rightly
+        // refused to ground a correct lesson against evidence it couldn't
+        // see. The brief must carry the tool name and the failure body.
+        assert!(
+            text.contains("stripe_refund") && text.contains("rate_limited"),
+            "tool evidence must carry name + outcome, got: {text:?}"
+        );
+    }
+}
+
 #[cfg(unix)]
 #[test]
 fn external_command_analyzer_surfaces_advisory_findings() {


### PR DESCRIPTION
Found live on the first loop+LLM smoke run: DISCOVER authored a correct lesson (the R5 UTC rule, 0.95 confidence) and GROUND rejected it — **correctly** — because `grain_brief` rendered every cited tool grain as empty text. The anti-fabrication gate refused to ground a claim against evidence it couldn't see; the bug was upstream, in evidence rendering.

Fix: tool grains render as `tool <name> <ok|error>: <content>`. Replayed against the same memory: the authored lesson now survives GROUND (supported=true with a verdict quoting the evidence) + VERIFY and stamps as the applicable, rollbackable `ADD fact` with model provenance and the verifier's confidence.

Regression test: the discover request's tool-grain evidence must carry name + outcome text. `areev-loop` 134 ✓, clippy clean.