### PR TITLE
ci(release): publish a postgres+oidc CLI asset

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -90,6 +90,16 @@ jobs:
           - { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, ext: "", features: "postgres-tls,oidc", suffix: "-postgres-oidc" }
     steps:
       - uses: actions/checkout@v4
+        with:
+          # A backfill labels its assets with attach_to_tag's version and
+          # uploads them to THAT release with --clobber, so they must be built
+          # from that tag. Left to its default this checks out whatever ref the
+          # run was dispatched against (main), and the backfill would overwrite
+          # a published release's binaries with different code under the old
+          # version's name — the one outcome a signed, attested asset is
+          # supposed to make impossible. Empty string keeps the default ref for
+          # a real release and for the plain dry-run dispatch.
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.attach_to_tag || '' }}
 
       - name: Install Rust
         run: rustup update stable && rustup target add ${{ matrix.target }}
@@ -139,6 +149,26 @@ jobs:
               *"STO-E003"*)                   echo "::error::built with plain postgres, not postgres-tls"; exit 1 ;;
             esac
           fi
+
+          # Same argument for oidc, which is the ENTIRE reason the
+          # -postgres-oidc asset exists: a feature-flag typo still builds and
+          # still passes every check above, and the miss only surfaces when a
+          # deployed console rejects its own --oidc-issuer. The two builds
+          # disagree in a way that is cheap to read: without the feature the
+          # flag is refused outright ("no native OIDC"), with it the flag is
+          # accepted and then asks for its companions.
+          case "${{ matrix.features }}" in
+            *oidc*)
+              out="$("$BIN" ui --db "$RUNNER_TEMP/smoke.db" \
+                       --oidc-issuer https://login.microsoftonline.com/smoke/v2.0 2>&1 || true)"
+              printf '%s\n' "$out"
+              case "$out" in
+                *"no native OIDC"*)      echo "::error::oidc feature missing from the -postgres-oidc asset"; exit 1 ;;
+                *"needs --oidc-client-id"*) echo "oidc present" ;;
+                *) echo "::error::unrecognised --oidc-issuer response; the smoke test can no longer tell the two builds apart"; exit 1 ;;
+              esac
+              ;;
+          esac
 
       - name: Package
         shell: bash

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -79,6 +79,15 @@ jobs:
           # Linux only — the server tier does not deploy on macOS/Windows.
           - { runner: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  ext: "", features: "postgres-tls", suffix: "-postgres" }
           - { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, ext: "", features: "postgres-tls", suffix: "-postgres" }
+          # A console that fronts a postgres memory on the public internet
+          # needs an identity stronger than a shared proxy secret, because an
+          # OIDC principal may answer a HITL ask and a proxy-asserted one may
+          # not. That combination — postgres storage AND native OIDC — was
+          # buildable and not published, so the only way to run it was to
+          # compile on the box. Linux only, for the same reason as the row
+          # above: the server tier does not deploy on macOS/Windows.
+          - { runner: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  ext: "", features: "postgres-tls,oidc", suffix: "-postgres-oidc" }
+          - { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, ext: "", features: "postgres-tls,oidc", suffix: "-postgres-oidc" }
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
A console fronting a postgres memory on the public internet wants an identity stronger than a shared proxy secret — an OIDC principal may answer a HITL ask and a proxy-asserted one may not, which is the entire reason native OIDC exists. That combination was buildable and unpublished: the matrix carried `postgres-tls` and no `oidc` anywhere, so the only way to run it was to compile on the box.

Two matrix rows, linux only, for the same reason the postgres rows are linux only — the server tier does not deploy on macOS or Windows. Asset naming already carries `matrix.suffix` and checksums are per-asset, so the new artifacts simply land as `areev-<version>-<target>-postgres-oidc.tar.gz`.

Two holes found while wiring the first real consumer (Rounic's `areev.rounic.com` console):

**Nothing proved `oidc` was in the binary.** The smoke test proved the postgres backend had reached the build but not the feature the asset exists for. A flag typo builds clean, passes every existing check, and surfaces only when a deployed console rejects its own `--oidc-issuer`. The builds disagree cheaply — without the feature the flag is refused outright, with it the flag is accepted and asks for its companions. Verified locally against a real `postgres-tls,oidc` build (`needs --oidc-client-id`) and a default build (`no native OIDC`).

**The backfill built from the wrong source.** `actions/checkout` had no `ref`, so a dispatch took whatever it was dispatched against (usually `main`), packaged it under `attach_to_tag`'s version, and `--clobber`ed it over a published release's binaries — assets named for one version, built from another, and attested in that state, which is what attestation is supposed to make impossible. Today `main` and `v1.7.0` differ only in CI, so nothing has shipped wrong; that is timing, not design.

All oidc deps (`jsonwebtoken`, `ureq`, `sha2`, `hex`, `getrandom`) are already in `Cargo.lock`, so `--locked` holds.

https://claude.ai/code/session_01HmUnEUTgLoekrezixv3Axv