### PR TITLE
loop: seed tool failures into the LLM's evidence, and the 2x2 arm switch

### DIFF
--- a/crates/areev-bench/SELFIMPROVE.md
+++ b/crates/areev-bench/SELFIMPROVE.md
@@ -96,13 +96,13 @@ task) and stays correctly silent on the 66 failures the agent self-corrected.
                 deterministic analyzers; scripted review applies the pending
                 lessons under a distinct reviewer actor, recording the full
                 ledger (applied / rejected / advisory).
-                Honesty note: LLM DISCOVER findings are ADVISORY by design
-                today (`Proposal::Data`, apply refuses) — they are counted
-                in the ledger and scored for reliability, but the executable
-                lessons that drive the causal arm are the analyzer proposals
-                (`tool_failure` → `ADD fact`, rollbackable). The engine
-                feature that makes verified LLM findings executable is on
-                the roadmap below; this bench absorbs it without redesign.
+                Which ORIGINS the review admits is the arm (`--llm-lessons`,
+                `--no-analyzer-lessons`): by default only analyzer proposals
+                (`tool_failure` → `ADD fact`, rollbackable) are applied and
+                LLM findings stay advisory — the published runs' policy. A
+                gate-surviving LLM draft that authored a lesson is applicable
+                too; every finding of either origin is ledgered regardless of
+                whether its arm admits it.
 3  EVAL A0      held-out set, prompt assembled from LIVE memory → no lessons
                 exist yet at A0-time is *not* how we do it: A0 is measured
                 with recommendations still pending (proposed, not applied),
@@ -195,6 +195,60 @@ seed 3 a dose-0 internal control and turned the result into a dose-response;
 and the B2 caveat proved stronger than written — an authored lesson is not
 merely re-authored rather than re-derived, it may not be re-authored at all.
 Full write-up: RESULTS.md, "Does an LLM write better lessons?".
+
+### Pre-registered interpretation — the 2x2, does LLM-authored learning self-improve ALONE (written before its runs)
+
+Committed 2026-08-30, after the first arm result and before any run of this
+design. The earlier comparison was `(deterministic)` vs
+`(deterministic + LLM)`; it never isolated the LLM, so it could not answer
+whether LLM-authored lessons self-improve **on their own**. This does.
+
+**Design.** Seeds 1/3/5, 300/100, same model pair, four cells over one axis
+each — *which lesson ORIGINS the review gate admits*. The analyzers always
+run, in every cell, so discovery is held constant and only application
+varies:
+
+| cell | analyzer lessons | LLM lessons | status |
+|---|---|---|---|
+| control | applied | advisory | **reused** — 2026-08-30 `governed-*` |
+| combined | applied | applied | **re-run** at this rev |
+| llm-only | advisory | applied | **new** (`--no-analyzer-lessons`) |
+| neither | advisory | advisory | **is state A0 by construction** — already measured in every run |
+
+Two runs are new because an engine fix at this rev changes what the LLM can
+see: the DISCOVER evidence bundle now seeds recent **Tool error grains**, not
+only Facts and Observations. Before it, the LLM saw a tool failure only if a
+deterministic finding happened to cite it — it could elaborate on what
+clustering caught but never find what clustering missed, which is the one
+thing it is there for. Every earlier LLM number was measured under that
+handicap and is superseded for comparison. The control is reused rather than
+re-run because the fix cannot change which lessons it applies (LLM findings
+stay advisory there); the A0 drift check below is what would catch that
+assumption being wrong.
+
+**The primary question is the llm-only cell's own causal chain** — A0→B,
+B→A1, A1→B2, each pooled-significant, which is the same bar the deterministic
+loop had to clear.
+
+- **Chain holds:** LLM-authored lessons self-improve on their own. Published
+  as that, with the effect size and the comparison against the deterministic
+  cell stated side by side — parity or a loss there does not retract it.
+- **Chain does not hold:** they do not, on this workload at this dose.
+  Published as that, and NOT as "LLM learning does not work": this workload's
+  six hidden rules are all tool-failure-shaped, which is precisely what
+  signature clustering detects, so it gives an LLM no headroom by
+  construction. That bound ships with the result.
+- **Interaction:** if `combined < control` while `llm-only > A0`, the earlier
+  finding sharpens from "authored lessons underperform" to **interference** —
+  they work alone and degrade the deterministic set they are added to.
+
+**Reported for every cell, whatever lands:** the authored-lesson DOSE per seed
+per pass (the LLM does not author on every pass; a cell whose B carried zero
+authored lessons is a dose-0 observation and evidence about nothing else), the
+A0 cross-cell drift check (all four cells are ignorant at A0, so a significant
+difference there is provider drift and invalidates that pairing rather than
+supporting it), per-rule recurrence, token cost, the governance ledgers, and
+the full transcripts.
 
 ## Runner protocol — one JSON per line on stdio
 
@@ -505,6 +559,7 @@ the prompt to re-run.
 | `--llm-cmd` / `--ground-cmd 'CMD'` | the loop's DISCOVER/VERIFY and GROUND backends (**loop** protocol) |
 | `--mock-llm` | keyless canned loop-LLM (authors one fixed lesson) in place of `--llm-cmd`; the two are mutually exclusive |
 | `--llm-lessons` | the **loop+LLM arm**: the scripted review also approves + applies LLM-authored lessons, and they render into LESSONS. Requires `--llm-cmd` or `--mock-llm`. Off = the published-run review policy, byte-for-byte |
+| `--no-analyzer-lessons` | suppress APPLYING analyzer lessons; the analyzers still run, so the LLM's evidence is unchanged. With `--llm-lessons` this is the **llm-only** cell of the 2x2. Refused on its own — nothing would apply and B would be a second A0 |
 | `--arms LIST` | comma list of `m-steel,m-all,m-llm,m-cmd`; empty = governed states only |
 | `--context-cmd 'CMD'` | the external context provider; required by (and only by) `m-cmd` |
 | `--mllm-cmd 'CMD'` | chat adapter for the `m-llm` summarizer; defaults to `--agent-cmd`, unused under `--mock` |

--- a/crates/areev-bench/src/bin/selfimprove_aba.rs
+++ b/crates/areev-bench/src/bin/selfimprove_aba.rs
@@ -42,7 +42,7 @@
 //! one thread.
 
 use areev_bench::selfimprove::context::{ContextProvider, ExperienceGrain};
-use areev_bench::selfimprove::memory::{Memory, MockLoopLlm};
+use areev_bench::selfimprove::memory::{LessonArms, Memory, MockLoopLlm};
 use areev_loop::{CommandLlm, LlmBackend};
 use areev_bench::selfimprove::{agent, context, env, report::Reporter};
 use areev_bench::selfimprove::{EvalSummary, Ledger, RuleId, RuleStat, TaskRunRecord, Usage};
@@ -73,6 +73,10 @@ struct Args {
     /// The `loop+LLM` arm: the scripted review also approves + applies
     /// LLM-authored lessons. Off = the published-run review policy.
     llm_lessons: bool,
+    /// Suppress APPLYING analyzer lessons (the analyzers still run, so the
+    /// LLM's evidence is unchanged). With `--llm-lessons` this is the
+    /// LLM-only cell of the 2x2.
+    no_analyzer_lessons: bool,
     /// Keyless canned loop-LLM (shape runs) in place of `--llm-cmd`.
     mock_llm: bool,
     /// Requested passive arms, deduped, in the order given (empty = the
@@ -88,6 +92,11 @@ struct Args {
 impl Args {
     fn wants(&self, arm: &str) -> bool {
         self.arms.iter().any(|a| a == arm)
+    }
+
+    /// Which lesson origins this run may apply — the 2x2 cell it measures.
+    fn lesson_arms(&self) -> LessonArms {
+        LessonArms { analyzer: !self.no_analyzer_lessons, llm: self.llm_lessons }
     }
 
     /// The chat adapter the m-llm summarizer runs on: its own flag, else the
@@ -119,7 +128,7 @@ fn usage() -> ! {
         "usage: selfimprove_aba --workdir PATH (--mock | --agent-cmd 'CMD')\n\
          \x20                       [--seed N] [--experience N] [--eval N]\n\
          \x20                       [--llm-cmd 'CMD' | --mock-llm] [--ground-cmd 'CMD']\n\
-         \x20                       [--llm-lessons]\n\
+         \x20                       [--llm-lessons] [--no-analyzer-lessons]\n\
          \x20                       [--arms m-steel,m-all,m-llm,m-cmd]\n\
          \x20                       [--context-cmd 'CMD'] [--mllm-cmd 'CMD']\n\
          \x20                       [--workers N] [--max-turns N] [--assert-shape]"
@@ -169,6 +178,7 @@ fn parse_args() -> Args {
     let mut assert_shape = false;
     let mut llm_lessons = false;
     let mut mock_llm = false;
+    let mut no_analyzer_lessons = false;
 
     let mut i = 0;
     while i < argv.len() {
@@ -187,6 +197,10 @@ fn parse_args() -> Args {
             }
             "--mock-llm" => {
                 mock_llm = true;
+                i += 1;
+            }
+            "--no-analyzer-lessons" => {
+                no_analyzer_lessons = true;
                 i += 1;
             }
             flag => {
@@ -245,6 +259,13 @@ fn parse_args() -> Args {
         eprintln!("selfimprove_aba: --llm-lessons requires --llm-cmd or --mock-llm");
         usage()
     }
+    // Without --llm-lessons this would apply NOTHING, making B a second
+    // measurement of A0 under a label that claims otherwise.
+    if no_analyzer_lessons && !llm_lessons {
+        eprintln!("selfimprove_aba: --no-analyzer-lessons requires --llm-lessons \
+                   (otherwise no lesson is applied at all and B is just another A0)");
+        usage()
+    }
     Args {
         workdir,
         seed,
@@ -255,6 +276,7 @@ fn parse_args() -> Args {
         llm_cmd,
         ground_cmd,
         llm_lessons,
+        no_analyzer_lessons,
         mock_llm,
         arms,
         context_cmd,
@@ -679,7 +701,7 @@ fn check_shape(
     eval_n: u32,
     applied1: &[String],
     applied2: &[String],
-    llm_lessons: bool,
+    lesson_arms: LessonArms,
 ) {
     let (a0, b, a1, b2) = (&evals[0], &evals[1], &evals[2], &evals[3]);
     let mut fails = Vec::new();
@@ -706,21 +728,28 @@ fn check_shape(
     // (--llm-lessons): authored lessons are the point, so at least one must
     // apply — an arm that admitted nothing new measured the governed states
     // twice under a different name.
-    if llm_lessons {
-        if !applied1.iter().any(|sig| sig.starts_with("llm :: ")) {
+    let is_llm = |sig: &String| sig.starts_with("llm :: ");
+    if lesson_arms.llm {
+        if !applied1.iter().any(is_llm) {
             fails.push(
                 "--llm-lessons applied no LLM-authored lesson — the arm measured nothing new"
                     .to_string(),
             );
         }
     } else {
-        for sig in applied1.iter().chain(applied2) {
-            if !sig.starts_with("loop.") {
-                fails.push(format!(
-                    "applied a non-analyzer lesson ({sig}) — LLM findings stay advisory \
-                     outside --llm-lessons"
-                ));
-            }
+        for sig in applied1.iter().chain(applied2).filter(|s| is_llm(s)) {
+            fails.push(format!(
+                "applied an LLM lesson ({sig}) — LLM findings stay advisory outside \
+                 --llm-lessons"
+            ));
+        }
+    }
+    if !lesson_arms.analyzer {
+        for sig in applied1.iter().chain(applied2).filter(|s| !is_llm(s)) {
+            fails.push(format!(
+                "applied an analyzer lesson ({sig}) under --no-analyzer-lessons — the \
+                 LLM-only cell would be measuring both"
+            ));
         }
     }
     if b.success_rate() <= a0.success_rate() + 0.1 {
@@ -766,7 +795,7 @@ fn check_shape(
     if fails.is_empty() {
         println!("\nassert-shape: PASS (B > A0 + 0.10, |A1−A0| ≤ 0.05, |B2−B| ≤ 0.05, A1 lessons empty)");
         let llm_applied = applied1.iter().filter(|s| s.starts_with("llm :: ")).count();
-        let origins = if llm_lessons {
+        let origins = if lesson_arms.llm {
             format!("{} analyzer + {llm_applied} llm-authored", applied1.len() - llm_applied)
         } else {
             "all analyzer-origin".to_string()
@@ -836,7 +865,7 @@ fn main() {
     // + applied, destructive rejected, advisory ledgered) → eval B.
     let (llm, ground) = loop_llm_backends(&args);
     let (ledger1, applied1) = mem
-        .learn_with(llm, ground, args.llm_lessons, t_learn1)
+        .learn_with(llm, ground, args.lesson_arms(), t_learn1)
         .unwrap_or_else(|e| die(&e));
     eprintln!(
         "learn 1: {} ledger rows, {} applied",
@@ -860,7 +889,7 @@ fn main() {
     // whole governed path a second time: re-propose → approve → apply.
     let (llm, ground) = loop_llm_backends(&args);
     let (ledger2, applied2) = mem
-        .learn_with(llm, ground, args.llm_lessons, t_learn2)
+        .learn_with(llm, ground, args.lesson_arms(), t_learn2)
         .unwrap_or_else(|e| die(&e));
     eprintln!(
         "learn 2: {} ledger rows, {} applied",
@@ -927,6 +956,7 @@ fn main() {
         "llm_cmd": args.llm_cmd,
         "ground_cmd": args.ground_cmd,
         "llm_lessons": args.llm_lessons,
+        "no_analyzer_lessons": args.no_analyzer_lessons,
         "mock_llm": args.mock_llm,
         "arms": args.arms,
         "context_cmd": args.context_cmd,
@@ -946,7 +976,7 @@ fn main() {
     print_results(&args, &evals, &ledger, applied1.len(), applied2.len());
 
     if args.assert_shape {
-        check_shape(&evals, args.eval as u32, &applied_sig1, &applied_sig2, args.llm_lessons);
+        check_shape(&evals, args.eval as u32, &applied_sig1, &applied_sig2, args.lesson_arms());
     }
 }
 
@@ -966,6 +996,7 @@ mod tests {
             llm_cmd: None,
             ground_cmd: None,
             llm_lessons: false,
+            no_analyzer_lessons: false,
             mock_llm: false,
             arms: vec![],
             context_cmd: None,
@@ -1112,7 +1143,7 @@ mod tests {
             summary("M-all", 10, 8),
         ];
         let applied = vec!["loop.tool_failure/1 :: Tool \"refund\" failed".to_string()];
-        check_shape(&evals, 10, &applied, &applied, false);
+        check_shape(&evals, 10, &applied, &applied, LessonArms::default());
     }
 
     /// The loop+LLM arm's passing shape: an llm-authored signature applied
@@ -1131,7 +1162,7 @@ mod tests {
             "llm :: the same tool failure keeps recurring — record lesson: \"...\"".to_string(),
             "loop.tool_failure/1 :: Tool \"refund\" failed".to_string(),
         ];
-        check_shape(&evals, 10, &applied, &applied, true);
+        check_shape(&evals, 10, &applied, &applied, LessonArms { analyzer: true, llm: true });
     }
 
     /// The signature list is what makes the restoration check possible across

--- a/crates/areev-bench/src/selfimprove/memory.rs
+++ b/crates/areev-bench/src/selfimprove/memory.rs
@@ -38,20 +38,39 @@ enum ReviewAction {
     ApproveApply,
 }
 
+/// Which lesson origins this run is allowed to APPLY. The analyzers always
+/// run either way — holding discovery constant is what makes the 2x2 read as
+/// one variable per axis — so this governs the review gate only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LessonArms {
+    /// Apply deterministic analyzer lessons (the published default).
+    pub analyzer: bool,
+    /// Apply LLM-authored lessons that survived GROUND + VERIFY.
+    pub llm: bool,
+}
+
+impl Default for LessonArms {
+    fn default() -> Self {
+        LessonArms { analyzer: true, llm: false }
+    }
+}
+
 /// The scripted review policy. Order matters: a `Proposal::Data` is advisory
-/// whatever authored it, and an LLM finding — even an executable authored
-/// lesson (`Proposal::Cal`) — stays advisory unless the run deliberately
-/// opted into the `loop+LLM` arm (`llm_lessons`). The published governed runs
-/// predate that arm, so the default keeps their review policy byte-for-byte.
+/// whatever authored it, and an executable lesson is applied only if this run
+/// opted into its ORIGIN. The default (`analyzer` on, `llm` off) is the
+/// published governed runs' policy, byte-for-byte.
 fn review_action(
     origin: &Origin,
     proposal: &Proposal,
     destructive: bool,
-    llm_lessons: bool,
+    arms: LessonArms,
 ) -> ReviewAction {
-    if matches!(proposal, Proposal::Data { .. })
-        || (matches!(origin, Origin::Llm { .. }) && !llm_lessons)
-    {
+    let origin_admitted = if matches!(origin, Origin::Llm { .. }) {
+        arms.llm
+    } else {
+        arms.analyzer
+    };
+    if matches!(proposal, Proposal::Data { .. }) || !origin_admitted {
         ReviewAction::Advisory
     } else if destructive {
         ReviewAction::Reject
@@ -245,19 +264,19 @@ impl Memory {
             )),
             None => None,
         };
-        self.learn_with(llm, ground, false, now_ms)
+        self.learn_with(llm, ground, LessonArms::default(), now_ms)
     }
 
-    /// [`learn`] with pre-built loop backends and the `loop+LLM` arm switch.
-    /// With `llm_lessons` on, the scripted review also approves + applies
-    /// LLM-authored lessons — the applicable, non-destructive `Proposal::Cal`
-    /// recommendations the engine stamps for gate-surviving lesson drafts.
-    /// Advisory LLM `Proposal::Data` findings stay advisory either way.
+    /// [`learn`] with pre-built loop backends and an explicit [`LessonArms`]
+    /// — which lesson ORIGINS this run may apply. The analyzers always run;
+    /// only the review gate changes, so the 2x2 (analyzer on/off x llm
+    /// on/off) varies one thing per axis. Advisory `Proposal::Data` findings
+    /// stay advisory in every arm.
     pub fn learn_with(
         &self,
         llm: Option<Box<dyn LlmBackend>>,
         ground: Option<Box<dyn LlmBackend>>,
-        llm_lessons: bool,
+        arms: LessonArms,
         now_ms: i64,
     ) -> Result<(Ledger, Vec<String>), String> {
         let mut engine = Engine::with_builtins();
@@ -286,7 +305,7 @@ impl Memory {
                 r.analyzer.clone()
             };
             let summary = r.summary.render();
-            match review_action(&r.origin, &r.proposal, r.destructive, llm_lessons) {
+            match review_action(&r.origin, &r.proposal, r.destructive, arms) {
                 ReviewAction::Advisory => ledger.entries.push(LedgerEntry {
                     hash: r.hash.clone(),
                     source,
@@ -699,20 +718,30 @@ mod tests {
         let data = Proposal::Data { data: Map::new() };
         let llm = Origin::Llm { model: "test-model".to_string() };
 
-        // The published-run policy (llm_lessons = false), byte-for-byte.
-        assert_eq!(review_action(&llm, &cal, false, false), ReviewAction::Advisory);
-        assert_eq!(review_action(&llm, &data, false, false), ReviewAction::Advisory);
-        assert_eq!(review_action(&Origin::Builtin, &data, false, false), ReviewAction::Advisory);
-        assert_eq!(review_action(&Origin::Builtin, &cal, true, false), ReviewAction::Reject);
-        assert_eq!(review_action(&Origin::Builtin, &cal, false, false), ReviewAction::ApproveApply);
+        let det_only = LessonArms::default();
+        let both = LessonArms { analyzer: true, llm: true };
+        let llm_only = LessonArms { analyzer: false, llm: true };
 
-        // The loop+LLM arm: authored lessons apply; Data stays advisory; a
+        // The published-run policy (analyzer only), byte-for-byte.
+        assert_eq!(review_action(&llm, &cal, false, det_only), ReviewAction::Advisory);
+        assert_eq!(review_action(&llm, &data, false, det_only), ReviewAction::Advisory);
+        assert_eq!(review_action(&Origin::Builtin, &data, false, det_only), ReviewAction::Advisory);
+        assert_eq!(review_action(&Origin::Builtin, &cal, true, det_only), ReviewAction::Reject);
+        assert_eq!(review_action(&Origin::Builtin, &cal, false, det_only), ReviewAction::ApproveApply);
+
+        // Both arms: authored lessons apply; Data stays advisory; a
         // destructive llm payload (cannot be stamped today) would reject,
         // never apply.
-        assert_eq!(review_action(&llm, &cal, false, true), ReviewAction::ApproveApply);
-        assert_eq!(review_action(&llm, &data, false, true), ReviewAction::Advisory);
-        assert_eq!(review_action(&llm, &cal, true, true), ReviewAction::Reject);
-        assert_eq!(review_action(&Origin::Builtin, &cal, false, true), ReviewAction::ApproveApply);
+        assert_eq!(review_action(&llm, &cal, false, both), ReviewAction::ApproveApply);
+        assert_eq!(review_action(&llm, &data, false, both), ReviewAction::Advisory);
+        assert_eq!(review_action(&llm, &cal, true, both), ReviewAction::Reject);
+        assert_eq!(review_action(&Origin::Builtin, &cal, false, both), ReviewAction::ApproveApply);
+
+        // LLM-only: the analyzers still RUN (their findings are ledgered and
+        // still seed the LLM's evidence), but only authored lessons reach
+        // memory — which is what isolates the LLM's contribution.
+        assert_eq!(review_action(&llm, &cal, false, llm_only), ReviewAction::ApproveApply);
+        assert_eq!(review_action(&Origin::Builtin, &cal, false, llm_only), ReviewAction::Advisory);
     }
 
     /// The loop+LLM arm end-to-end at bench level: the mock loop-LLM authors
@@ -729,7 +758,7 @@ mod tests {
         // Arm OFF: the authored lesson survives the gates but is ledgered
         // advisory — nothing llm-origin applies, no rule line renders.
         let (ledger, applied) = mem
-            .learn_with(Some(Box::new(MockLoopLlm)), None, false, T1)
+            .learn_with(Some(Box::new(MockLoopLlm)), None, LessonArms::default(), T1)
             .unwrap();
         assert!(
             ledger.entries.iter().any(|e| e.source == "llm" && e.disposition == "advisory"),
@@ -741,8 +770,9 @@ mod tests {
 
         // Arm ON: approved + applied through the same scripted review, and
         // the rule renders under the LESSONS heading the agent scans.
+        let arms = LessonArms { analyzer: true, llm: true };
         let (ledger, applied) = mem
-            .learn_with(Some(Box::new(MockLoopLlm)), None, true, T3)
+            .learn_with(Some(Box::new(MockLoopLlm)), None, arms, T3)
             .unwrap();
         assert!(
             ledger.entries.iter().any(|e| e.source == "llm" && e.disposition == "applied"),
@@ -759,7 +789,7 @@ mod tests {
 
         // Restoration is a fresh governed pass (rolled_back is terminal).
         let (_, applied2) = mem
-            .learn_with(Some(Box::new(MockLoopLlm)), None, true, T3 + 2 * HOUR_MS)
+            .learn_with(Some(Box::new(MockLoopLlm)), None, arms, T3 + 2 * HOUR_MS)
             .unwrap();
         assert!(!applied2.is_empty());
         assert!(mem.lessons_markdown().unwrap().contains(MOCK_LLM_LESSON));

--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -566,6 +566,36 @@ impl Engine {
             namespaces.iter().map(|n| Some(n.as_str())).collect()
         };
         let opts = ReadOpts { live_only: true, since_ms: watermark };
+        // Tool grains carry the raw experience of a tool-using agent, and an
+        // ERROR is the part a reflection pass can act on. Seeded FIRST and
+        // capped at half the bundle so a busy desk cannot crowd out the facts
+        // and observations below.
+        //
+        // Without this the LLM saw tool failures only through the
+        // deterministic findings that happened to cite them: it could
+        // elaborate on what clustering already caught, but could never find
+        // a failure clustering missed — the one thing it is here for. The
+        // top-up below called itself "non-parasitic" while omitting the very
+        // grain type the flagship analyzer reads.
+        const TOOL_SEED_CAP: usize = 32;
+        let mut tool_seeded = 0usize;
+        'tools: for ns in &scan_ns {
+            if let Ok(recent) = sub.grains_of_type(crate::model::grain_type::TOOL, *ns, opts) {
+                for g in recent {
+                    if tool_seeded >= TOOL_SEED_CAP || evidence.len() >= 64 {
+                        break 'tools;
+                    }
+                    if !g.is_error() {
+                        continue;
+                    }
+                    let before = evidence.len();
+                    push_evidence(&mut evidence, &mut bundle, &mut ns_by_hash, &g);
+                    if evidence.len() > before {
+                        tool_seeded += 1;
+                    }
+                }
+            }
+        }
         'seed: for gt in [
             crate::model::grain_type::FACT,
             crate::model::grain_type::OBSERVATION,

--- a/crates/areev-loop/src/integration.rs
+++ b/crates/areev-loop/src/integration.rs
@@ -678,6 +678,79 @@ fn tool_grain_evidence_reaches_the_llm_with_text() {
     }
 }
 
+#[test]
+fn llm_sees_tool_failures_no_analyzer_flagged() {
+    use std::sync::{Arc, Mutex};
+    struct RecordingLlm {
+        inner: MockLlm,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+    impl crate::llm::LlmBackend for RecordingLlm {
+        fn model(&self) -> &str {
+            "recording-mock"
+        }
+        fn complete(&self, request: &str) -> crate::error::Result<String> {
+            self.seen.lock().unwrap().push(request.to_string());
+            self.inner.complete(request)
+        }
+    }
+    let mut sub = TestSubstrate::new();
+    // TWO failures against many successes: far under tool_failure's
+    // threshold, so NO analyzer flags anything and `candidates` is empty.
+    // The LLM must still see the failures — that is the whole point of a
+    // reflection pass, and before the tool-grain seeding it saw nothing
+    // here and abstained on an empty bundle.
+    for _ in 0..2 {
+        sub.add_tool_call("stripe_refund", true, "cancelled_before_refund");
+    }
+    for _ in 0..20 {
+        sub.add_tool_call("stripe_refund", false, "{\"ok\":true}");
+    }
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let e = Engine::with_builtins().with_llm(Box::new(RecordingLlm {
+        inner: MockLlm {
+            discover: r#"{"recommendations":[]}"#.to_string(),
+            ground: r#"{"results":[]}"#.to_string(),
+            verify: r#"{"results":[]}"#.to_string(),
+            enrich: r#"{"notes":[]}"#.to_string(),
+        },
+        seen: Arc::clone(&seen),
+    }));
+    e.run(&mut sub.inner, &RunOptions::default(), 10_000).unwrap();
+    let seen = seen.lock().unwrap();
+    let discover = seen
+        .iter()
+        .find(|r| r.contains("\"op\":\"discover\""))
+        .expect("DISCOVER runs even with no deterministic finding to elaborate");
+    let v: serde_json::Value = serde_json::from_str(discover).unwrap();
+    assert!(
+        v["findings"].as_array().is_none_or(|f| f.is_empty()),
+        "precondition: no analyzer flagged anything"
+    );
+    let tools: Vec<_> = v["evidence"]
+        .as_array()
+        .expect("evidence")
+        .iter()
+        .filter(|i| i["grain_type"] == "tool")
+        .collect();
+    assert_eq!(tools.len(), 2, "both unflagged failures reach the bundle");
+    for t in tools {
+        let text = t["text"].as_str().unwrap_or("");
+        assert!(
+            text.contains("cancelled_before_refund"),
+            "the failure body is what makes it actionable, got {text:?}"
+        );
+    }
+    // Successes are not seeded: at a 64-item budget they are noise, and the
+    // 20 here would otherwise crowd out everything else.
+    assert!(
+        v["evidence"].as_array().unwrap().iter().all(|i| {
+            i["grain_type"] != "tool" || i["text"].as_str().unwrap_or("").contains("error")
+        }),
+        "only error tool grains are seeded"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn external_command_analyzer_surfaces_advisory_findings() {


### PR DESCRIPTION
Two changes, one point: **the LLM has never been given a fair test.**

## Engine — the LLM couldn't see failures the analyzers missed

The DISCOVER evidence bundle seeded from what deterministic findings cite, then topped up from recent **Fact and Observation** grains — never **Tool** grains. For a tool-using agent the raw experience *is* tool calls, so the LLM only ever saw a failure an analyzer had already flagged and cited. It could elaborate on what clustering caught; it could never find what clustering missed — the one thing it's there for. The code called that top-up "the non-parasitic step" while omitting the grain type the flagship analyzer reads.

Recent tool **errors** are now seeded first, capped at half the bundle so a busy desk can't crowd out facts/observations; successes are skipped as noise at a 64-item budget. Regression test: two failures far below `tool_failure`'s threshold (so nothing is flagged) must still reach the bundle with their error body.

**Every earlier LLM number was measured under the old behaviour and is superseded for comparison.**

## Bench — the missing cell of the 2x2

`--llm-lessons` becomes one axis. `LessonArms { analyzer, llm }` says which lesson **origins** the review gate admits, and the new `--no-analyzer-lessons` gives the cell that was missing: **LLM-authored lessons applied alone**.

| cell | analyzer | llm | |
|---|---|---|---|
| control | applied | advisory | published default |
| combined | applied | applied | `--llm-lessons` |
| llm-only | advisory | applied | `+ --no-analyzer-lessons` **(new)** |
| neither | advisory | advisory | is state A0 by construction |

The analyzers still **run** in every cell — only application varies — so each axis is one variable and the LLM's evidence is identical across cells. Refused without `--llm-lessons`, where nothing would apply and B would silently be a second A0. `--assert-shape`'s origin check now covers all three live cells; verified keylessly on each.

## Pre-registration

In SELFIMPROVE.md, committed before any run of this design, with the primary question (does the llm-only cell clear the same A0→B→A1→B2 bar the deterministic loop did?), every outcome branch, and the bound stated up front: **this workload's six hidden rules are all tool-failure-shaped — exactly what signature clustering detects — so a null result here is not a verdict on LLM learning in general.**

Tests: `areev-loop` 135, `areev-bench` 84, golden CLI 34, clippy clean, `repo_stats --check` clean.