### PR TITLE
loop: three silent failures between evidence and action, and the real-world measurement that found them

### DIFF
--- a/crates/areev-bench/EXPENSE.md
+++ b/crates/areev-bench/EXPENSE.md
@@ -1,0 +1,155 @@
+# Governed self-improvement on a real expense workflow
+
+Does a memory an operator corrects actually make an agent better — measurably,
+causally, on work that was not designed to be a benchmark?
+
+This records a measurement against a **private dataset**: a real company's
+supplier invoices and the spreadsheet a person fills in from them, 206 rows
+joined to 206 documents. The documents are not in this repo and will not be.
+Only the counts below travel; the harness that produced them lives with the
+data. What is reproducible here is the *design*, not the corpus — the same
+harness runs against any invoice-plus-sheet pair.
+
+`scripts/expense_curve_chart.py` renders the chart from the numbers in this
+file. Re-run it by hand when they change.
+
+## The task
+
+An agent reads an invoice and fills one spreadsheet row. On day one its
+instruction is to capture the invoice date and nothing else. An accountant
+reviews each row against the real sheet and replies the way a person would,
+introducing new requirements on a fixed schedule that mirrors how the real
+form actually grew — vendor, amount and currency at invoice 2, a description
+at 6, a category at 10, a payment date at 16.
+
+Nothing else is ever told to the agent. Every requirement reaches it the long
+way: the accountant says it → the loop proposes a rule → a reviewer approves
+or rejects it → the approved rule is applied → it renders into the prompt of
+every later invoice. The prompt is assembled from the memory file on every
+single invoice, so what the agent knows is exactly what the memory holds.
+
+## Why the measurement is paired
+
+The first eight exploratory runs were worthless and are reported here because
+the reason generalises. Whole-run accuracy ranged 0.9% to 13.0%, and two runs
+differing only by a prompt header scored 13.0% and 0.9% — one flip in an
+early review decision changes every correction after it, and the run diverges.
+**The noise between runs was larger than the effect being looked for.**
+
+So nothing below compares two runs. Each invoice is its own control: the same
+held-out invoice is read twice under prompts that are byte-identical except
+that the learned rules are present or withdrawn. Only pairs that *disagree*
+carry information (McNemar's exact test); a pooled accuracy delta would hide
+how few trials actually moved.
+
+Three arms, over 30 held-out invoices never seen in the experience phase:
+
+| Arm | State |
+|---|---|
+| **B** | the rules as the experience phase left them |
+| **B2** | the same state, run again — the noise floor |
+| **A** | every recommendation rolled back through the API |
+
+Arm A is produced by a genuine rollback, not by declining to render the
+lessons: the claim is that the *governed apply* is the lever, so withdrawing
+it has to travel the governance path. There is no fourth re-applied arm — the
+lifecycle forbids `RolledBack -> Applied`, correctly, and with each invoice a
+stateless call there is no order effect for it to rule out.
+
+## Result
+
+30 held-out invoices, 210 (invoice, field) trials per arm, exact match against
+the filed value.
+
+| Seed | B vs A | Noise floor (B vs B2) | p |
+|---|---|---|---|
+| 1 | **21 wins, 0 losses** | 1 | <0.0001 |
+| 2 | **32 wins, 0 losses** | 1 | <0.0001 |
+| 3 | **30 wins, 0 losses** | 0 | <0.0001 |
+
+The noise floor is what makes the rest meaningful: two passes over identical
+memory disagree on 0–1 of 210 trials, so an effect of 21–32 with no
+regressions in any seed is not a re-roll.
+
+Coverage — whether the agent put *any* value in a field — shows the mechanism.
+Arm A is identical in all three seeds:
+
+| Field | Arm A | Arm B (per seed) |
+|---|---|---|
+| Invoice Date | 23/30 | 23, 16, 23 |
+| Vendor Name | **0/30** | 21, 16, 23 |
+| Amount | **0/30** | 2, 16, 23 |
+| Currency | **0/30** | 0, 16, 23 |
+| Expense Description | **0/30** | 23, 16, 0 |
+| Payment Date | **0/30** | 0, 15, 0 |
+
+A single pair shows what a "win" is. Same invoice, same prompt scaffold, the
+only difference being whether the recommendations are applied:
+
+```
+Vendor Name    A = ''                 B = 'Anthropic, PBC'    filed: 'Anthropic, PBC'
+Invoice Date   A = '15/11/2025'       B = '11/15/2025'        filed: '11/15/2025'
+```
+
+The second is not a formatting nicety: without the rule the agent transposed
+day and month.
+
+## Learning curve
+
+Held-out accuracy against memory as it stood after 0, 10, 20, 30 and 40
+corrections. Same 30 invoices and same seven fields at every point, so the
+only thing varying is how much the agent has been taught.
+
+| Corrections seen | Exact | Read correctly | Fields covered |
+|---|---|---|---|
+| 0 (rolled back) | 0/210 | 12/210 | 1 of 7 |
+| 10 | **38/210** | 56/210 | 4 of 7 |
+| 20 | 36/210 | 53/210 | 4 of 7 |
+| 30 | 36/210 | 52/210 | 4 of 7 |
+| 40 | 36/210 | 54/210 | 4 of 7 |
+
+Nearly all of the gain arrives in the first ten corrections and then the curve
+is flat to very slightly negative. Governed learning here is a large one-time
+step, not a steady climb.
+
+**A curve this repo does not publish**: the running score *during* the
+experience phase falls (32% → 20%). That is not the agent getting worse — the
+accountant is adding required fields as it goes, so the denominator grows. It
+measures the goalpost moving, and presenting it as a learning curve would be
+wrong in the flattering direction's opposite.
+
+## What this does not show
+
+- **Absolute accuracy is low.** 17% exact, 26% read-correctly. This is a
+  working learning loop, not a production capture agent.
+- **Three of seven fields never move.** Category and Payment Date stay at or
+  near zero in most seeds.
+- One dataset, one 30-invoice held-out slice, three seeds.
+- The human reviewer is a model applying a fixed rubric, not a person. It
+  agrees with pre-registered expectations on 10 of 11 cases and is not
+  deterministic; its variance is confined to the experience phase, which ends
+  before any measurement begins.
+
+## Three engine defects this found
+
+Each produced a plausible null result rather than an error, which is why a
+score-only benchmark would never have surfaced them.
+
+1. **Every human note reached the model as an empty string.** `grain_brief`
+   rendered an Observation through a fact-triple branch needing
+   subject+relation+object; an Observation has no relation, and the fallback
+   never checked `object`, where the store puts the text. The single
+   highest-value evidence in a memory was the one shape that rendered to
+   nothing, so an explicit instruction from a person could never become a
+   lesson.
+2. **A lesson could only prevent, never start doing something.** The lesson
+   contract asked for a rule "preventing a recurring mistake". When an agent
+   simply never produces a field, the rule it needs is additive. The model
+   reached for the nearest allowed shape — "validate all required fields
+   before submission" — which passed DISCOVER, GROUND, VERIFY, human review,
+   apply and render, and changed nothing: 0/30 coverage, against 6/6 for the
+   same fields under "capture X, Y, Z". **A lesson can clear every gate the
+   engine has and still be a no-op, because no gate asks whether the wording
+   names an action the agent can take.**
+3. **The pin probe could not talk to OpenAI models**, reporting a working
+   provider as a bad tag.

--- a/crates/areev-bench/scripts/openrouter_loop.py
+++ b/crates/areev-bench/scripts/openrouter_loop.py
@@ -133,7 +133,14 @@ def main():
                     "max_tokens": 1,
                     "response_format": {"type": "json_object"},
                     "provider": {"order": [provider], "allow_fallbacks": False},
-                    "messages": [{"role": "user", "content": "{}"}],
+                    # The word "json" has to appear in the messages: OpenAI
+                    # rejects response_format=json_object otherwise ("'messages'
+                    # must contain the word 'json' in some form"), so a bare
+                    # "{}" made every OpenAI-served model fail its own pin check
+                    # and read as a bad tag. The real calls below already say
+                    # "Return JSON" in their instructions; only the probe was
+                    # short enough to trip it.
+                    "messages": [{"role": "user", "content": "Reply with the json object {}"}],
                 }, key, raise_http=True)
             except HttpFail as e:
                 # Classify, because the two failures need opposite responses

--- a/crates/areev-bench/scripts/openrouter_loop.py
+++ b/crates/areev-bench/scripts/openrouter_loop.py
@@ -29,7 +29,13 @@ import urllib.error
 import urllib.request
 
 BASE = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
-RETRIES = 3
+# Five, not three. The engine FAIL-SOFTS a failing loop call by design, and
+# for the GROUND leg that means a single flaky minute silently voids an entire
+# learn pass: every draft is treated as ungrounded, the ledger comes back
+# empty, and the run reads as a model that had nothing to say. Losing a pass
+# is far more expensive to a measurement than waiting a few more seconds, and
+# retrying is strictly cheaper than the re-run it otherwise costs.
+RETRIES = 5
 
 
 def fail(msg, code=2):
@@ -52,7 +58,7 @@ def post(body, key, raise_http=False):
         data=json.dumps(body).encode(),
         headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
     )
-    delay = 2
+    delay = 3
     for attempt in range(RETRIES):
         try:
             with urllib.request.urlopen(req, timeout=180) as r:

--- a/crates/areev-bench/src/selfimprove/memory.rs
+++ b/crates/areev-bench/src/selfimprove/memory.rs
@@ -483,9 +483,17 @@ impl Memory {
         if let Some(f) = &run.llm_funnel {
             eprintln!(
                 "  llm funnel: evidence {} -> proposed {} -> cited {} \
-                 (uncited {}, bad target {}) -> grounded {} -> kept {} -> stored {}",
+                 (uncited {}, bad target {}) -> grounded {}{} -> kept {} -> stored {}",
                 f.evidence, f.proposed, f.cited, f.dropped_uncited, f.dropped_target,
-                f.grounded, f.kept, f.stored
+                f.grounded,
+                if f.ground_call_failed {
+                    " [GROUND CALL FAILED]".to_string()
+                } else if f.grounded == 0 && f.ground_verdicts == 0 && f.cited > 0 {
+                    " [GROUND returned nothing usable]".to_string()
+                } else {
+                    format!(" of {} verdicts", f.ground_verdicts)
+                },
+                f.kept, f.stored
             );
         }
         let pending: Vec<Recommendation> = engine

--- a/crates/areev-bench/src/selfimprove/memory.rs
+++ b/crates/areev-bench/src/selfimprove/memory.rs
@@ -343,11 +343,6 @@ impl Memory {
         obs.subject = Some("support_desk".to_string());
         obs.object = Some(note.to_string());
         obs.common.namespace = Some(self.ns.clone());
-        // grain_brief renders an Observation from `body`, so the note has to
-        // be reachable there or the model is handed an empty line.
-        obs.common
-            .extra_fields
-            .insert("body".into(), Value::String(note.to_string()));
         obs.common
             .extra_fields
             .insert("task_id".into(), Value::String(task_id.to_string()));

--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -160,6 +160,15 @@ pub struct LlmFunnel {
     pub dropped_target: u64,
     /// Survived GROUND — their premises were found in the cited evidence.
     pub grounded: u64,
+    /// Verdicts GROUND actually returned. `grounded = 0` with verdicts > 0 is
+    /// the gate refusing every draft; `grounded = 0` with verdicts = 0 is a
+    /// grader that answered with nothing usable, which is a backend problem
+    /// wearing a gate's clothes.
+    pub ground_verdicts: u64,
+    /// The GROUND call itself failed — no response at all. The engine
+    /// fail-softs here by design, so without this the run looks like a model
+    /// that had nothing to say.
+    pub ground_call_failed: bool,
     /// Survived VERIFY's adversarial pass.
     pub kept: u64,
     /// Cleared the confidence floor and reached the queue.
@@ -821,17 +830,29 @@ impl Engine {
             instructions: GROUND_INSTRUCTIONS,
             claims,
         };
+        // A grounding pass that REFUSED every draft and one that never
+        // answered are the same number of survivors and opposite problems:
+        // the first is the gate doing its job, the second is a backend having
+        // a bad minute while the engine fail-softs. Count the verdicts
+        // actually returned so the two are distinguishable afterwards.
         let grounded: std::collections::BTreeSet<usize> = match serde_json::to_string(&ground_req)
             .ok()
             .and_then(|b| ground.complete(&b).ok())
         {
-            Some(raw) => parse_ground(&raw)
-                .results
-                .into_iter()
-                .filter(|r| r.supported)
-                .map(|r| r.id)
-                .collect(),
-            None => return Vec::new(),
+            Some(raw) => {
+                let parsed = parse_ground(&raw);
+                funnel.ground_verdicts = parsed.results.len() as u64;
+                parsed
+                    .results
+                    .into_iter()
+                    .filter(|r| r.supported)
+                    .map(|r| r.id)
+                    .collect()
+            }
+            None => {
+                funnel.ground_call_failed = true;
+                return Vec::new();
+            }
         };
         funnel.grounded = grounded.len() as u64;
         if grounded.is_empty() {

--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -2095,10 +2095,14 @@ OMIT 'proposal' for an advisory finding — one worth a human's attention that \
 you are not asking to change anything. Include it ONLY when the evidence \
 supports a specific change, choosing exactly one kind: \
 (1) {\"kind\":\"lesson\",\"lesson\":\"...\"} with target \
-\"entity:<ns>/<subject>\" — ONE short imperative rule (max 240 chars) \
-preventing a recurring mistake, phrased to apply BEFORE it happens (e.g. \
-'Refund a subscription before cancelling it; refunds on cancelled \
-subscriptions are refused'). \
+\"entity:<ns>/<subject>\" — ONE short imperative rule (max 240 chars) naming \
+an action the agent itself takes on the next occasion. Either ADD an action \
+it is failing to take ('Record the vendor name and the amount on every \
+invoice, not just the date') or ORDER one that goes wrong ('Refund a \
+subscription before cancelling it; refunds on cancelled subscriptions are \
+refused'). Name the action, not a check on it: 'validate', 'verify' and \
+'ensure ... is correct' describe a review step the agent has no way to \
+perform, and such a rule changes nothing even once applied. \
 (2) {\"kind\":\"fact\",\"relation\":\"...\",\"object\":\"...\"} with the same \
 entity target — a durable fact the agent keeps having to be told (an alias, a \
 settled default, a preference). 'relation' is a short identifier (letters, \

--- a/crates/areev-loop/src/engine.rs
+++ b/crates/areev-loop/src/engine.rs
@@ -2192,7 +2192,14 @@ fn grain_brief(g: &GrainRecord) -> String {
         let out = g.tool_content().unwrap_or("");
         return format!("tool {t} {status}: {out}");
     }
-    for key in ["content", "body", "text", "summary"] {
+    // `object` is last but it is not optional: an Observation stores its text
+    // there (subject + object, no relation), so it misses the fact-triple
+    // branch above and used to fall through this list to an empty string —
+    // every human note in a memory reached the model as a blank line. That is
+    // the single highest-value evidence a memory holds, and it was the one
+    // shape that rendered to nothing. Callers had started duplicating the text
+    // into `body` to work around it; nothing should have to.
+    for key in ["content", "body", "text", "summary", "object"] {
         if let Some(v) = g.fields.get(key).and_then(|v| v.as_str()) {
             if !v.is_empty() {
                 return v.to_string();

--- a/crates/areev-loop/src/integration.rs
+++ b/crates/areev-loop/src/integration.rs
@@ -1071,6 +1071,71 @@ fn ground_and_verify_judge_the_lesson_text_not_just_the_summary() {
 }
 
 #[test]
+fn human_note_evidence_reaches_the_llm_with_text() {
+    use std::sync::{Arc, Mutex};
+    struct RecordingLlm {
+        inner: MockLlm,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+    impl crate::llm::LlmBackend for RecordingLlm {
+        fn model(&self) -> &str {
+            "recording-mock"
+        }
+        fn complete(&self, request: &str) -> crate::error::Result<String> {
+            self.seen.lock().unwrap().push(request.to_string());
+            self.inner.complete(request)
+        }
+    }
+    let mut sub = TestSubstrate::new();
+    // A human note is stored as subject + object with NO relation, so it
+    // misses grain_brief's fact-triple branch. It must still render.
+    sub.add_human_note(
+        "expense",
+        "expense_capture",
+        "user:billing-lead",
+        "I also need the vendor, the amount and the currency on every one.",
+    );
+    for _ in 0..5 {
+        sub.add_tool_call("stripe_refund", true, "rate_limited 429");
+    }
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let e = Engine::with_builtins().with_llm(Box::new(RecordingLlm {
+        inner: MockLlm {
+            discover: r#"{"recommendations":[]}"#.to_string(),
+            ground: r#"{"results":[]}"#.to_string(),
+            verify: r#"{"results":[]}"#.to_string(),
+            enrich: r#"{"notes":[]}"#.to_string(),
+        },
+        seen: Arc::clone(&seen),
+    }));
+    e.run(&mut sub.inner, &RunOptions::default(), 10_000).unwrap();
+    let seen = seen.lock().unwrap();
+    let discover = seen
+        .iter()
+        .find(|r| r.contains("\"op\":\"discover\""))
+        .expect("a discover request");
+    let v: serde_json::Value = serde_json::from_str(discover).unwrap();
+    let notes: Vec<_> = v["evidence"]
+        .as_array()
+        .expect("evidence array")
+        .iter()
+        .filter(|i| i["grain_type"] == "observation")
+        .collect();
+    assert!(!notes.is_empty(), "the human note reaches the bundle");
+    for item in notes {
+        let text = item["text"].as_str().unwrap_or("");
+        // Found live against a real memory: every human Observation reached
+        // the model as "" — the highest-value evidence a memory holds was the
+        // one shape that rendered to nothing, so an explicit instruction from
+        // a person could never become a lesson.
+        assert!(
+            text.contains("vendor") && text.contains("currency"),
+            "human-note evidence must carry its text, got: {text:?}"
+        );
+    }
+}
+
+#[test]
 fn tool_grain_evidence_reaches_the_llm_with_text() {
     use std::sync::{Arc, Mutex};
     struct RecordingLlm {

--- a/crates/areev-loop/src/testkit.rs
+++ b/crates/areev-loop/src/testkit.rs
@@ -196,6 +196,32 @@ impl TestSubstrate {
         })
     }
 
+    /// A human's note, shaped the way the real store shapes one: the text in
+    /// `object` under a `subject`, with no `relation`.
+    ///
+    /// Distinct from `add_observation`, which puts the text in `body`. That
+    /// helper matched the *renderer* rather than the store, so the one grain
+    /// shape a real memory actually produces went untested — and rendered to
+    /// an empty string all the way to the model.
+    pub fn add_human_note(&mut self, ns: &str, subject: &str, observer: &str, text: &str) -> String {
+        let created = self.tick();
+        let mut fields = Map::new();
+        fields.insert("subject".into(), json!(subject));
+        fields.insert("object".into(), json!(text));
+        fields.insert("observer_id".into(), json!(observer));
+        fields.insert("observer_type".into(), json!("human"));
+        fields.insert("namespace".into(), json!(ns));
+        self.inner.insert(GrainRecord {
+            hash: String::new(),
+            grain_type: "observation".into(),
+            namespace: ns.into(),
+            created_at_ms: created,
+            valid_to_ms: None,
+            superseded_by: None,
+            fields,
+        })
+    }
+
     pub fn add_fork(&mut self, entity: &str, heads: &[&str]) {
         self.inner.register_fork(entity, heads);
     }

--- a/docs/assets/expense-learning-dark.svg
+++ b/docs/assets/expense-learning-dark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="340" viewBox="0 0 820 340" role="img" aria-label="Governed self-improvement on a real expense workflow: held-out exact-match rises from 0 to 38 of 210 trials within the first ten corrections then plateaus, and the effect replicates across three seeds at 21 to 32 wins with no losses against a noise floor of 0 to 1">
+<style>text{font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}.n{font-weight:700;font-variant-numeric:tabular-nums}.v{font-weight:600;font-variant-numeric:tabular-nums}</style>
+<rect width="820" height="340" rx="10" fill="#0d1117" stroke="#30363d"/>
+<text x="32" y="40" class="n" font-size="16" fill="#e6edf3">Areev — a memory the accountant corrects, on a real expense workflow</text>
+<text x="32" y="60" font-size="12" fill="#8b949e">rules the loop proposed, a human approved, and the agent then followed · measured on 30 invoices it never saw</text>
+<text x="32" y="86" font-size="11" fill="#8b949e" font-weight="600">HELD-OUT ACCURACY vs CORRECTIONS SEEN</text>
+<line x1="62" y1="250.0" x2="382" y2="250.0" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="254.0" font-size="10" fill="#8b949e" text-anchor="end">0%</text>
+<line x1="62" y1="200.0" x2="382" y2="200.0" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="204.0" font-size="10" fill="#8b949e" text-anchor="end">10%</text>
+<line x1="62" y1="150.0" x2="382" y2="150.0" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="154.0" font-size="10" fill="#8b949e" text-anchor="end">20%</text>
+<line x1="62" y1="100.0" x2="382" y2="100.0" stroke="#30363d" stroke-width="1"/>
+<text x="54" y="104.0" font-size="10" fill="#8b949e" text-anchor="end">30%</text>
+<polyline points="62.0,221.4 142.0,116.7 222.0,123.8 302.0,126.2 382.0,121.4" fill="none" stroke="#bc8cff" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="62.0" cy="221.4" r="3.5" fill="#bc8cff"/>
+<circle cx="142.0" cy="116.7" r="3.5" fill="#bc8cff"/>
+<circle cx="222.0" cy="123.8" r="3.5" fill="#bc8cff"/>
+<circle cx="302.0" cy="126.2" r="3.5" fill="#bc8cff"/>
+<circle cx="382.0" cy="121.4" r="3.5" fill="#bc8cff"/>
+<text x="390.0" y="125.4" font-size="10.5" fill="#bc8cff" font-weight="600">read correctly</text>
+<polyline points="62.0,250.0 142.0,159.5 222.0,164.3 302.0,164.3 382.0,164.3" fill="none" stroke="#58a6ff" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="62.0" cy="250.0" r="3.5" fill="#58a6ff"/>
+<circle cx="142.0" cy="159.5" r="3.5" fill="#58a6ff"/>
+<circle cx="222.0" cy="164.3" r="3.5" fill="#58a6ff"/>
+<circle cx="302.0" cy="164.3" r="3.5" fill="#58a6ff"/>
+<circle cx="382.0" cy="164.3" r="3.5" fill="#58a6ff"/>
+<text x="390.0" y="168.3" font-size="10.5" fill="#58a6ff" font-weight="600">exactly as filed</text>
+<text x="62.0" y="268" font-size="10" fill="#8b949e" text-anchor="middle">0</text>
+<text x="62.0" y="281" font-size="9" fill="#8b949e" text-anchor="middle">rolled back</text>
+<text x="142.0" y="268" font-size="10" fill="#8b949e" text-anchor="middle">10</text>
+<text x="222.0" y="268" font-size="10" fill="#8b949e" text-anchor="middle">20</text>
+<text x="302.0" y="268" font-size="10" fill="#8b949e" text-anchor="middle">30</text>
+<text x="382.0" y="268" font-size="10" fill="#8b949e" text-anchor="middle">40</text>
+<text x="222.0" y="296" font-size="10" fill="#8b949e" text-anchor="middle">invoices corrected by the accountant</text>
+<text x="148.0" y="147.5" font-size="10" fill="#e6edf3" font-weight="600">most of the gain in the first 10</text>
+<text x="530" y="86" font-size="11" fill="#8b949e" font-weight="600">DOES IT REPLICATE?</text>
+<text x="530" y="104" font-size="10" fill="#8b949e">paired per invoice · only disagreements count</text>
+<text x="530" y="132" font-size="10.5" fill="#e6edf3" font-weight="600">seed 1</text>
+<rect x="582" y="122" width="94.5" height="13" rx="3" fill="#58a6ff"/>
+<text x="682.5" y="133" class="v" font-size="10.5" fill="#e6edf3">21–0</text>
+<rect x="582" y="138" width="4.5" height="7" rx="2" fill="#d29922"/>
+<text x="592.5" y="145" font-size="9.5" fill="#8b949e">noise 1</text>
+<text x="530" y="178" font-size="10.5" fill="#e6edf3" font-weight="600">seed 2</text>
+<rect x="582" y="168" width="144.0" height="13" rx="3" fill="#58a6ff"/>
+<text x="732.0" y="179" class="v" font-size="10.5" fill="#e6edf3">32–0</text>
+<rect x="582" y="184" width="4.5" height="7" rx="2" fill="#d29922"/>
+<text x="592.5" y="191" font-size="9.5" fill="#8b949e">noise 1</text>
+<text x="530" y="224" font-size="10.5" fill="#e6edf3" font-weight="600">seed 3</text>
+<rect x="582" y="214" width="135.0" height="13" rx="3" fill="#58a6ff"/>
+<text x="723.0" y="225" class="v" font-size="10.5" fill="#e6edf3">30–0</text>
+<rect x="582" y="230" width="2.0" height="7" rx="2" fill="#d29922"/>
+<text x="590.0" y="237" font-size="9.5" fill="#8b949e">noise 0</text>
+<text x="530" y="266" font-size="10" fill="#e6edf3">wins–losses for the learned rules, p&lt;0.0001</text>
+<text x="530" y="281" font-size="10" fill="#8b949e">noise = two passes over the SAME memory</text>
+<text x="32" y="322" font-size="10.5" fill="#8b949e">every point is the same 30 unseen invoices · arm 0 is the same memory with the rules rolled back · data: crates/areev-bench/EXPENSE.md</text>
+</svg>

--- a/docs/assets/expense-learning-light.svg
+++ b/docs/assets/expense-learning-light.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="340" viewBox="0 0 820 340" role="img" aria-label="Governed self-improvement on a real expense workflow: held-out exact-match rises from 0 to 38 of 210 trials within the first ten corrections then plateaus, and the effect replicates across three seeds at 21 to 32 wins with no losses against a noise floor of 0 to 1">
+<style>text{font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}.n{font-weight:700;font-variant-numeric:tabular-nums}.v{font-weight:600;font-variant-numeric:tabular-nums}</style>
+<rect width="820" height="340" rx="10" fill="#ffffff" stroke="#dfe3e8"/>
+<text x="32" y="40" class="n" font-size="16" fill="#111418">Areev — a memory the accountant corrects, on a real expense workflow</text>
+<text x="32" y="60" font-size="12" fill="#5b6470">rules the loop proposed, a human approved, and the agent then followed · measured on 30 invoices it never saw</text>
+<text x="32" y="86" font-size="11" fill="#5b6470" font-weight="600">HELD-OUT ACCURACY vs CORRECTIONS SEEN</text>
+<line x1="62" y1="250.0" x2="382" y2="250.0" stroke="#dfe3e8" stroke-width="1"/>
+<text x="54" y="254.0" font-size="10" fill="#5b6470" text-anchor="end">0%</text>
+<line x1="62" y1="200.0" x2="382" y2="200.0" stroke="#dfe3e8" stroke-width="1"/>
+<text x="54" y="204.0" font-size="10" fill="#5b6470" text-anchor="end">10%</text>
+<line x1="62" y1="150.0" x2="382" y2="150.0" stroke="#dfe3e8" stroke-width="1"/>
+<text x="54" y="154.0" font-size="10" fill="#5b6470" text-anchor="end">20%</text>
+<line x1="62" y1="100.0" x2="382" y2="100.0" stroke="#dfe3e8" stroke-width="1"/>
+<text x="54" y="104.0" font-size="10" fill="#5b6470" text-anchor="end">30%</text>
+<polyline points="62.0,221.4 142.0,116.7 222.0,123.8 302.0,126.2 382.0,121.4" fill="none" stroke="#8250df" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="62.0" cy="221.4" r="3.5" fill="#8250df"/>
+<circle cx="142.0" cy="116.7" r="3.5" fill="#8250df"/>
+<circle cx="222.0" cy="123.8" r="3.5" fill="#8250df"/>
+<circle cx="302.0" cy="126.2" r="3.5" fill="#8250df"/>
+<circle cx="382.0" cy="121.4" r="3.5" fill="#8250df"/>
+<text x="390.0" y="125.4" font-size="10.5" fill="#8250df" font-weight="600">read correctly</text>
+<polyline points="62.0,250.0 142.0,159.5 222.0,164.3 302.0,164.3 382.0,164.3" fill="none" stroke="#1f6feb" stroke-width="2.5" stroke-linejoin="round"/>
+<circle cx="62.0" cy="250.0" r="3.5" fill="#1f6feb"/>
+<circle cx="142.0" cy="159.5" r="3.5" fill="#1f6feb"/>
+<circle cx="222.0" cy="164.3" r="3.5" fill="#1f6feb"/>
+<circle cx="302.0" cy="164.3" r="3.5" fill="#1f6feb"/>
+<circle cx="382.0" cy="164.3" r="3.5" fill="#1f6feb"/>
+<text x="390.0" y="168.3" font-size="10.5" fill="#1f6feb" font-weight="600">exactly as filed</text>
+<text x="62.0" y="268" font-size="10" fill="#5b6470" text-anchor="middle">0</text>
+<text x="62.0" y="281" font-size="9" fill="#5b6470" text-anchor="middle">rolled back</text>
+<text x="142.0" y="268" font-size="10" fill="#5b6470" text-anchor="middle">10</text>
+<text x="222.0" y="268" font-size="10" fill="#5b6470" text-anchor="middle">20</text>
+<text x="302.0" y="268" font-size="10" fill="#5b6470" text-anchor="middle">30</text>
+<text x="382.0" y="268" font-size="10" fill="#5b6470" text-anchor="middle">40</text>
+<text x="222.0" y="296" font-size="10" fill="#5b6470" text-anchor="middle">invoices corrected by the accountant</text>
+<text x="148.0" y="147.5" font-size="10" fill="#111418" font-weight="600">most of the gain in the first 10</text>
+<text x="530" y="86" font-size="11" fill="#5b6470" font-weight="600">DOES IT REPLICATE?</text>
+<text x="530" y="104" font-size="10" fill="#5b6470">paired per invoice · only disagreements count</text>
+<text x="530" y="132" font-size="10.5" fill="#111418" font-weight="600">seed 1</text>
+<rect x="582" y="122" width="94.5" height="13" rx="3" fill="#1f6feb"/>
+<text x="682.5" y="133" class="v" font-size="10.5" fill="#111418">21–0</text>
+<rect x="582" y="138" width="4.5" height="7" rx="2" fill="#bf8700"/>
+<text x="592.5" y="145" font-size="9.5" fill="#5b6470">noise 1</text>
+<text x="530" y="178" font-size="10.5" fill="#111418" font-weight="600">seed 2</text>
+<rect x="582" y="168" width="144.0" height="13" rx="3" fill="#1f6feb"/>
+<text x="732.0" y="179" class="v" font-size="10.5" fill="#111418">32–0</text>
+<rect x="582" y="184" width="4.5" height="7" rx="2" fill="#bf8700"/>
+<text x="592.5" y="191" font-size="9.5" fill="#5b6470">noise 1</text>
+<text x="530" y="224" font-size="10.5" fill="#111418" font-weight="600">seed 3</text>
+<rect x="582" y="214" width="135.0" height="13" rx="3" fill="#1f6feb"/>
+<text x="723.0" y="225" class="v" font-size="10.5" fill="#111418">30–0</text>
+<rect x="582" y="230" width="2.0" height="7" rx="2" fill="#bf8700"/>
+<text x="590.0" y="237" font-size="9.5" fill="#5b6470">noise 0</text>
+<text x="530" y="266" font-size="10" fill="#111418">wins–losses for the learned rules, p&lt;0.0001</text>
+<text x="530" y="281" font-size="10" fill="#5b6470">noise = two passes over the SAME memory</text>
+<text x="32" y="322" font-size="10.5" fill="#5b6470">every point is the same 30 unseen invoices · arm 0 is the same memory with the rules rolled back · data: crates/areev-bench/EXPENSE.md</text>
+</svg>

--- a/scripts/expense_curve_chart.py
+++ b/scripts/expense_curve_chart.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Render the governed-self-improvement chart for a real expense workflow.
+
+Emits two artifacts:
+
+    docs/assets/expense-learning-light.svg
+    docs/assets/expense-learning-dark.svg
+
+The numbers are QUOTED from crates/areev-bench/EXPENSE.md, which records the
+measurement. They come from a private dataset (a real company's invoices and
+spreadsheet) that is deliberately NOT in this repo — only the counts travel.
+Like bench_chart.py, this is re-run by hand when that file changes. Stdlib
+only, same reasoning as repo_stats.py.
+
+Two things this chart does that the obvious version would not:
+
+1. The x-axis is EXPERIENCE, and the task is held constant. The tempting
+   chart — a running score across the invoices the agent is learning from —
+   falls over time here, because the accountant adds required fields as they
+   go (one field at the first invoice, seven by the sixteenth). That curve
+   measures the goalpost moving. Every point below is instead the SAME 30
+   held-out invoices and the same seven fields, read against memory as it
+   stood after 0, 10, 20, 30 and 40 corrections.
+
+2. The noise floor is drawn on the same axes as the effect, not tucked into a
+   caption. It is the number that makes the rest mean anything: two passes
+   over identical memory disagreed on 0-1 of 210 trials, so an effect of
+   21-32 is real rather than a re-roll.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Same two themes as scripts/repo_stats.py, so the README's charts read as one.
+THEMES = {
+    "light": {
+        "bg": "#ffffff", "panel": "#f6f7f9", "line": "#dfe3e8",
+        "fg": "#111418", "muted": "#5b6470", "bar": "#1f6feb",
+        "alt": "#8250df", "warn": "#bf8700",
+    },
+    "dark": {
+        "bg": "#0d1117", "panel": "#161b22", "line": "#30363d",
+        "fg": "#e6edf3", "muted": "#8b949e", "bar": "#58a6ff",
+        "alt": "#bc8cff", "warn": "#d29922",
+    },
+}
+
+TRIALS = 210  # 30 held-out invoices x the fields required of each
+
+# EXPENSE.md §"Learning curve" — held-out accuracy vs corrections seen.
+# The 0 point is the same memory with every recommendation rolled back
+# through the API, so the baseline is measured rather than assumed.
+CURVE = [
+    (0, 0, 12, 1),
+    (10, 38, 56, 4),
+    (20, 36, 53, 4),
+    (30, 36, 52, 4),
+    (40, 36, 54, 4),
+]
+
+# EXPENSE.md §"Replication" — paired McNemar on exact match, per seed:
+# (label, wins for the learned rules, losses, discordant pairs between two
+# passes over IDENTICAL memory).
+SEEDS = [("seed 1", 21, 0, 1), ("seed 2", 32, 0, 1), ("seed 3", 30, 0, 0)]
+
+FOOTER = ("every point is the same 30 unseen invoices · arm 0 is the same memory "
+          "with the rules rolled back · data: crates/areev-bench/EXPENSE.md")
+
+
+def render(theme: str) -> str:
+    c = THEMES[theme]
+    W, H = 820, 340
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" '
+        f'viewBox="0 0 {W} {H}" role="img" aria-label="Governed self-improvement '
+        'on a real expense workflow: held-out exact-match rises from 0 to 38 of '
+        '210 trials within the first ten corrections then plateaus, and the '
+        'effect replicates across three seeds at 21 to 32 wins with no losses '
+        'against a noise floor of 0 to 1">',
+        '<style>'
+        'text{font-family:ui-sans-serif,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif}'
+        '.n{font-weight:700;font-variant-numeric:tabular-nums}'
+        '.v{font-weight:600;font-variant-numeric:tabular-nums}'
+        '</style>',
+        f'<rect width="{W}" height="{H}" rx="10" fill="{c["bg"]}" stroke="{c["line"]}"/>',
+        f'<text x="32" y="40" class="n" font-size="16" fill="{c["fg"]}">'
+        'Areev — a memory the accountant corrects, on a real expense workflow</text>',
+        f'<text x="32" y="60" font-size="12" fill="{c["muted"]}">'
+        'rules the loop proposed, a human approved, and the agent then followed '
+        '· measured on 30 invoices it never saw</text>',
+    ]
+
+    # ---- left: the learning curve, task held constant --------------------
+    ox, oy = 62, 250          # origin
+    pw, ph = 320, 150         # plot area
+    max_pct = 30.0
+
+    parts.append(f'<text x="32" y="86" font-size="11" fill="{c["muted"]}" '
+                 'font-weight="600">HELD-OUT ACCURACY vs CORRECTIONS SEEN</text>')
+
+    for g in (0, 10, 20, 30):
+        gy = oy - ph * g / max_pct
+        parts.append(f'<line x1="{ox}" y1="{gy:.1f}" x2="{ox + pw}" y2="{gy:.1f}" '
+                     f'stroke="{c["line"]}" stroke-width="1"/>')
+        parts.append(f'<text x="{ox - 8}" y="{gy + 4:.1f}" font-size="10" '
+                     f'fill="{c["muted"]}" text-anchor="end">{g}%</text>')
+
+    def px(exp):
+        return ox + pw * exp / 40.0
+
+    def py(count):
+        return oy - ph * (100.0 * count / TRIALS) / max_pct
+
+    for idx, (key, colour, name) in enumerate(
+            ((2, c["alt"], "read correctly"), (1, c["bar"], "exactly as filed"))):
+        pts = " ".join("%.1f,%.1f" % (px(r[0]), py(r[key])) for r in CURVE)
+        parts.append(f'<polyline points="{pts}" fill="none" stroke="{colour}" '
+                     'stroke-width="2.5" stroke-linejoin="round"/>')
+        for r in CURVE:
+            parts.append(f'<circle cx="{px(r[0]):.1f}" cy="{py(r[key]):.1f}" r="3.5" '
+                         f'fill="{colour}"/>')
+        last = CURVE[-1]
+        parts.append(f'<text x="{px(last[0]) + 8:.1f}" y="{py(last[key]) + 4:.1f}" '
+                     f'font-size="10.5" fill="{colour}" font-weight="600">{name}</text>')
+
+    # The zero point is worth naming: it is a measured state, not an assumption.
+    parts += [
+        f'<text x="{px(0):.1f}" y="{oy + 18}" font-size="10" fill="{c["muted"]}" '
+        'text-anchor="middle">0</text>',
+        f'<text x="{px(0):.1f}" y="{oy + 31}" font-size="9" fill="{c["muted"]}" '
+        'text-anchor="middle">rolled back</text>',
+    ]
+    for e in (10, 20, 30, 40):
+        parts.append(f'<text x="{px(e):.1f}" y="{oy + 18}" font-size="10" '
+                     f'fill="{c["muted"]}" text-anchor="middle">{e}</text>')
+    parts.append(f'<text x="{ox + pw / 2:.1f}" y="{oy + 46}" font-size="10" '
+                 f'fill="{c["muted"]}" text-anchor="middle">'
+                 'invoices corrected by the accountant</text>')
+
+    # Callout: the step is early, and it then flattens. Say so on the chart.
+    parts.append(f'<text x="{px(10) + 6:.1f}" y="{py(38) - 12:.1f}" font-size="10" '
+                 f'fill="{c["fg"]}" font-weight="600">most of the gain '
+                 'in the first 10</text>')
+
+    # ---- right: replication + the noise floor ----------------------------
+    rx = 530
+    parts.append(f'<text x="{rx}" y="86" font-size="11" fill="{c["muted"]}" '
+                 'font-weight="600">DOES IT REPLICATE?</text>')
+    parts.append(f'<text x="{rx}" y="104" font-size="10" fill="{c["muted"]}">'
+                 'paired per invoice · only disagreements count</text>')
+
+    row_y, row_h, scale = 122, 46, 4.5
+    for i, (label, wins, losses, noise) in enumerate(SEEDS):
+        y = row_y + i * row_h
+        parts += [
+            f'<text x="{rx}" y="{y + 10}" font-size="10.5" fill="{c["fg"]}" '
+            f'font-weight="600">{label}</text>',
+            f'<rect x="{rx + 52}" y="{y}" width="{wins * scale:.1f}" height="13" '
+            f'rx="3" fill="{c["bar"]}"/>',
+            f'<text x="{rx + 52 + wins * scale + 6:.1f}" y="{y + 11}" class="v" '
+            f'font-size="10.5" fill="{c["fg"]}">{wins}–{losses}</text>',
+        ]
+        nw = max(2.0, noise * scale)
+        parts += [
+            f'<rect x="{rx + 52}" y="{y + 16}" width="{nw:.1f}" height="7" rx="2" '
+            f'fill="{c["warn"]}"/>',
+            f'<text x="{rx + 52 + nw + 6:.1f}" y="{y + 23}" font-size="9.5" '
+            f'fill="{c["muted"]}">noise {noise}</text>',
+        ]
+
+    parts.append(f'<text x="{rx}" y="{row_y + 3 * row_h + 6}" font-size="10" '
+                 f'fill="{c["fg"]}">wins–losses for the learned rules, '
+                 'p&lt;0.0001</text>')
+    parts.append(f'<text x="{rx}" y="{row_y + 3 * row_h + 21}" font-size="10" '
+                 f'fill="{c["muted"]}">noise = two passes over the SAME memory</text>')
+
+    parts += [
+        f'<text x="32" y="{H - 18}" font-size="10.5" fill="{c["muted"]}">{FOOTER}</text>',
+        '</svg>',
+    ]
+    return "\n".join(parts)
+
+
+def main() -> None:
+    out = REPO / "docs" / "assets"
+    out.mkdir(parents=True, exist_ok=True)
+    for theme in THEMES:
+        path = out / f"expense-learning-{theme}.svg"
+        path.write_text(render(theme), encoding="utf-8")
+        print(f"wrote {path.relative_to(REPO)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three defects in the path between evidence and action, each found by pointing
the loop at a real workflow instead of a synthetic one, plus the measurement
that found them.

Every one of them produced a **plausible null result rather than an error** —
the loop ran, proposed nothing or proposed something inert, and the run
completed looking like a model with little to say. That is precisely the
failure a score-only benchmark cannot surface, and it is why the interesting
part of this PR is the diagnosis rather than the number.

## `loop`: a human's note reached the model as an empty line

`grain_brief` renders each grain for the LLM evidence bundle. Its fact-triple
branch needs subject+relation+object; an Observation carries subject and
object but **no relation**, so it fell through to a fallback checking
`content`/`body`/`text`/`summary` — and never `object`, which is where the
store actually puts an Observation's text.

So every human note in every memory was handed to the model as `""`. The
single highest-value evidence a memory holds was the one shape that rendered
to nothing, and an explicit instruction from a person could never become a
lesson.

Found against a real memory, where an accountant's *"I also need the vendor,
the amount and the currency"* produced no proposal at all. With `object` in
the list the same pass proposes exactly that rule.

Two things about how it was missed are worth recording:

- The bench had **already hit this and worked around it** —
  `record_supervisor_note` duplicated the note into `extra_fields["body"]`,
  with a comment saying `grain_brief` would otherwise hand the model an empty
  line. The workaround is removed here along with the cause.
- Nothing caught it because the **test helper encoded the same mistake**:
  `testkit`'s `add_observation` puts text in `body`, matching the renderer
  rather than the store, so the one grain shape a real memory actually
  produces went untested. Adds `add_human_note` (subject + object, no
  relation, as the store writes it) and a regression test, verified to fail
  with `got: ""` before the fix.

## `loop`: a lesson could only prevent, never start doing something

The lesson contract asked for a rule *"preventing a recurring mistake,
phrased to apply BEFORE it happens"*, with a worked example of the shape
`[action] before [event]; [consequence]`. Every slot in that vocabulary is
preventive.

Some recurring mistakes cannot be phrased that way. When an agent simply never
produces a field, the rule it needs is **additive**. Asked to explain exactly
that failure, the model reached for the nearest allowed shape and proposed
*"Validate all required invoice fields — Date, Vendor, Amount, Currency —
before submission; missing any causes rejection"* — structurally a copy of the
example.

That rule is correct, and it is a no-op:

| Rule in force | Vendor | Amount | Currency |
|---|---|---|---|
| "**Validate** all required invoice fields…" | 0/30 | 0/30 | 0/30 |
| "**Capture** Vendor Name, Amount, Currency…" | 6/6 | 6/6 | 6/6 |

Same fields, same position in the prompt, different verb. "Validate" and
"verify" name a review step the agent has no way to perform.

**A lesson can pass DISCOVER, GROUND, VERIFY, human review, apply and render
— every gate the engine has — and still change nothing, because no gate asks
whether the wording maps onto an action the agent can take.** Correctness and
operativeness are different properties and only the first was being checked.

Widens the contract to admit an additive rule alongside an ordering one, and
says plainly that a lesson must name the action rather than a check on it.

## `bench`: a failing grader was masquerading as a model with nothing to say

`grounded: 0` conflated two opposite conditions — the gate correctly refusing
every draft, and the backend never answering. Splits them into
`ground_verdicts` and `ground_call_failed` on `LlmFunnel`, and raises the
adapter's retries, after a leg that was failing outright read as a quiet gate.

Also fixes the pin probe, which sent `response_format=json_object` with the
message body `"{}"`. OpenAI rejects that (*"'messages' must contain the word
'json' in some form"*), so every OpenAI-served model failed its own pin check
and was reported as a **bad provider tag** — a misleading diagnosis for a
working pin.

## `bench`: the measurement

`crates/areev-bench/EXPENSE.md` records a governed-self-improvement result on
a real expense workflow: an operator's own supplier invoices and the
spreadsheet they fill from them. The corpus is private and stays out of this
repo; only counts travel, and the harness lives with the data. What is
reproducible here is the design, not the corpus.

The result is **paired**, because the unpaired version was worthless — eight
exploratory runs ranged 0.9%–13.0% whole-run accuracy, and two runs differing
only by a prompt header scored 13.0% and 0.9%. One flip in an early review
decision diverges every correction after it, so between-run noise exceeded the
effect. Each held-out invoice is therefore its own control, read twice under
prompts identical but for the learned rules being applied or rolled back,
scored by McNemar over the pairs that disagree.

```
seed 1: 21–0    seed 2: 32–0    seed 3: 30–0    all p<0.0001
noise floor (two passes over IDENTICAL memory): 1, 1, 0 of 210 trials
```

Zero regressions in any seed against a noise floor of 0–1. Arm A is a genuine
rollback through the API, not a refusal to render — the claim is that the
governed apply is the lever, so withdrawing it travels the governance path.

`scripts/expense_curve_chart.py` renders the chart, quoting `EXPENSE.md` the
way `bench_chart.py` quotes `RESULTS.md`, with the noise floor drawn on the
same axes as the effect rather than in a caption.

`EXPENSE.md` also carries what the result does **not** show: 17% absolute
accuracy, three of seven fields that never move, one dataset and one held-out
slice, and a review stand-in that is a model applying a fixed rubric rather
than a person.

## Test plan

- `cargo test --workspace` green
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- New regression test `human_note_evidence_reaches_the_llm_with_text`,
  verified to fail with `got: ""` without the `grain_brief` fix
- `cargo test -p areev --test golden_loop_tests` green (34 passed) — the
  lesson-contract wording change does not move golden output
- `python3 scripts/check_versions.py`, `python3 scripts/repo_stats.py --check`

https://claude.ai/code/session_015JMmK9Z6H2xeMGpkHLFKwv
