### PR TITLE
readme: the headline result is now the three-independent-stream run

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,46 +90,50 @@ this repo — click through:
 
 Anyone can show a number going up. The honest test is whether the *learning*
 caused it — so we remove what was learned and watch the gain leave, then put
-it back and watch it return. One frozen model at temperature 0, three seeded
-runs over 100 held-out tasks each (n=300) the agent has never seen; the only
-thing that changes between bars is whether the lessons Areev learned from
-the agent's own failures are in its prompt:
+it back and watch it return. One frozen model at temperature 0, three
+independent task streams of 100 held-out tasks each (n=300) the agent has
+never seen; the only thing that changes between bars is whether the lessons
+Areev learned from the agent's own failures are in its prompt:
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/aba-selfimprove-dark.svg">
   <img src="docs/assets/aba-selfimprove-light.svg" width="860"
-       alt="A/B/A/B self-improvement bar chart: 39.0% of held-out tasks passed before learning, 59.7% with lessons applied, 37.7% with lessons rolled back, 56.3% re-applied — the gain follows the lessons in both directions, every transition paired McNemar p < 0.0001">
+       alt="A/B/A/B self-improvement bar chart: 46.3% of held-out tasks passed before learning, 68.7% with lessons applied, 47.0% with lessons rolled back, 67.0% re-applied — the gain follows the lessons in both directions, every transition paired McNemar p < 0.0001">
 </picture>
 
 | what the memory holds | tasks passed | |
 |---|:---:|---|
-| nothing learned yet | 39.0% | the agent keeps repeating its mistakes |
-| the lessons, applied | **59.7%** ▲ | it stops |
-| the lessons, rolled back | 37.7% ▼ | **the proof** — take them away and the gain leaves with them |
-| the lessons, re-applied | **56.3%** ▲ | put them back and it returns |
+| nothing learned yet | 46.3% | the agent keeps repeating its mistakes |
+| the lessons, applied | **68.7%** ▲ | it stops |
+| the lessons, rolled back | 47.0% ▼ | **the proof** — take them away and the gain leaves with them |
+| the lessons, re-applied | **67.0%** ▲ | put them back and it returns |
 
-Every transition is significant at **p < 0.0001** (paired McNemar, n=300);
-the two lessons-off states are statistically indistinguishable. There is no
-benchmark mode: the prompt is assembled from live memory on every run, so
-rolling the lessons back empties it structurally. Three results behind the
-chart:
+Every transition is significant at **p < 0.0001** (paired McNemar, n=300, and
+independently significant in each of the three streams); the two lessons-off
+states are statistically indistinguishable. There is no benchmark mode: the
+prompt is assembled from live memory on every run, so rolling the lessons back
+empties it structurally. Three results behind the chart:
 
 - **It learned for free.** The lessons come from deterministic clustering
   over the agent's own tool calls — **zero model calls** — and each one
   cites the failures it was computed from, by hash.
 - **It improved without regressing.** Every hidden rule the loop touched got
-  better, none got worse.
-  [The per-rule numbers →](crates/areev-bench/RESULTS.md#it-improves-without-regressing)
+  better, none got worse — refund/cancel ordering 56% → **20%**, UTC
+  timestamps 37% → **20%**, rate-limit recovery 76% → **50%** — and each one
+  returns to baseline when the lessons are rolled back.
+  [The per-rule numbers →](crates/areev-bench/RESULTS.md#the-headline-run--2026-08-30-three-independent-task-streams)
 - **It matches heavyweight retrieval at a fraction of the cost.** The same
   store with the loop *off* — raw failure history retrieved into the prompt
   three different ways — never significantly outscored the lessons, paid
   **1.3–6.2× the prompt tokens** every turn doing it, and its best-scoring
-  variant doubled a class of mistakes the loop had eliminated.
+  variant doubled a class of mistakes the loop had eliminated. (Measured in
+  the earlier run, which this one did not repeat.)
   [The baselines →](crates/areev-bench/RESULTS.md#does-the-loop-beat-the-store--the-passive-memory-arms)
 
 One synthetic workload, built to make learning *measurable* rather than to
 mimic production traffic — and we wrote the test, so re-run it yourself: the
-whole three-seed comparison costs about **$2.30**.
+three-seed run behind this chart is about **$0.70** on a small open-weights
+model, with every task and outcome committed.
 [Full results & caveats →](crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof) ·
 [Reproduce it →](crates/areev-bench/SELFIMPROVE.md#reproduce) ·
 [How the loop works →](docs/loop.md)

--- a/crates/areev-bench/RESULTS.md
+++ b/crates/areev-bench/RESULTS.md
@@ -606,35 +606,77 @@ two commands above against the model you will actually deploy.
 pre-registered interpretation and full flag reference:
 [`SELFIMPROVE.md`](SELFIMPROVE.md).
 
-*Run: 2026-08-26 · **3 seeds** · agent Qwen3-30B-A3B-Instruct-2507 via
-OpenRouter, temperature 0, 6-way eval concurrency. Per seed: 300 experience
-tasks, 100 held-out tasks scored in every state. Loop LLM stages on
-(DISCOVER/VERIFY on the agent model, GROUND on `deepseek-chat` so the proposer
-never grades itself). Every tool call and every per-task outcome transcribed in
-[`results/selfimprove-3seed-qwen3-30b-2026-08-26/`](results/) — enough to
-recompute every number below from the raw rows, though **not** a record of the
-model calls themselves (SELFIMPROVE.md, "What the transcripts actually
-contain"). No provider pin was passed, so routing was OpenRouter's choice and
-is not recorded.*
+*Two published runs, both 3 seeds · agent Qwen3-30B-A3B-Instruct-2507 via
+OpenRouter, temperature 0. Per seed: 300 experience tasks, 100 held-out tasks
+scored in every state. Loop LLM stages on (DISCOVER/VERIFY on the agent model,
+GROUND on `deepseek-chat` so the proposer never grades itself). Every tool call
+and every per-task outcome is transcribed — enough to recompute every number
+below from the raw rows, though **not** a record of the model calls themselves
+(SELFIMPROVE.md, "What the transcripts actually contain"). No provider pin was
+passed in either, so routing was OpenRouter's choice and is not recorded. The
+2026-08-30 run leads because its seeds are three independent task streams; the
+2026-08-26 run keeps the passive-memory arms, which the later run did not
+repeat.*
 
 The only lever between states is Areev's own governed apply/rollback: the eval
 prompt is assembled from live memory on every run, so rollback empties the
 LESSONS section structurally. There is no harness flag that changes behaviour.
 
+### The headline run — 2026-08-30, three independent task streams
+
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="../../docs/assets/aba-selfimprove-dark.svg">
   <img src="../../docs/assets/aba-selfimprove-light.svg" width="860"
-       alt="Bar chart of governed self-improvement on 300 held-out tasks: A0 before learning 39.0% (117/300), B lessons applied 59.7% (179/300) up 20.7 points, A1 lessons rolled back 37.7% (113/300) down 22.0 points, B2 lessons re-applied 56.3% (169/300) up 18.7 points. Every transition paired McNemar p below 0.0001; both same-condition controls null.">
+       alt="Bar chart of governed self-improvement on 300 held-out tasks: A0 before learning 46.3% (139/300), B lessons applied 68.7% (206/300) up 22.3 points, A1 lessons rolled back 47.0% (141/300) down 21.7 points, B2 lessons re-applied 67.0% (201/300) up 20.0 points. Every transition paired McNemar p below 0.0001; both same-condition controls null.">
 </picture>
 
-Regenerate with `python3 crates/areev-bench/scripts/aba_chart.py
-docs/assets/aba-selfimprove <run-dir>` — rates come from `report.json` and the
-p-values from `aba_stats.py`, imported rather than recomputed, so the picture
-cannot drift from the tables below. The visible SVG is deliberately the chart
-alone — the narrative lives as real text here and in the README — but its
-`<title>` and `<desc>` still carry the full result (rates, deltas, McNemar
-rows), so a crawler, a screen reader, or a model reading the file gets the
-finding without rendering the bars.
+*Seeds **1, 3, 5** — odd, so the seed-derivation defect below cannot collapse
+two of them into one stream; this run is three genuinely independent task
+sets, which the 2026-08-26 run was not. Same model pair, same 300/100 sizes,
+governed states only (no passive arms — those remain the earlier run's).
+Evidence:
+[`results/selfimprove-llmarm-3seed-qwen3-30b-2026-08-30/`](results/selfimprove-llmarm-3seed-qwen3-30b-2026-08-30/),
+the `governed-*` runs; it is the control half of the loop+LLM comparison
+below, which is why both live in one directory.*
+
+| state | seed 1 | seed 3 | seed 5 | pooled |
+|---|---|---|---|---|
+| A0 before lessons | 45% | 42% | 52% | **46.3%** (139/300) |
+| B lessons applied | 63% | 67% | 76% | **68.7%** (206/300) |
+| A1 lessons rolled back | 43% | 44% | 54% | **47.0%** (141/300) |
+| B2 lessons re-applied | 60% | 66% | 75% | **67.0%** (201/300) |
+
+Paired exact McNemar, pooled: A0→B **+22.3 pts** (b=84 c=17, p<0.0001),
+B→A1 **−21.7** (b=19 c=84, p<0.0001), A1→B2 **+20.0** (b=74 c=14, p<0.0001);
+every transition independently significant in **each** of the three seeds.
+The same-condition controls are null — A0↔A1 p=0.8388, B↔B2 p=0.6089 — so the
+swing tracks the applied lessons and nothing else. Per-rule, every rule the
+loop touched improved and each returns to baseline when the lessons are
+rolled back:
+
+| hidden rule | A0 | B | A1 | B2 |
+|---|---|---|---|---|
+| R4 refund/cancel ordering | 42/75 (56%) | **15/75 (20%)** | 44/75 (59%) | 23/75 (31%) |
+| R5 UTC timestamps | 28/75 (37%) | **15/75 (20%)** | 28/75 (37%) | 17/75 (23%) |
+| R6 rate-limit recovery | 100/132 (76%) | **66/132 (50%)** | 96/132 (73%) | 65/132 (49%) |
+
+Regenerate the chart with `python3 crates/areev-bench/scripts/aba_chart.py
+docs/assets/aba-selfimprove <run-dir> [--prefix P]` — rates come from
+`report.json` and the p-values from `aba_stats.py`, imported rather than
+recomputed, so the picture cannot drift from the tables. `--prefix` selects
+one configuration out of a set holding more than one; pooling a control and
+an arm would draw a population that was never run. The visible SVG is
+deliberately the chart alone — the narrative lives as real text here and in
+the README — but its `<title>` and `<desc>` still carry the full result, so a
+crawler, a screen reader, or a model reading the file gets the finding
+without rendering the bars.
+
+### The 2026-08-26 run — the same claim, plus the passive-memory arms
+
+*The original publication. Its numbers stand and its arms are not superseded
+(the run above did not repeat them), but its replication breadth is **two**
+task streams, not three — see the defect note below. Evidence:
+[`results/selfimprove-3seed-qwen3-30b-2026-08-26/`](results/selfimprove-3seed-qwen3-30b-2026-08-26/).*
 
 | state | seed 1 | seed 2 | seed 3 | mean | avg prompt tokens |
 |---|---|---|---|---|---|
@@ -680,10 +722,12 @@ python3 crates/areev-bench/scripts/verify_run.py \
   crates/areev-bench/results/selfimprove-3seed-qwen3-30b-2026-08-26
 ```
 
-### It improves without regressing
+### It improves without regressing (2026-08-26 run)
 
 Per-rule mishandling (tasks that failed to handle a hidden rule / tasks that
-exercised it), summed over three seeds. A rule is "mishandled" when the agent
+exercised it), summed over that run's three seeds — the 2026-08-30 run's
+equivalent table, which also shows each rule returning to baseline on
+rollback, is in its section above. A rule is "mishandled" when the agent
 repeats the same error or gives up on it — an unavoidable first failure that
 the agent then handles does not count:
 

--- a/crates/areev-bench/SELFIMPROVE.md
+++ b/crates/areev-bench/SELFIMPROVE.md
@@ -594,8 +594,16 @@ rather than trusting a figure in a doc.
 | what | scale | cost |
 |---|---|---|
 | full three-seed replication | 2,800 task-runs, 4 states + 3 arms | **$2.30** |
+| three-seed headline run (governed only, 300/100) | 2,100 task-runs, 4 states · 9.3M prompt + 0.29M completion tokens | **~$0.70** |
+| the loop+LLM arm beside it (same scale) | 2,100 task-runs · 9.4M + 0.29M | **~$0.70** |
 | one seed, governed states only (150/60) | ~390 task-runs | **~$0.35** |
 | keyless floor (`--mock`) | any | **$0** |
+
+The two 2026-08-30 rows are the only **scaled** figures here: their token
+counts are measured (and recomputable from the transcripts), but the dollar
+amount is the $2.30 run's billed rate applied to those counts, not an invoice.
+A seed of the pilot config (150/60) is the row above it and was billed
+directly.
 
 The prompt-token total dwarfs completion by 60×, which is the shape of this
 benchmark: long tool schemas and a growing message history re-sent every turn.

--- a/crates/areev-bench/scripts/aba_chart.py
+++ b/crates/areev-bench/scripts/aba_chart.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """Render the A/B/A/B self-improvement result as a bar chart (light + dark SVG).
 
-    aba_chart.py OUT_STEM RUN_DIR
+    aba_chart.py OUT_STEM RUN_DIR [--prefix P]
 
     aba_chart.py docs/assets/aba-selfimprove \
-      crates/areev-bench/results/selfimprove-3seed-qwen3-30b-2026-08-26
+      crates/areev-bench/results/selfimprove-llmarm-3seed-qwen3-30b-2026-08-30 \
+      --prefix governed
 
-Writes OUT_STEM-light.svg and OUT_STEM-dark.svg.
+Writes OUT_STEM-light.svg and OUT_STEM-dark.svg. `--prefix` selects one
+CONFIGURATION out of a results set that holds more than one — without it a
+set carrying both a control and an arm would pool them into bars describing
+a population that was never run.
 
 ONE run, four bars, read left to right: the lessons are off, applied, rolled
 back, applied again. Colour encodes the only thing that changes — whether the
@@ -73,19 +77,26 @@ def esc(s):
     return str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def load_run(run_dir):
+def load_run(run_dir, prefix=""):
     """({state: (rate, successes, n)}, {(x, y): (b, c, n, p)}, n_seeds).
 
     A directory may hold several seeds. Rates are POOLED — successes and tasks
     summed across seeds, which is the mean RESULTS.md quotes — so each bar and
     the p-value beside it describe the same population.
+
+    `prefix` selects a subset of a set that holds more than one
+    CONFIGURATION (e.g. `governed` in a directory that also carries a
+    `llm` arm). Pooling two configurations into one set of bars would
+    describe a population that was never run — so this is a filter, not a
+    convenience.
     """
     reports = sorted(
         f for f in os.listdir(run_dir)
-        if f == "report.json" or f.endswith(".report.json")
+        if (f == "report.json" or f.endswith(".report.json")) and f.startswith(prefix)
     )
     if not reports:
-        raise SystemExit(f"aba_chart: no report.json in {run_dir}")
+        where = f"{run_dir} matching {prefix!r}" if prefix else run_dir
+        raise SystemExit(f"aba_chart: no report.json in {where}")
 
     totals = {}
     for name in reports:
@@ -99,7 +110,11 @@ def load_run(run_dir):
         raise SystemExit(f"aba_chart: {run_dir} has no {', '.join(missing)} state(s)")
     rates = {st: (s / n if n else 0.0, s, n) for st, (s, n) in totals.items()}
 
+    # The same filter must reach the statistics, or the bars would describe
+    # one configuration and the p-values beside them another.
     runs = aba_stats.load_runs(run_dir)
+    if prefix:
+        runs = [(n, r) for n, r in runs if n.rsplit("/", 1)[-1].startswith(prefix)]
     stats = {}
     present = set()
     for _, r in runs:
@@ -247,11 +262,12 @@ def render(theme, rates, stats, n_seeds, headline):
 
 
 def main(argv):
-    if len(argv) != 3:
-        print("usage: aba_chart.py OUT_STEM RUN_DIR", file=sys.stderr)
+    if len(argv) not in (3, 5) or (len(argv) == 5 and argv[3] != "--prefix"):
+        print("usage: aba_chart.py OUT_STEM RUN_DIR [--prefix P]", file=sys.stderr)
         return 2
     out_stem, run_dir = argv[1], argv[2]
-    rates, stats, n_seeds = load_run(run_dir)
+    prefix = argv[4] if len(argv) == 5 else ""
+    rates, stats, n_seeds = load_run(run_dir, prefix)
     gain = (rates["B"][0] - rates["A0"][0]) * 100
     headline = (
         f"An AI agent that learns from its own mistakes: "

--- a/docs/assets/aba-selfimprove-dark.svg
+++ b/docs/assets/aba-selfimprove-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="860" height="332" viewBox="0 0 860 332" role="img" aria-labelledby="aba-title aba-desc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
-<title id="aba-title">An AI agent that learns from its own mistakes: +20.7 points on held-out tasks, and it disappears when you remove what it learned</title>
-<desc id="aba-desc">Areev governed self-improvement benchmark: an AI agent learns from its own tool-use failures, and the learned lessons are applied, rolled back, and re-applied while everything else — model, prompts, tools, and the 300 held-out tasks — is held fixed. A0 before learning: 39.0% (117/300 tasks passed); B lessons applied: 59.7% (179/300 tasks passed); A1 lessons rolled back: 37.7% (113/300 tasks passed); B2 lessons re-applied: 56.3% (169/300 tasks passed). Paired exact McNemar over the same tasks: apply (A0-&gt;B): +20.7 pts, p &lt; 0.0001, b=70 c=8 n=300; roll back (B-&gt;A1): -22.0 pts, p &lt; 0.0001, b=8 c=74 n=300; re-apply (A1-&gt;B2): +18.7 pts, p &lt; 0.0001, b=65 c=9 n=300; control A0-&gt;A1 (same condition, expect no change): p = 0.289, b=2 c=6 n=300; control B-&gt;B2 (same condition, expect no change): p = 0.11, b=11 c=21 n=300. Removing the lessons removes the gain and restoring them brings it back, which is what makes the improvement causal rather than correlational. Measured over 3 seeded runs at temperature zero; b = tasks that failed in the first state and passed in the second, c = the reverse.</desc>
+<title id="aba-title">An AI agent that learns from its own mistakes: +22.3 points on held-out tasks, and it disappears when you remove what it learned</title>
+<desc id="aba-desc">Areev governed self-improvement benchmark: an AI agent learns from its own tool-use failures, and the learned lessons are applied, rolled back, and re-applied while everything else — model, prompts, tools, and the 300 held-out tasks — is held fixed. A0 before learning: 46.3% (139/300 tasks passed); B lessons applied: 68.7% (206/300 tasks passed); A1 lessons rolled back: 47.0% (141/300 tasks passed); B2 lessons re-applied: 67.0% (201/300 tasks passed). Paired exact McNemar over the same tasks: apply (A0-&gt;B): +22.3 pts, p &lt; 0.0001, b=84 c=17 n=300; roll back (B-&gt;A1): -21.7 pts, p &lt; 0.0001, b=19 c=84 n=300; re-apply (A1-&gt;B2): +20.0 pts, p &lt; 0.0001, b=74 c=14 n=300; control A0-&gt;A1 (same condition, expect no change): p = 0.839, b=13 c=11 n=300; control B-&gt;B2 (same condition, expect no change): p = 0.609, b=28 c=33 n=300. Removing the lessons removes the gain and restoring them brings it back, which is what makes the improvement causal rather than correlational. Measured over 3 seeded runs at temperature zero; b = tasks that failed in the first state and passed in the second, c = the reverse.</desc>
 <rect width="860" height="332" fill="#0d1117"/>
 <rect x="74" y="18" width="11" height="11" rx="2" fill="#d95926"/>
 <text x="91" y="28" font-size="12" fill="#e6edf3">lessons OFF</text>
@@ -16,34 +16,34 @@
 <text x="62" y="125.6" font-size="11" text-anchor="end" fill="#8b949e">60%</text>
 <line x1="74" y1="75.5" x2="830" y2="75.5" stroke="#30363d" stroke-width="1"/>
 <text x="62" y="79.5" font-size="11" text-anchor="end" fill="#8b949e">80%</text>
-<path d="M126.5,260.0 L126.5,174.1 Q126.5,170.1 130.5,170.1 L206.5,170.1 Q210.5,170.1 210.5,174.1 L210.5,260.0 Z" fill="#d95926"/>
-<text x="168.5" y="162.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">39.0%</text>
+<path d="M126.5,260.0 L126.5,157.2 Q126.5,153.2 130.5,153.2 L206.5,153.2 Q210.5,153.2 210.5,157.2 L210.5,260.0 Z" fill="#d95926"/>
+<text x="168.5" y="145.2" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">46.3%</text>
 <text x="168.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">A0</text>
 <text x="168.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">before learning</text>
-<text x="168.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">117/300 passed</text>
-<path d="M315.5,260.0 L315.5,126.4 Q315.5,122.4 319.5,122.4 L395.5,122.4 Q399.5,122.4 399.5,126.4 L399.5,260.0 Z" fill="#3987e5"/>
-<text x="357.5" y="114.4" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">59.7%</text>
+<text x="168.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">139/300 passed</text>
+<path d="M315.5,260.0 L315.5,105.7 Q315.5,101.7 319.5,101.7 L395.5,101.7 Q399.5,101.7 399.5,105.7 L399.5,260.0 Z" fill="#3987e5"/>
+<text x="357.5" y="93.7" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">68.7%</text>
 <text x="357.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">B</text>
 <text x="357.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons applied</text>
-<text x="357.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">179/300 passed</text>
-<path d="M504.5,260.0 L504.5,177.1 Q504.5,173.1 508.5,173.1 L584.5,173.1 Q588.5,173.1 588.5,177.1 L588.5,260.0 Z" fill="#d95926"/>
-<text x="546.5" y="165.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">37.7%</text>
+<text x="357.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">206/300 passed</text>
+<path d="M504.5,260.0 L504.5,155.6 Q504.5,151.6 508.5,151.6 L584.5,151.6 Q588.5,151.6 588.5,155.6 L588.5,260.0 Z" fill="#d95926"/>
+<text x="546.5" y="143.6" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">47.0%</text>
 <text x="546.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">A1</text>
 <text x="546.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons rolled back</text>
-<text x="546.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">113/300 passed</text>
-<path d="M693.5,260.0 L693.5,134.1 Q693.5,130.1 697.5,130.1 L773.5,130.1 Q777.5,130.1 777.5,134.1 L777.5,260.0 Z" fill="#3987e5"/>
-<text x="735.5" y="122.1" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">56.3%</text>
+<text x="546.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">141/300 passed</text>
+<path d="M693.5,260.0 L693.5,109.5 Q693.5,105.5 697.5,105.5 L773.5,105.5 Q777.5,105.5 777.5,109.5 L777.5,260.0 Z" fill="#3987e5"/>
+<text x="735.5" y="97.5" font-size="15" font-weight="700" text-anchor="middle" fill="#e6edf3">67.0%</text>
 <text x="735.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#e6edf3">B2</text>
 <text x="735.5" y="295.0" font-size="11" text-anchor="middle" fill="#8b949e">lessons re-applied</text>
-<text x="735.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">169/300 passed</text>
+<text x="735.5" y="310.0" font-size="10" text-anchor="middle" fill="#8b949e">201/300 passed</text>
 <line x1="74" y1="260" x2="830" y2="260" stroke="#8b949e" stroke-width="1"/>
-<path d="M168.5,97.4 L168.5,88.4 L357.5,88.4 L357.5,97.4" fill="none" stroke="#8b949e" stroke-width="1"/>
-<text x="263.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+20.7 pts</text>
-<text x="263.0" y="85.4" font-size="10" text-anchor="middle" fill="#8b949e">apply · p &lt; 0.0001</text>
-<path d="M357.5,97.4 L357.5,88.4 L546.5,88.4 L546.5,97.4" fill="none" stroke="#8b949e" stroke-width="1"/>
-<text x="452.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">-22.0 pts</text>
-<text x="452.0" y="85.4" font-size="10" text-anchor="middle" fill="#8b949e">roll back · p &lt; 0.0001</text>
-<path d="M546.5,105.1 L546.5,96.1 L735.5,96.1 L735.5,105.1" fill="none" stroke="#8b949e" stroke-width="1"/>
-<text x="641.0" y="82.1" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+18.7 pts</text>
-<text x="641.0" y="93.1" font-size="10" text-anchor="middle" fill="#8b949e">re-apply · p &lt; 0.0001</text>
+<path d="M168.5,76.7 L168.5,67.7 L357.5,67.7 L357.5,76.7" fill="none" stroke="#8b949e" stroke-width="1"/>
+<text x="263.0" y="53.7" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+22.3 pts</text>
+<text x="263.0" y="64.7" font-size="10" text-anchor="middle" fill="#8b949e">apply · p &lt; 0.0001</text>
+<path d="M357.5,76.7 L357.5,67.7 L546.5,67.7 L546.5,76.7" fill="none" stroke="#8b949e" stroke-width="1"/>
+<text x="452.0" y="53.7" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">-21.7 pts</text>
+<text x="452.0" y="64.7" font-size="10" text-anchor="middle" fill="#8b949e">roll back · p &lt; 0.0001</text>
+<path d="M546.5,80.5 L546.5,71.5 L735.5,71.5 L735.5,80.5" fill="none" stroke="#8b949e" stroke-width="1"/>
+<text x="641.0" y="57.5" font-size="12.5" font-weight="700" text-anchor="middle" fill="#e6edf3">+20.0 pts</text>
+<text x="641.0" y="68.5" font-size="10" text-anchor="middle" fill="#8b949e">re-apply · p &lt; 0.0001</text>
 </svg>

--- a/docs/assets/aba-selfimprove-light.svg
+++ b/docs/assets/aba-selfimprove-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="860" height="332" viewBox="0 0 860 332" role="img" aria-labelledby="aba-title aba-desc" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
-<title id="aba-title">An AI agent that learns from its own mistakes: +20.7 points on held-out tasks, and it disappears when you remove what it learned</title>
-<desc id="aba-desc">Areev governed self-improvement benchmark: an AI agent learns from its own tool-use failures, and the learned lessons are applied, rolled back, and re-applied while everything else — model, prompts, tools, and the 300 held-out tasks — is held fixed. A0 before learning: 39.0% (117/300 tasks passed); B lessons applied: 59.7% (179/300 tasks passed); A1 lessons rolled back: 37.7% (113/300 tasks passed); B2 lessons re-applied: 56.3% (169/300 tasks passed). Paired exact McNemar over the same tasks: apply (A0-&gt;B): +20.7 pts, p &lt; 0.0001, b=70 c=8 n=300; roll back (B-&gt;A1): -22.0 pts, p &lt; 0.0001, b=8 c=74 n=300; re-apply (A1-&gt;B2): +18.7 pts, p &lt; 0.0001, b=65 c=9 n=300; control A0-&gt;A1 (same condition, expect no change): p = 0.289, b=2 c=6 n=300; control B-&gt;B2 (same condition, expect no change): p = 0.11, b=11 c=21 n=300. Removing the lessons removes the gain and restoring them brings it back, which is what makes the improvement causal rather than correlational. Measured over 3 seeded runs at temperature zero; b = tasks that failed in the first state and passed in the second, c = the reverse.</desc>
+<title id="aba-title">An AI agent that learns from its own mistakes: +22.3 points on held-out tasks, and it disappears when you remove what it learned</title>
+<desc id="aba-desc">Areev governed self-improvement benchmark: an AI agent learns from its own tool-use failures, and the learned lessons are applied, rolled back, and re-applied while everything else — model, prompts, tools, and the 300 held-out tasks — is held fixed. A0 before learning: 46.3% (139/300 tasks passed); B lessons applied: 68.7% (206/300 tasks passed); A1 lessons rolled back: 47.0% (141/300 tasks passed); B2 lessons re-applied: 67.0% (201/300 tasks passed). Paired exact McNemar over the same tasks: apply (A0-&gt;B): +22.3 pts, p &lt; 0.0001, b=84 c=17 n=300; roll back (B-&gt;A1): -21.7 pts, p &lt; 0.0001, b=19 c=84 n=300; re-apply (A1-&gt;B2): +20.0 pts, p &lt; 0.0001, b=74 c=14 n=300; control A0-&gt;A1 (same condition, expect no change): p = 0.839, b=13 c=11 n=300; control B-&gt;B2 (same condition, expect no change): p = 0.609, b=28 c=33 n=300. Removing the lessons removes the gain and restoring them brings it back, which is what makes the improvement causal rather than correlational. Measured over 3 seeded runs at temperature zero; b = tasks that failed in the first state and passed in the second, c = the reverse.</desc>
 <rect width="860" height="332" fill="#ffffff"/>
 <rect x="74" y="18" width="11" height="11" rx="2" fill="#eb6834"/>
 <text x="91" y="28" font-size="12" fill="#111418">lessons OFF</text>
@@ -16,34 +16,34 @@
 <text x="62" y="125.6" font-size="11" text-anchor="end" fill="#5b6470">60%</text>
 <line x1="74" y1="75.5" x2="830" y2="75.5" stroke="#dfe3e8" stroke-width="1"/>
 <text x="62" y="79.5" font-size="11" text-anchor="end" fill="#5b6470">80%</text>
-<path d="M126.5,260.0 L126.5,174.1 Q126.5,170.1 130.5,170.1 L206.5,170.1 Q210.5,170.1 210.5,174.1 L210.5,260.0 Z" fill="#eb6834"/>
-<text x="168.5" y="162.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">39.0%</text>
+<path d="M126.5,260.0 L126.5,157.2 Q126.5,153.2 130.5,153.2 L206.5,153.2 Q210.5,153.2 210.5,157.2 L210.5,260.0 Z" fill="#eb6834"/>
+<text x="168.5" y="145.2" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">46.3%</text>
 <text x="168.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">A0</text>
 <text x="168.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">before learning</text>
-<text x="168.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">117/300 passed</text>
-<path d="M315.5,260.0 L315.5,126.4 Q315.5,122.4 319.5,122.4 L395.5,122.4 Q399.5,122.4 399.5,126.4 L399.5,260.0 Z" fill="#1f6feb"/>
-<text x="357.5" y="114.4" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">59.7%</text>
+<text x="168.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">139/300 passed</text>
+<path d="M315.5,260.0 L315.5,105.7 Q315.5,101.7 319.5,101.7 L395.5,101.7 Q399.5,101.7 399.5,105.7 L399.5,260.0 Z" fill="#1f6feb"/>
+<text x="357.5" y="93.7" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">68.7%</text>
 <text x="357.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">B</text>
 <text x="357.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons applied</text>
-<text x="357.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">179/300 passed</text>
-<path d="M504.5,260.0 L504.5,177.1 Q504.5,173.1 508.5,173.1 L584.5,173.1 Q588.5,173.1 588.5,177.1 L588.5,260.0 Z" fill="#eb6834"/>
-<text x="546.5" y="165.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">37.7%</text>
+<text x="357.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">206/300 passed</text>
+<path d="M504.5,260.0 L504.5,155.6 Q504.5,151.6 508.5,151.6 L584.5,151.6 Q588.5,151.6 588.5,155.6 L588.5,260.0 Z" fill="#eb6834"/>
+<text x="546.5" y="143.6" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">47.0%</text>
 <text x="546.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">A1</text>
 <text x="546.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons rolled back</text>
-<text x="546.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">113/300 passed</text>
-<path d="M693.5,260.0 L693.5,134.1 Q693.5,130.1 697.5,130.1 L773.5,130.1 Q777.5,130.1 777.5,134.1 L777.5,260.0 Z" fill="#1f6feb"/>
-<text x="735.5" y="122.1" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">56.3%</text>
+<text x="546.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">141/300 passed</text>
+<path d="M693.5,260.0 L693.5,109.5 Q693.5,105.5 697.5,105.5 L773.5,105.5 Q777.5,105.5 777.5,109.5 L777.5,260.0 Z" fill="#1f6feb"/>
+<text x="735.5" y="97.5" font-size="15" font-weight="700" text-anchor="middle" fill="#111418">67.0%</text>
 <text x="735.5" y="279.0" font-size="12" font-weight="600" text-anchor="middle" fill="#111418">B2</text>
 <text x="735.5" y="295.0" font-size="11" text-anchor="middle" fill="#5b6470">lessons re-applied</text>
-<text x="735.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">169/300 passed</text>
+<text x="735.5" y="310.0" font-size="10" text-anchor="middle" fill="#5b6470">201/300 passed</text>
 <line x1="74" y1="260" x2="830" y2="260" stroke="#5b6470" stroke-width="1"/>
-<path d="M168.5,97.4 L168.5,88.4 L357.5,88.4 L357.5,97.4" fill="none" stroke="#5b6470" stroke-width="1"/>
-<text x="263.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+20.7 pts</text>
-<text x="263.0" y="85.4" font-size="10" text-anchor="middle" fill="#5b6470">apply · p &lt; 0.0001</text>
-<path d="M357.5,97.4 L357.5,88.4 L546.5,88.4 L546.5,97.4" fill="none" stroke="#5b6470" stroke-width="1"/>
-<text x="452.0" y="74.4" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">-22.0 pts</text>
-<text x="452.0" y="85.4" font-size="10" text-anchor="middle" fill="#5b6470">roll back · p &lt; 0.0001</text>
-<path d="M546.5,105.1 L546.5,96.1 L735.5,96.1 L735.5,105.1" fill="none" stroke="#5b6470" stroke-width="1"/>
-<text x="641.0" y="82.1" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+18.7 pts</text>
-<text x="641.0" y="93.1" font-size="10" text-anchor="middle" fill="#5b6470">re-apply · p &lt; 0.0001</text>
+<path d="M168.5,76.7 L168.5,67.7 L357.5,67.7 L357.5,76.7" fill="none" stroke="#5b6470" stroke-width="1"/>
+<text x="263.0" y="53.7" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+22.3 pts</text>
+<text x="263.0" y="64.7" font-size="10" text-anchor="middle" fill="#5b6470">apply · p &lt; 0.0001</text>
+<path d="M357.5,76.7 L357.5,67.7 L546.5,67.7 L546.5,76.7" fill="none" stroke="#5b6470" stroke-width="1"/>
+<text x="452.0" y="53.7" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">-21.7 pts</text>
+<text x="452.0" y="64.7" font-size="10" text-anchor="middle" fill="#5b6470">roll back · p &lt; 0.0001</text>
+<path d="M546.5,80.5 L546.5,71.5 L735.5,71.5 L735.5,80.5" fill="none" stroke="#5b6470" stroke-width="1"/>
+<text x="641.0" y="57.5" font-size="12.5" font-weight="700" text-anchor="middle" fill="#111418">+20.0 pts</text>
+<text x="641.0" y="68.5" font-size="10" text-anchor="middle" fill="#5b6470">re-apply · p &lt; 0.0001</text>
 </svg>


### PR DESCRIPTION
Updates the README's benchmark section to the 2026-08-30 run (merged in #151), which is both **stronger** and **methodologically cleaner** than the one it quoted.

The old headline had to carry a caveat: its seeds 1/2/3 collide under the documented seed-derivation defect, so it spans **two** task streams, not three. The new run uses odd seeds — three genuinely independent streams — so that caveat retires.

| what the memory holds | was | now |
|---|---|---|
| nothing learned yet | 39.0% | 46.3% |
| lessons applied | 59.7% | **68.7%** |
| lessons rolled back | 37.7% | 47.0% |
| lessons re-applied | 56.3% | **67.0%** |

+22.3 / −21.7 / +20.0 points, every transition p<0.0001 pooled **and** independently in each of the three streams; both same-condition controls null.

- **Per-rule bullet now carries numbers**, not just a link: refund/cancel ordering 56%→20%, UTC timestamps 37%→20%, rate-limit recovery 76%→50%. RESULTS.md's new table also shows each rule *returning to baseline on rollback* — the ablation visible per rule, not only in aggregate.
- **Attribution is explicit.** The passive-arms bullet is marked as the earlier run's (this one didn't repeat them); the 2026-08-26 section keeps its tables and its two-stream bound; the LLM-arm comparison from #151 is untouched and stays in RESULTS.md.
- **Cost re-derived rather than inherited.** The two 2026-08-30 rows in the cost table are labelled as scaled from measured token counts, not billed — the $2.30 row remains the measured one.
- **`aba_chart.py --prefix`**: the new results set holds two configurations, and without a filter the chart would have pooled control and arm into bars describing a population that was never run. The stats behind the bars are filtered by the same prefix so picture and p-values can't describe different populations.

Verified: both results sets pass `verify_run.py`, `aba_arm_stats.py --selftest` passes, `repo_stats.py --check` clean, the old run's chart still generates without `--prefix` (no regression), and all three README→RESULTS.md anchors resolve.