### PR TITLE
docs: stop presenting "no model key" as the point of the learning

### DIFF
--- a/docs/loop.md
+++ b/docs/loop.md
@@ -68,9 +68,14 @@ capture  (tool calls, facts, events)        — record_tool_call / add / import
   → measure   (outcome review)               — re-run the metric, revert on regression
 ```
 
-The loop closes with **no LLM**. Every recommendation cites the grains it was
-computed from; every apply stores its inverse (or is marked non-rollbackable
-up front); every decision carries a written reason.
+The loop closes **without requiring an LLM** — a floor that always runs, not
+a ceiling, and not a boast: deterministic signature lessons are also what
+measured strongest on the self-improvement benchmark
+([RESULTS.md](../crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof)),
+and `--llm-cmd` adds verified reflection on top where judgement needs
+language. Whichever runs, the guarantees are the same: every recommendation
+cites the grains it was computed from; every apply stores its inverse (or is
+marked non-rollbackable up front); every decision carries a written reason.
 
 ## The four gates
 

--- a/examples/agents/clinical-referrals/README.md
+++ b/examples/agents/clinical-referrals/README.md
@@ -144,7 +144,10 @@ Then the desk reads its own record:
   namespace.
 - **`areev loop run` finds the cluster**: `HIGH — Workflow e9cb3f56c7b8
   failed 3/9 recent runs (33%): extract: … REF-2205 is missing required
-  identifier(s): date`. Deterministic analyzers; no model key involved.
+  identifier(s): date`. Found by deterministic analyzers — the lesson kind
+  that measured stronger than LLM-authored ones on our benchmark
+  ([RESULTS.md](../../../crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof)),
+  and keyless besides; `LOOP_LLM_CMD` adds verified LLM reflection on top.
 - **The gate holds**: the engine refuses to apply its own advisory finding,
   and refuses any decision with no written reason. A clinician approves it,
   signing name and reasoning — and the reasoning is *don't relax the check*.

--- a/examples/agents/hiring-screening/README.md
+++ b/examples/agents/hiring-screening/README.md
@@ -185,8 +185,11 @@ Two more applicants, and four more broken ATS exports.
   the criteria and the grants under a token budget.
 - **`areev loop run` finds the cluster**: `Tool "parse_application" failed
   10 times (45% of the calls that could fail this way): unreadable: the
-  uploaded file has no text layer`. Deterministic analyzers; no model key
-  was involved.
+  uploaded file has no text layer`. Found by deterministic analyzers —
+  the lesson kind that measured stronger than LLM-authored ones on our
+  benchmark ([RESULTS.md](../../../crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof)),
+  and keyless besides. `LOOP_LLM_CMD` adds verified LLM reflection on top
+  where a finding needs language.
 - **The gates hold.** The pass proposed one finding and applied none; a
   blank `BECAUSE` is refused by the engine (`LOP-E011`); a recruiter
   approves with a reason; approving the same finding twice is refused

--- a/examples/agents/incident-response/README.md
+++ b/examples/agents/incident-response/README.md
@@ -140,7 +140,11 @@ Then the desk reads its own record:
 - **`areev loop run` finds the pattern**: `HIGH — Workflow fe5f922214b7
   failed 3/9 recent runs (33%): apply_remediation: … rollback refused —
   ledger-sync deploy channel is pinned (release freeze); the runbook step
-  cannot execute`. Deterministic analyzers; no model key involved. (The smoke
+  cannot execute`. Found by deterministic analyzers — the lesson kind that
+  measured stronger than LLM-authored ones on our benchmark
+  ([RESULTS.md](../../../crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof)),
+  and keyless besides; `LOOP_LLM_CMD` adds verified LLM reflection on top.
+  (The smoke
   also tunes them to a low-volume desk with `set_analyzer_config` — at nine
   runs a fortnight the stock thresholds would stay silent for a quarter.)
 - **The gate holds**: the engine refuses to apply its own advisory finding,

--- a/examples/agents/invoice-to-accounting/README.md
+++ b/examples/agents/invoice-to-accounting/README.md
@@ -112,8 +112,12 @@ Then the desk reads its own record:
   describing its current setup — its queries, grains, and workflows — from
   the same file it runs on.
 - **`areev loop run` finds the pattern**: `HIGH — Workflow 3da2300c1296
-  failed 4/9 recent runs (44%): parse_attachments: … scanned image`. The
-  analyzers are deterministic; no model key was involved. (The smoke also
+  failed 4/9 recent runs (44%): parse_attachments: … scanned image`. Found
+  by deterministic analyzers — the lesson kind that measured stronger than
+  LLM-authored ones on our benchmark
+  ([RESULTS.md](../../../crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof)),
+  and keyless besides; `LOOP_LLM_CMD` adds verified LLM reflection on top.
+  (The smoke also
   shows tuning them to a low-volume desk via `set_analyzer_config` — at
   four invoices a week, the stock thresholds would stay silent a quarter.)
 - **The gate holds**: the engine refuses to apply its own advisory finding,

--- a/examples/agents/sanctions-screening/README.md
+++ b/examples/agents/sanctions-screening/README.md
@@ -109,7 +109,10 @@ the journal.
 Then the part no other example in this repo can show:
 
 1. **`areev loop run` finds the cluster** — `failed 3/8 recent runs (38%):
-   screen: … is not readable ASCII`. Deterministic analyzers; no model key.
+   screen: … is not readable ASCII`. Found by deterministic analyzers — the
+   lesson kind that measured stronger than LLM-authored ones on our benchmark
+   ([RESULTS.md](../../../crates/areev-bench/RESULTS.md#areev-loop-self-improvement--the-abab-causal-proof)),
+   and keyless besides; `LOOP_LLM_CMD` adds verified LLM reflection on top.
 2. **The gate holds.** The engine refuses to apply its own advisory finding,
    and refuses any decision with no written reason.
 3. **A person approves, signing name and reasoning.**

--- a/examples/hermes/areev/__init__.py
+++ b/examples/hermes/areev/__init__.py
@@ -373,7 +373,12 @@ class AreevMemoryProvider(MemoryProvider):
         return ""
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
-        """Deterministic analyzers only — no LLM, no network. Findings are
+        """Run the loop's deterministic analyzers over the session.
+
+        Deterministic because that is what measured stronger on the
+        self-improvement benchmark, not because avoiding a model is a goal
+        in itself; it also keeps this hook free of keys and network. Wire
+        `--llm-cmd` on the CLI to add verified LLM reflection. Findings are
         advisory recommendation grains that never auto-apply."""
         if not self._db or not self._writable:
             return


### PR DESCRIPTION
**Why:** "Deterministic analyzers; no model key was involved" had spread to five example READMEs and the hermes hook docstring. The phrasing leaked out of the keyless-CI context — where "no credentials, no network, no model key" is an accurate reproducibility statement — into the **learning** sections, where it reads as pride in avoiding a model.

That's the wrong frame. The goal is to learn in the best way and give the best outcome to the end user; whether an LLM is involved matters much less. Keyless is a nice-to-have floor, not a virtue — and as a boast it answers a procurement question when the reader is asking a quality one: *without an LLM, how does it propose learning intelligently?*

**What changed** — outcome-first in every learning passage:

> ~~Deterministic analyzers; no model key was involved.~~
> Found by deterministic analyzers — the lesson kind that measured stronger than LLM-authored ones on our benchmark ([RESULTS.md](../crates/areev-bench/RESULTS.md)), and keyless besides. `LOOP_LLM_CMD` adds verified LLM reflection on top where a finding needs language.

The evidence claim is real (the three-seed comparison in #151), and the `LOOP_LLM_CMD` pointer is real too — all five examples already read that env var in `improve()`, so it's a working knob, not aspiration. `docs/loop.md`'s positioning sentence gets the same treatment: closing without an LLM is a **floor that always runs, not a ceiling and not a boast**.

**Deliberately unchanged:** the nine "Nothing here needs a credential, a network, or a model key: … so CI proves it on every release" passages, and every `smoke.sh` / `CLAUDE.md` keyless-floor rule. There the claim is about reproducibility without secrets, which is exactly what it says — that distinction is the whole point of this change.

Verified: hermes module still parses, all five relative RESULTS.md links resolve, no learning-context boast remains (`grep`), `repo_stats.py --check` clean.