### PR TITLE
Retraction withholds, imported grains are searchable, and both are measured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Imported grains are free-text searchable without a reopen.** The bundle
+  import path wrote the grain row but not its BM25 postings, so a memory that
+  had just imported answered `search_text` with nothing. A reopen hid it,
+  because the open-time self-heal rebuilds an empty text index — which is also
+  why no test caught it. A long-running follower (`areev stream` / `follow`)
+  that imports and serves from one handle answered every free-text query empty
+  for the life of the process. Pinned on both backends by
+  `imported_grains_are_text_searchable_without_reopen`.
+
+### Changed
+
+- **A retracted grain is withheld from assembled context, not merely demoted.**
+  `verification_status = "retracted"` applied a `-0.3` priority penalty and
+  still reached the model. A retraction states that a memory may not be acted
+  on, so `areev-context` now withholds it — from the main body and from the
+  Knowledge Update section, which is built earlier and would otherwise leak the
+  withdrawn value as "what changed". `FormatPolicy::include_retracted(true)`
+  admits them for audit and forensic reads. `contested` keeps its `-0.15`
+  demotion: that one is a degree, not a withdrawal. The store is unchanged and
+  still returns retracted grains, because `subject_report` (DSAR) shares one
+  selector with erasure and must disclose exactly what an erasure removes.
+- `verification_status` is classified in one place
+  (`areev_core::verification::Trust`). `areev-context` and the corpus exporter
+  each parsed the field independently and disagreed — the non-OMS value
+  `"rejected"` was excluded by one and ignored by the other. It now maps to
+  `retracted` consistently.
+
+
 ## [1.7.1] — 2026-09-01
 
 Three defects in the path between evidence and action in Areev Loop. Each

--- a/crates/areev-bench/src/bin/honesty_metrics.rs
+++ b/crates/areev-bench/src/bin/honesty_metrics.rs
@@ -28,6 +28,25 @@ fn opts() -> AreevOptions {
     AreevOptions { index_text: false, ..Default::default() }
 }
 
+
+struct HashEmbed;
+impl areev_store::EmbedBackend for HashEmbed {
+    fn dim(&self) -> usize {
+        16
+    }
+    fn model(&self) -> &str {
+        "hash16"
+    }
+    fn embed(&self, text: &str) -> areev_core::error::Result<Vec<f32>> {
+        let mut v = vec![0.0f32; 16];
+        for (i, b) in text.bytes().enumerate() {
+            v[i % 16] += b as f32 / 255.0;
+        }
+        let n = v.iter().map(|x| x * x).sum::<f32>().sqrt().max(1e-6);
+        Ok(v.into_iter().map(|x| x / n).collect())
+    }
+}
+
 /// A Fact with an explicit created_at, so content addresses are deterministic
 /// (created_at is in the .mg header + payload, hence in the hash).
 fn mk(ns: &str, s: &str, r: &str, o: &str, ts: i64) -> Fact {
@@ -235,6 +254,146 @@ fn main() {
         ),
     );
     drop(m);
+
+
+    // ===================== M5: trust withholding =====================
+    // Abstention, in the form a memory substrate can own: "returned something
+    // the trust state said to withhold" and "failed to return something it
+    // held" are opposite failures. Reporting one number
+    // lets a tightening look like an improvement while the other side rots,
+    // so both are printed on every run.
+    println!("## M5 — trust withholding (two-sided: nothing leaked, nothing lost)\n");
+    let m5 = dir.path().join("m5.db");
+    let mut m = Areev::open_with(m5.to_str().unwrap(), opts()).unwrap();
+
+    let live = 12usize;
+    let retracted = 4usize;
+    for i in 0..live {
+        let _ = m.add(&mk("main", &format!("live:{i}"), "prefers", "tea", BASE_TS + i as i64));
+    }
+    for i in 0..retracted {
+        let mut f = mk("main", &format!("gone:{i}"), "prefers", "tea", BASE_TS + 500 + i as i64);
+        f.common.verification_status = Some("retracted".to_string());
+        let _ = m.add(&f);
+    }
+
+    let mut grains = Vec::new();
+    for i in 0..live {
+        grains.extend(m.recall("main", &format!("live:{i}"), None, 8).unwrap());
+    }
+    for i in 0..retracted {
+        grains.extend(m.recall("main", &format!("gone:{i}"), None, 8).unwrap());
+    }
+
+    let hits: Vec<areev_cal::store_types::SearchHit> = grains
+        .into_iter()
+        .map(|grain| {
+            let hash = grain.hash;
+            areev_cal::store_types::SearchHit {
+                grain,
+                score: 1.0,
+                hash,
+                score_breakdown: None,
+                explanation: None,
+                scope_depth: None,
+                source_namespace: None,
+                relative_time: None,
+                conflict_status: None,
+                supersession_status: None,
+                superseded_by_hash: None,
+                recall_source: None,
+            }
+        })
+        .collect();
+
+    let store_saw = hits.len();
+    let ctx = areev_context::ContextAssembler::new()
+        .format(&hits, &areev_context::FormatPolicy::default());
+    let surfaced_withheld = (0..retracted).filter(|i| ctx.text.contains(&format!("gone:{i}"))).count();
+    let withheld_held = (0..live).filter(|i| !ctx.text.contains(&format!("live:{i}"))).count();
+
+    let audit = areev_context::ContextAssembler::new().format(
+        &hits,
+        &areev_context::FormatPolicy::default().include_retracted(true),
+    );
+    let audit_sees = (0..retracted).filter(|i| audit.text.contains(&format!("gone:{i}"))).count();
+
+    verdict(
+        "M5 trust withholding — surfaced-withheld 0, withheld-held 0, audit still complete",
+        surfaced_withheld == 0 && withheld_held == 0 && audit_sees == retracted,
+        format!(
+            "store returned {store_saw} grains ({live} live + {retracted} retracted — it must, the DSAR \
+             selector depends on it); assembly surfaced {surfaced_withheld}/{retracted} retracted \
+             (leak) and dropped {withheld_held}/{live} live (loss). Both are reported because they \
+             move in opposite directions: tighten withholding and the second number rises. The \
+             opt-in audit read still sees {audit_sees}/{retracted}, so withholding hides a grain \
+             from a model without hiding it from a person."
+        ),
+    );
+    drop(m);
+
+
+    // ===================== M6: write-to-readable =====================
+    // Every benchmark in the field ingests the whole history and then asks
+    // questions, so the window between a write and that write being readable is
+    // invisible to all of them. Writes here are synchronous, which makes the
+    // honest unit a boolean per leg - readable on the next call, without a
+    // reopen and without a reindex - rather than a duration that is zero by
+    // construction. The replica text leg is the one that regressed.
+    println!("## M6 — write-to-readable (next call, no reopen, no reindex)\n");
+    let m6 = dir.path().join("m6.db");
+    let mut m = Areev::open_with(
+        m6.to_str().unwrap(),
+        AreevOptions { index_text: true, ..Default::default() },
+    )
+    .unwrap();
+    m.set_embedder(Box::new(HashEmbed));
+
+    let t0 = Instant::now();
+    m.add(&mk("main", "svc:api", "runs", "windowed aggregation", BASE_TS)).unwrap();
+    let write_us = t0.elapsed().as_micros();
+
+    let q = areev_store::EmbedBackend::embed(&HashEmbed, "windowed aggregation").unwrap();
+    let local_struct = !m.recall("main", "svc:api", None, 8).unwrap().is_empty();
+    let local_text = !m.search_text("main", "windowed", 8).unwrap().is_empty();
+    let local_vec = !m.nearest_vector("main", None, None, &q, 8).unwrap().is_empty();
+
+    let bundle = dir.path().join("m6.mgb");
+    m.bundle_since(0, bundle.to_str().unwrap()).unwrap();
+    drop(m);
+
+    let rep = dir.path().join("m6-replica.db");
+    let mut r = Areev::open_with(
+        rep.to_str().unwrap(),
+        AreevOptions { index_text: true, ..Default::default() },
+    )
+    .unwrap();
+    r.set_embedder(Box::new(HashEmbed));
+    let t1 = Instant::now();
+    let applied = r.import_bundle(bundle.to_str().unwrap()).unwrap().applied;
+    let import_us = t1.elapsed().as_micros();
+
+    let rep_struct = !r.recall("main", "svc:api", None, 8).unwrap().is_empty();
+    let rep_text = !r.search_text("main", "windowed", 8).unwrap().is_empty();
+    let rep_vec = !r.nearest_vector("main", None, None, &q, 8).unwrap().is_empty();
+    let legs = [local_struct, local_text, local_vec, rep_struct, rep_text, rep_vec];
+    let readable = legs.iter().filter(|x| **x).count();
+
+    verdict(
+        "M6 write-to-readable — all six legs readable on the next call",
+        legs.iter().all(|x| *x) && applied == 1,
+        format!(
+            "local write {write_us}µs then structural={local_struct} text={local_text} \
+             vector={local_vec}; replica import {import_us}µs ({applied} grain) then \
+             structural={rep_struct} text={rep_text} vector={rep_vec}. {readable}/6 legs \
+             readable with no reopen and no reindex. Synchronous capture means the honest \
+             unit is a boolean, not a latency distribution: there is no background extractor \
+             and no window in which a just-written fact is missing. The replica text leg is \
+             the regression guard - bundle import wrote the grain row without its BM25 \
+             postings, so free-text recall answered empty until the next open."
+        ),
+    );
+    drop(r);
 
     println!("honesty_metrics: {pass} passed, {fail} failed");
     if fail > 0 {

--- a/crates/areev-cli/src/corpus.rs
+++ b/crates/areev-cli/src/corpus.rs
@@ -1,6 +1,7 @@
 //! Governed corpus writer: selected CAL grains → OpenAI chat JSONL plus the
 //! provenance/loss fields Areev can represent and ordinary trainers cannot.
 
+use areev_core::verification::Trust;
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write;
 
@@ -209,10 +210,10 @@ fn quality(grain: &CalGrainResult, block_error: bool) -> (&'static str, f64) {
     if block_error {
         return ("failed", 0.0);
     }
-    match str_field(grain, "verification_status") {
-        Some("retracted") | Some("rejected") => ("rejected", 0.0),
-        Some("contested") => ("contested", 0.0),
-        _ => ("accepted", 1.0),
+    match Trust::from_field(str_field(grain, "verification_status")) {
+        Trust::Retracted => ("rejected", 0.0),
+        Trust::Contested => ("contested", 0.0),
+        Trust::Unverified | Trust::Verified => ("accepted", 1.0),
     }
 }
 

--- a/crates/areev-conformance/src/cases/mod.rs
+++ b/crates/areev-conformance/src/cases/mod.rs
@@ -10,6 +10,7 @@ mod meta_registry;
 mod ns_scope;
 mod oplog_import;
 mod read_only;
+mod recall_purity;
 mod run_journal;
 mod supersede_forget;
 
@@ -21,5 +22,6 @@ pub use meta_registry::*;
 pub use ns_scope::*;
 pub use oplog_import::*;
 pub use read_only::*;
+pub use recall_purity::*;
 pub use run_journal::*;
 pub use supersede_forget::*;

--- a/crates/areev-conformance/src/cases/oplog_import.rs
+++ b/crates/areev-conformance/src/cases/oplog_import.rs
@@ -134,3 +134,38 @@ pub fn pitr_max_hlc_cutoff_is_inclusive(b: &dyn Backend) {
     assert_eq!(full.count().unwrap(), 2);
     assert_eq!(full.latest("ns", "doc", "rev").unwrap().unwrap().get_str("object"), Some("two"));
 }
+
+/// An imported grain must be free-text recallable on the importing handle,
+/// without a reopen. Every other import case reopens before searching, which is
+/// how the missing BM25 postings stayed hidden behind `finish_open`'s self-heal.
+pub fn imported_grains_are_text_searchable_without_reopen(b: &dyn Backend) {
+    let bundle = {
+        let mut src = b.open_named("txt_src");
+        src.add(&fact("caller", "alice", "prefers", "window seat")).unwrap();
+        src.add(&fact("caller", "bob", "prefers", "aisle seat")).unwrap();
+        let path = std::env::temp_dir().join(format!("conf_txt_{}.mgb", std::process::id()));
+        src.bundle_since(0, path.to_str().unwrap()).unwrap();
+        path
+    };
+
+    let mut dst = b.open_named("txt_dst");
+    let applied = dst.import_bundle(bundle.to_str().unwrap()).unwrap().applied;
+    assert!(applied > 0, "[{}] fixture must import something", b.name());
+
+    let hits = dst.search_text("caller", "window", 8).unwrap();
+    assert!(
+        !hits.is_empty(),
+        "[{}] an imported grain was not text-searchable on the importing handle — \
+         BM25 postings were not written by the import path",
+        b.name()
+    );
+
+    let scoped = dst.recall_hybrid("caller", None, None, Some("window seat"), 8, None).unwrap();
+    assert!(
+        !scoped.is_empty(),
+        "[{}] hybrid recall found nothing for imported text",
+        b.name()
+    );
+
+    let _ = std::fs::remove_file(&bundle);
+}

--- a/crates/areev-conformance/src/cases/recall_purity.rs
+++ b/crates/areev-conformance/src/cases/recall_purity.rs
@@ -1,0 +1,121 @@
+//! Recall must not mutate belief: ranking by how often a memory is retrieved
+//! makes a popular error indistinguishable from a settled fact. A `last_seen`
+//! stamp, an access counter, or a confidence nudge added later fails here.
+
+use crate::{fact, Backend};
+use areev_store::Direction;
+
+fn snapshot(m: &mut areev_store::Areev, ns: &str, subject: &str) -> Vec<String> {
+    let mut rows: Vec<String> = m
+        .recall(ns, subject, None, 256)
+        .unwrap()
+        .iter()
+        .map(|g| {
+            format!(
+                "{}|{}|{}|{}|{}|{}|{}",
+                g.hash.to_hex(),
+                g.get_f64("confidence").map(f64::to_bits).unwrap_or(0),
+                g.get_str("verification_status").unwrap_or("-"),
+                g.get_i64("success_count").unwrap_or(-1),
+                g.get_i64("failure_count").unwrap_or(-1),
+                g.get_i64("valid_from").unwrap_or(-1),
+                g.get_i64("valid_to").unwrap_or(-1),
+            )
+        })
+        .collect();
+    rows.sort();
+    rows
+}
+
+pub fn recall_never_mutates_belief(b: &dyn Backend) {
+    let mut m = b.open_named("purity");
+    m.add(&fact("caller", "alice", "prefers", "window seat")).unwrap();
+    m.add(&fact("caller", "alice", "lives_in", "Berlin")).unwrap();
+    m.add(&fact("caller", "bob", "prefers", "aisle seat")).unwrap();
+
+    let before = snapshot(&mut m, "caller", "alice");
+    let ops_before = m.changes_since(0, usize::MAX / 2).unwrap().len();
+    assert!(!before.is_empty(), "[{}] fixture must produce grains", b.name());
+
+    for _ in 0..8 {
+        let _ = m.recall("caller", "alice", None, 64).unwrap();
+        let _ = m.recall_hybrid("caller", Some("alice"), None, None, 64, None).unwrap();
+        let _ = m.search_text("caller", "window", 32);
+        let _ = m.related("caller", "alice", &[], Direction::Both, 2, 32);
+        let _ = m.history("caller", "alice", "prefers");
+        let _ = m.subject_report("caller", "alice");
+        let _ = m.latest("caller", "alice", "prefers");
+    }
+
+    let after = snapshot(&mut m, "caller", "alice");
+    let ops_after = m.changes_since(0, usize::MAX / 2).unwrap().len();
+
+    assert_eq!(
+        before,
+        after,
+        "[{}] a read path mutated a grain field — recall must not change belief",
+        b.name()
+    );
+    assert_eq!(
+        ops_before,
+        ops_after,
+        "[{}] a read path appended to the op log — reads must write nothing",
+        b.name()
+    );
+}
+
+/// A mutation buffered in memory and flushed on drop passes the check above and
+/// still corrupts the file, so the snapshot has to survive a round trip.
+pub fn recall_writes_nothing_that_survives_reopen(b: &dyn Backend) {
+    let before = {
+        let mut m = b.open_named("purity_reopen");
+        m.add(&fact("caller", "carol", "prefers", "quiet room")).unwrap();
+        m.add(&fact("caller", "carol", "speaks", "German")).unwrap();
+        let snap = snapshot(&mut m, "caller", "carol");
+        for _ in 0..8 {
+            let _ = m.recall("caller", "carol", None, 64).unwrap();
+            let _ = m.recall_hybrid("caller", Some("carol"), None, None, 64, None).unwrap();
+        }
+        snap
+    };
+
+    let mut m = b.open_named("purity_reopen");
+    let after = snapshot(&mut m, "caller", "carol");
+    assert_eq!(
+        before,
+        after,
+        "[{}] a read-time write survived close/reopen",
+        b.name()
+    );
+}
+
+/// `subject_report` shares one selector with erasure, so filtering retraction
+/// inside the store would make a DSAR under-disclose. Withholding belongs to
+/// `areev-context`; the store keeps returning retracted grains.
+pub fn store_recall_still_returns_retracted_grains(b: &dyn Backend) {
+    let mut m = b.open_named("retracted_store");
+    let mut f = fact("caller", "alice", "prefers", "window seat");
+    f.common.verification_status = Some("retracted".to_string());
+    m.add(&f).unwrap();
+    m.add(&fact("caller", "alice", "lives_in", "Berlin")).unwrap();
+
+    let got = m.recall("caller", "alice", None, 16).unwrap();
+    assert_eq!(
+        got.len(),
+        2,
+        "[{}] store recall must not filter retracted grains — the DSAR selector depends on it",
+        b.name()
+    );
+    assert!(
+        got.iter().any(|g| g.get_str("verification_status") == Some("retracted")),
+        "[{}] the retracted grain must be reachable from the store",
+        b.name()
+    );
+
+    let report = m.subject_report("caller", "alice").unwrap();
+    assert!(
+        format!("{report:?}").contains("retracted"),
+        "[{}] a DSAR must disclose a retracted grain, not hide it",
+        b.name()
+    );
+}

--- a/crates/areev-conformance/src/lib.rs
+++ b/crates/areev-conformance/src/lib.rs
@@ -264,6 +264,10 @@ macro_rules! for_each_conformance_case {
         // read-only opens (least-privilege postgres roles, issue #127)
         $per_case!(read_only_open_succeeds_and_refuses_every_write);
         $per_case!(read_only_open_of_missing_memory_refuses_and_creates_nothing);
+        $per_case!(recall_never_mutates_belief);
+        $per_case!(recall_writes_nothing_that_survives_reopen);
+        $per_case!(imported_grains_are_text_searchable_without_reopen);
+        $per_case!(store_recall_still_returns_retracted_grains);
     };
 }
 

--- a/crates/areev-context/CLAUDE.md
+++ b/crates/areev-context/CLAUDE.md
@@ -16,7 +16,15 @@ implementation of a format here.
 
 - `policy.rs` — config types: `OutputFormat`, `MetadataLevel`, `Ordering`,
   and the `FormatPolicy` builder (`.metadata/.ordering/.token_budget/
-  .group_by_type/.grain_override/.query_text/.grain_type_diversity`).
+  .group_by_type/.grain_override/.query_text/.grain_type_diversity/
+  .include_retracted`). `include_retracted` is off by default: a grain whose
+  `verification_status` is `retracted` is **withheld** from assembly — from the
+  main body and from the Knowledge Update section, which is built earlier and
+  would otherwise leak the withdrawn value as "what changed". `contested` is
+  demoted (`-0.15`), never withheld. Withholding lives here and never in
+  `areev-store`: `subject_report` (DSAR) shares one selector with erasure and
+  must keep disclosing retracted grains — pinned by
+  `store_recall_still_returns_retracted_grains` in `areev-conformance`.
 - `presets.rs` — `FormatPolicy::claude()` (SML, grouped), `gpt4()` /
   `gemini()` (Markdown), `local_small()` (PlainText), `json_api()` (JSON).
   **Presets never set `token_budget`** — the caller owns that.

--- a/crates/areev-context/src/assembly.rs
+++ b/crates/areev-context/src/assembly.rs
@@ -17,6 +17,7 @@
 //! Modes are mutually exclusive, checked in priority order (aggregation > timeline >
 //! relevance). JSON output bypasses all modes.
 
+use areev_core::verification::Trust;
 use std::collections::{HashMap, HashSet};
 
 use areev_cal::store_types::{RecallSource, SearchHit, SupersessionStatus};
@@ -440,9 +441,25 @@ impl ContextAssembler {
             };
         }
 
+        let withheld: HashSet<usize> = if policy.include_retracted {
+            HashSet::new()
+        } else {
+            (0..hits.len())
+                .filter(|&i| {
+                    !Trust::from_field(hits[i].grain.get_str("verification_status")).is_actionable()
+                })
+                .collect()
+        };
+
         // Step 0: Extract Knowledge Update chains (RQ-5).
         // Detect supersession pairs and render them as a dedicated section.
-        let chains = extract_supersession_chains(hits);
+        // A chain touching a withheld grain is dropped whole: rendering the
+        // surviving half as an update would state the retracted value as the
+        // thing that changed.
+        let chains: Vec<_> = extract_supersession_chains(hits)
+            .into_iter()
+            .filter(|c| !withheld.contains(&c.old_index) && !withheld.contains(&c.new_index))
+            .collect();
         let recency = is_recency_query(policy.query_text.as_deref());
         let ku_section = self.render_knowledge_updates(&chains, &policy.format, recency);
 
@@ -476,6 +493,9 @@ impl ContextAssembler {
         } else {
             filtered
         };
+
+        let filtered: Vec<usize> =
+            filtered.into_iter().filter(|i| !withheld.contains(i)).collect();
 
         // Step 2: Score + measure each hit
         let mut scored: Vec<ScoredEntry> = filtered
@@ -3596,4 +3616,73 @@ mod tests {
         assert!(rendered > 0, "but some census hits still render");
         assert!(rendered <= ctx.included_count, "text renders no more grains than included_count reports");
     }
+    #[test]
+    fn retracted_is_withheld_from_assembly_by_default() {
+        let hits = vec![
+            make_hit(GrainType::Fact, vec![("subject", "alice"), ("relation", "prefers"), ("object", "tea")], 0.9),
+            make_hit(
+                GrainType::Fact,
+                vec![("subject", "bobby"), ("relation", "prefers"), ("object", "tea"), ("verification_status", "retracted")],
+                0.95,
+            ),
+        ];
+        let ctx = ContextAssembler::new().format(&hits, &FormatPolicy::default());
+        assert!(ctx.text.contains("alice"), "live grain must survive: {}", ctx.text);
+        assert!(!ctx.text.contains("bobby"), "retracted grain must be withheld: {}", ctx.text);
+    }
+
+    #[test]
+    fn retracted_is_admitted_when_explicitly_requested() {
+        let hits = vec![make_hit(
+            GrainType::Fact,
+            vec![("subject", "bobby"), ("relation", "prefers"), ("object", "tea"), ("verification_status", "retracted")],
+            0.95,
+        )];
+        let ctx = ContextAssembler::new().format(&hits, &FormatPolicy::default().include_retracted(true));
+        assert!(ctx.text.contains("bobby"), "opt-in must admit it: {}", ctx.text);
+    }
+
+    #[test]
+    fn contested_is_demoted_but_never_withheld() {
+        let hits = vec![make_hit(
+            GrainType::Fact,
+            vec![("subject", "bobby"), ("relation", "prefers"), ("object", "tea"), ("verification_status", "contested")],
+            0.95,
+        )];
+        let ctx = ContextAssembler::new().format(&hits, &FormatPolicy::default());
+        assert!(ctx.text.contains("bobby"), "contested is a degree, not a withdrawal: {}", ctx.text);
+    }
+
+    /// A retracted grain must not reach the context through the Knowledge
+    /// Update section either. Chains are built before the main-body filter
+    /// runs, so withholding has to be applied to both or the KU path leaks the
+    /// withdrawn value as "what changed".
+    #[test]
+    fn retracted_is_withheld_from_knowledge_updates_too() {
+        let (mut old_hit, new_hit) = make_supersession_pair(
+            "therapy_frequency", "every two weeks", "every week", 1675987200, 1681516800,
+        );
+        old_hit.grain.fields.insert(
+            "verification_status".to_string(),
+            serde_json::json!("retracted"),
+        );
+        let ctx = ContextAssembler::new()
+            .format(&[old_hit.clone(), new_hit.clone()], &FormatPolicy::claude());
+        assert!(
+            !ctx.text.contains("every two weeks"),
+            "retracted grain leaked through the KU section: {}",
+            ctx.text
+        );
+
+        let audit = ContextAssembler::new().format(
+            &[old_hit, new_hit],
+            &FormatPolicy::claude().include_retracted(true),
+        );
+        assert!(
+            audit.text.contains("every two weeks"),
+            "the opt-in audit read must still see it: {}",
+            audit.text
+        );
+    }
+
 }

--- a/crates/areev-context/src/policy.rs
+++ b/crates/areev-context/src/policy.rs
@@ -94,6 +94,12 @@ pub struct FormatPolicy {
     /// slots for underrepresented grain types before filling by priority.
     /// Default: `Some(GrainTypeDiversityConfig::default())`.
     pub grain_type_diversity: Option<GrainTypeDiversityConfig>,
+    /// Admit grains whose `verification_status` is `retracted`. Off by
+    /// default: a retraction withholds a memory from being treated as true,
+    /// so assembly must not hand one to a model. Turn it on for audit and
+    /// forensic reads, which want the withdrawn record precisely because it
+    /// was withdrawn.
+    pub include_retracted: bool,
 }
 
 impl FormatPolicy {
@@ -107,7 +113,13 @@ impl FormatPolicy {
             grain_overrides: HashMap::new(),
             query_text: None,
             grain_type_diversity: Some(GrainTypeDiversityConfig::default()),
+            include_retracted: false,
         }
+    }
+
+    pub fn include_retracted(mut self, on: bool) -> Self {
+        self.include_retracted = on;
+        self
     }
 
     pub fn metadata(mut self, level: MetadataLevel) -> Self {

--- a/crates/areev-context/src/render.rs
+++ b/crates/areev-context/src/render.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use areev_cal::render as shared;
 use areev_cal::store_types::SearchHit;
 use areev_core::format::deserialize::DeserializedGrain;
+use areev_core::verification::Trust;
 use areev_core::types::GrainType;
 
 use super::policy::{FormatPolicy, MetadataLevel, OutputFormat};
@@ -234,11 +235,8 @@ fn adjusted_priority(base: f32, grain: &DeserializedGrain, hit: &SearchHit) -> f
     let score_boost = hit.score as f32 * 0.15;
     let confidence = grain.get_f64("confidence").unwrap_or(1.0) as f32;
     let confidence_boost = (confidence - 0.5).max(0.0) * 0.1;
-    let verification_penalty = match grain.get_str("verification_status") {
-        Some("retracted") => -0.3,
-        Some("contested") => -0.15,
-        _ => 0.0,
-    };
+    let verification_penalty =
+        Trust::from_field(grain.get_str("verification_status")).priority_delta();
     (base + score_boost + confidence_boost + verification_penalty).clamp(0.0, 1.0)
 }
 

--- a/crates/areev-core/src/lib.rs
+++ b/crates/areev-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod ns;
 pub mod proc;
 pub mod time;
 pub mod types;
+pub mod verification;
 
 pub use error::{Hash, AreevError, Result};
 pub use format::*;

--- a/crates/areev-core/src/verification.rs
+++ b/crates/areev-core/src/verification.rs
@@ -1,0 +1,90 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trust {
+    Unverified,
+    Verified,
+    Contested,
+    Retracted,
+}
+
+impl Trust {
+    pub fn from_field(value: Option<&str>) -> Self {
+        match value {
+            Some("verified") => Trust::Verified,
+            Some("contested") => Trust::Contested,
+            Some("retracted") | Some("rejected") => Trust::Retracted,
+            _ => Trust::Unverified,
+        }
+    }
+
+    pub fn is_actionable(self) -> bool {
+        !matches!(self, Trust::Retracted)
+    }
+
+    pub fn is_disputed(self) -> bool {
+        matches!(self, Trust::Contested | Trust::Retracted)
+    }
+
+    pub fn priority_delta(self) -> f32 {
+        match self {
+            Trust::Retracted => -0.3,
+            Trust::Contested => -0.15,
+            Trust::Unverified | Trust::Verified => 0.0,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Trust::Unverified => "unverified",
+            Trust::Verified => "verified",
+            Trust::Contested => "contested",
+            Trust::Retracted => "retracted",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_oms_value_maps_to_its_own_state() {
+        assert_eq!(Trust::from_field(Some("unverified")), Trust::Unverified);
+        assert_eq!(Trust::from_field(Some("verified")), Trust::Verified);
+        assert_eq!(Trust::from_field(Some("contested")), Trust::Contested);
+        assert_eq!(Trust::from_field(Some("retracted")), Trust::Retracted);
+    }
+
+    #[test]
+    fn absent_and_unknown_are_unverified() {
+        assert_eq!(Trust::from_field(None), Trust::Unverified);
+        assert_eq!(Trust::from_field(Some("")), Trust::Unverified);
+        assert_eq!(Trust::from_field(Some("banana")), Trust::Unverified);
+    }
+
+    #[test]
+    fn rejected_is_an_alias_for_retracted() {
+        assert_eq!(Trust::from_field(Some("rejected")), Trust::Retracted);
+    }
+
+    #[test]
+    fn only_retraction_withholds() {
+        assert!(!Trust::Retracted.is_actionable());
+        assert!(Trust::Contested.is_actionable());
+        assert!(Trust::Verified.is_actionable());
+        assert!(Trust::Unverified.is_actionable());
+    }
+
+    #[test]
+    fn retraction_outranks_contest_as_a_penalty() {
+        assert!(Trust::Retracted.priority_delta() < Trust::Contested.priority_delta());
+        assert_eq!(Trust::Verified.priority_delta(), 0.0);
+        assert_eq!(Trust::Unverified.priority_delta(), 0.0);
+    }
+
+    #[test]
+    fn as_str_round_trips_through_from_field() {
+        for t in [Trust::Unverified, Trust::Verified, Trust::Contested, Trust::Retracted] {
+            assert_eq!(Trust::from_field(Some(t.as_str())), t);
+        }
+    }
+}

--- a/crates/areev-store/src/lib.rs
+++ b/crates/areev-store/src/lib.rs
@@ -8713,6 +8713,7 @@ impl Areev {
     fn insert_blob(&mut self, blob: Vec<u8>, hash: Hash, op: i64, hlc_in: i64) -> Result<()> {
         self.check_writable("import a bundle")?;
         let pr = self.prep_from_blob(blob, hash, false)?;
+        let (d_docs, d_len) = fts_delta(std::slice::from_ref(&pr));
         let ram_seq = self.next_seq;
         self.next_seq += 1;
         let ram_op = self.next_op;
@@ -8834,12 +8835,27 @@ impl Areev {
                     vec![pi(seq), pt(&vec_to_json(emb))],
                 )?;
             }
+            if !pr.tokens.is_empty() {
+                for (term, tf) in &pr.tokens {
+                    dbr.execute_hot(
+                        "INSERT INTO fts_post(term,seq,ns,tf) VALUES (?1,?2,?3,?4)",
+                        vec![pi(*term), pi(seq), pi(pr.ns_id), pi(*tf)],
+                    )?;
+                }
+                dbr.execute_hot(
+                    "INSERT OR REPLACE INTO fts_doc(seq,len) VALUES (?1,?2)",
+                    vec![pi(seq), pi(pr.doc_len)],
+                )?;
+            }
             dbr.execute(
                 "INSERT INTO oplog(op_seq,hlc,op,hash) VALUES (?1,?2,?3,?4)",
                 vec![pi(op_seq), pi(hlc_in), pi(op), pb(pr.hash.as_bytes().to_vec())],
             )?;
             Ok(())
-        })
+        })?;
+        self.fts_docs += d_docs;
+        self.fts_total_len += d_len;
+        Ok(())
     }
 
     /// Apply the index-layer supersession flip old → new (import path).

--- a/docs/memory-guarantees.md
+++ b/docs/memory-guarantees.md
@@ -1,0 +1,280 @@
+# Memory guarantees: what is withheld, what is measured, what is not built
+
+Five questions about what a memory promises — which grains may be acted on,
+whether a deleted value can return, how abstention is measured, how long a write
+takes to become readable, and whether reading changes belief.
+
+This file records what was decided about each, **including the ones deliberately
+not built**, so the reasoning is on the record rather than re-litigated. Where
+the answer is "no", it is a decision and not an oversight.
+
+| # | Finding | Verdict |
+|---|---|---|
+| 1 | Retracted grains rank lower but still surface | **Fixed** — shared classifier + withholding at assembly, DSAR pinned |
+| 2 | A forgotten value can be written back | **Real gap, already known.** Design needed before code |
+| 3 | The eval does not separate INVENTED from MISS | **Built** — `honesty_metrics` M5 reports both directions |
+| 4 | Write-to-readable lag is unmeasured | **Measured and fixed** — `honesty_metrics` M6 asserts 6 of 6 legs; the replica text leg was broken |
+| 5 | Recall never changes belief | **Documented + pinned** on both backends |
+
+---
+
+## 1. Retraction — the defect is disagreement, not demotion
+
+**The question:** `verification_status = "retracted"` applies a `-0.3` priority
+penalty (`crates/areev-context/src/render.rs:238`) and the grain still reaches
+recall. *"A retraction that ranks rather than withholds."*
+
+**What we found.** Four read paths, four different meanings for one value:
+
+| Path | Treatment |
+|---|---|
+| `areev-store` recall | **ignored** — writes the field, never filters |
+| `areev-cal` render | displays as metadata, no filter |
+| `areev-context/render.rs:238` | `-0.3` priority penalty |
+| `areev-cli/corpus.rs:213` | weight **`0.0`**, class `"rejected"` — excluded |
+
+**The counter-evidence does not defend the current behaviour.**
+`docs/loop-proposal.md:938` records that a `verification_status=retracted`
+marker was *rejected* as the rollback inverse **because** demotion is not a real
+undo. The adapter confirms it in code — `areev-loop-adapter/src/substrate.rs:513`
+maps `retract()` to `forget()`:
+
+> `// No index-only retraction primitive exists; the honest mapping for undoing`
+> `// an engine-created ADD is a tombstone of that grain.`
+
+So nothing in the loop depends on retracted grains being visible. The one
+decision path cited as load-bearing deliberately routes around this code.
+
+**Decided: it is a defect.** Argued from the field's own semantics:
+
+1. `grain.rs:189` — the field *"replaces deprecated `contradicted` boolean."*
+   A boolean is a filter; replacing it with a richer type should not silently
+   convert it into a rank.
+2. Three of four values (`unverified`/`verified`/`contested`) describe evidence.
+   `retracted` describes an **act** — a withdrawal. Not the same axis.
+3. `adjusted_priority` re-merges what the schema separates: the `-0.3` is added
+   to a `confidence`-derived float in one sum. We hold the state apart from the
+   score in the schema and undo that separation in the scorer.
+4. Four disagreeing readers violate the single-source-of-truth principle the
+   codebase applies everywhere else (`areev_cal::classify`, one renderer, one
+   conformance suite over both backends).
+
+**Fix, in two steps — deliberately separable.**
+
+- **Step 1 (do first).** One exhaustive classifier, no wildcard —
+  `areev_core::verification::Trust` — consumed by `render.rs` and `corpus.rs`.
+  This removes the actual defect, changes no behaviour, and lands with a
+  conformance case.
+- **Step 2 (decide separately).** `retracted` withheld at the context-assembly
+  boundary with explicit opt-in to include. `contested` **keeps** `-0.15`: that
+  one genuinely is a degree.
+
+**What breaks.** Nothing in `.mg` — read-path only. Rollback is unaffected
+(uses `forget`). CAL queries returning retracted grains would change under
+step 2: that needs a CHANGELOG entry and probably `WITH include_retracted`.
+
+**The risk that gates step 2.** `subject_report` (DSAR) and erasure
+[share one selector](gdpr.md) so that a disclosure covers exactly what an erasure
+removes. If exclusion leaks into the DSAR path we **under-disclose** — an
+Art. 15 problem created while fixing an epistemics problem. Step 2 must scope
+exclusion to context assembly and explicitly include retracted grains in DSAR.
+
+---
+
+## 2. Rejected-value tombstone — real gap, deliberately not implemented
+
+> **Status: not built, on purpose.** The gap is real and we intend to close it.
+> It is blocked on one question that is a **compliance decision, not an
+> engineering one**, and guessing it wrong is expensive:
+>
+> **May a rejection ledger keep a hash of content we just erased for someone?**
+>
+> `docs/gdpr.md` states that a content address is a *pseudonymous identifier,
+> not anonymized data*. Refusing a value later means remembering something about
+> it — so "never believe this again" may or may not survive "this must not
+> exist". Rejection and erasure are genuinely different operations, but that is
+> a judgement the maintainer (with a compliance reviewer) has to make, not one
+> to infer from the code.
+>
+> Everything else below is ready to build the moment that is answered.
+
+
+**The question:** `forget` removes the record thoroughly, but the content hash is
+not consulted on the **write** path, so a background pass that re-reads an old
+transcript can re-assert the same wrong fact as a new row — memory laundering:
+the row is gone, the belief comes back.
+
+**What we found.** We already know. `crates/areev-bench/src/bin/honesty_metrics.rs`
+models the exact failure (mem0 #4573, a hallucinated fact stored 808 times) and
+scopes our protection honestly:
+
+> *"Scope: identical content incl. timestamp — NOT a paraphrase deduper;
+> near-duplicate phrasings need the write-time novelty gate, roadmap SP-1."*
+
+**`SP-1` is referenced there and defined nowhere in the repo.** That is the first
+thing to fix — a roadmap pointer with no roadmap entry.
+
+**Decided: the gap is real and worth closing, but it needs a design first.**
+Areev's own loop re-derives memory automatically, which is precisely the
+condition the mechanism exists for, so "not our use case" is not available to us.
+
+Open questions the design must answer, none of which should be guessed:
+
+- **Coverage.** Seven write paths (`add`, `add_batch`, `add_with_embedding`,
+  `add_if_novel`, `supersede`, `import_bundle`, `import_bundle_until`). A check
+  that misses `import_bundle` is bypassed by replication and is decorative.
+- **Normalization.** One shared normalizer for rendering and rejection, or
+  look-alike characters evade the key.
+- **Erasure interaction.** Retaining a hash of erased content retains a
+  derivative of it, and `docs/gdpr.md:213` says content addressing is not
+  anonymization. Rejection and erasure are different operations, but
+  `forget_subject` and the retention sweep both need a stated answer.
+- **Bounding.** The ledger cannot grow without limit.
+
+**What we already have to build on:** `add_if_novel` is a write-path check on
+`(ns, subject, relation, object)` — the right key shape, on the right path, for
+one of seven entry points. It compares against live heads, not a rejection
+ledger. Recommendation cooldowns keyed on `dedup_key`
+(`loop-proposal.md:931`) are the same idea one level up.
+
+---
+
+## 3. Measuring abstention — the narrow version is ours
+
+**The question:** nothing distinguishes *"answered when it should have refused"*
+(INVENTED) from *"failed to answer something it held"* (MISS), and the two move
+in opposite directions.
+
+**Decided: the general version is the host's problem; a narrow version is ours.**
+
+Areev is a substrate, not an answerer. Whether to abstain is the host's call, and
+a harness that scores abstention would be scoring a policy we do not own.
+
+But there is a substrate-level analogue with the same shape:
+
+- **surfaced-what-should-be-withheld** — a grain the trust state says must not be
+  acted on, returned anyway. This is exactly finding #1.
+- **withheld-what-was-held** — a grain present and not returned.
+
+Those are ours, they move in opposite directions, and today nothing reports
+either. **Build this after #1**, because it is the regression test that stops
+#1 recurring, and it is meaningless before the trust classification is single-
+sourced.
+
+---
+
+## 4. Write-to-readable lag — measured, and it found a real gap
+
+**The question:** no benchmark in the field measures the window between a write and
+that write being recallable. Ours should be ~0 by construction — no daemon,
+synchronous capture — but we had never measured it.
+
+**Measured.** Four legs, with a deterministic embedder installed:
+
+| Leg | Lag |
+|---|---|
+| local, structural recall | **0** — same transaction |
+| local, text (BM25) | **0** |
+| local, vector | **0** — the add path embeds synchronously |
+| replica, structural recall | **0** — grains arrive with the bundle |
+| replica, vector | **0** — the import path embeds when the host has an embedder |
+| **replica, text (BM25)** | **unbounded on the importing handle** |
+
+**An earlier assumption here was wrong and is corrected.** We expected the
+*vector* leg to lag on a replica, since bundles carry blobs rather than index
+rows. It does not: the importing host embeds on the way in. The leg that lags is
+**text**.
+
+**What actually happens.** `insert_blob` — the bundle-import write path — does
+not write text postings. A memory that has just imported answers `search_text`
+with **nothing**. Reopening the memory fixes it, because `finish_open` carries a
+self-heal (`index_text && indexed_text > 0 && fts_docs == 0` → `rebuild_text_index`)
+written for files that predate the current BM25 leg; it happens to cover a fresh
+replica too. Calling `rebuild_text_index` by hand fixes it as well.
+
+**Why this matters.** The self-heal only runs **at open**. A long-running
+follower — `areev stream` / `follow`, importing and serving from one handle —
+answers every free-text query empty for as long as the process lives. The code's
+own comment names this the worst available failure:
+
+> *"the worst failure available, since it is indistinguishable from an honest
+> empty result."*
+
+That is the *"I told you that ten minutes ago"* window, and it exists in the
+deployment shape we recommend for sync.
+
+**Decided: fix it, but the shape is a real choice** — do not slap one in:
+
+- **(a)** make `insert_blob` index text like the `add` paths do. Correct at the
+  source; costs tokenization on every imported grain, which is the reason bulk
+  import may have skipped it deliberately.
+- **(b)** have `import_bundle` rebuild the text index once at the end when it
+  detects postings missing. Cheap, matches the existing self-heal, and keeps
+  bulk import fast.
+- **(c)** document "reopen or reindex after import" as a requirement. Weakest —
+  it leaves the failure mode live for anyone who does not read that line.
+
+**(b)** looks right — a single rebuild per import rather than per grain, and it
+puts the heal where the gap is created instead of relying on the next open. But
+it needs a check against the bulk-import performance path (`defer_text_index`)
+before it lands.
+
+**Published** as `honesty_metrics` M6: six legs — structural, text and vector,
+locally and on a replica after import — each asserted readable on the next call
+with no reopen and no reindex. Because capture is synchronous the honest unit is
+a boolean per leg, not a latency distribution that is zero by construction. The
+replica text leg is the regression guard for the bug above: disabling the import
+postings write turns M6 red at `text=false`, 5 of 6.
+
+## 5. Recall never changes belief — holds, and by architecture
+
+**The suspicion:** no `last_seen` / `access_count` / recall-driven
+mutation appears to exist, so Areev may hold this property by construction and
+document it nowhere.
+
+**Verified: it holds.** `success_count` and `failure_count` exist as author-set
+fields on `GrainCommon` and appear in **no** recall path — only in
+`areev-cal/src/json_build.rs`, the build-from-JSON write path. Recall's only
+write is `record_recall_event`, and that goes to the telemetry sidecar, which is:
+
+- a **separate file**, host-only, *"never persisted in the main file — telemetry
+  is host config, not a file-truth"*;
+- **never synced** — *"bundles carry the memory file only"*;
+- rebuildable — *"losing it costs evidence detail, never state"*;
+- and consumed only by hygiene analyzers (cold grains, coverage gaps, budget
+  pressure). It **does not feed ranking**.
+
+That last point is not an accident and cannot casually be undone: ranking that
+read the sidecar would make the same query return different results on different
+hosts, breaking the guarantee in `docs/loop.md` that *"a synced file behaves
+identically on its next host."* **Replication determinism is what enforces the
+property**, which is a stronger guarantee than a convention.
+
+**Decided: document it as an explicit guarantee and pin it with a conformance
+test** that fails if a recall path ever writes to the memory file. Cheapest item
+on this page, and systems get this wrong in both directions — some let recall
+raise a confidence class, others never record usefulness at all.
+
+---
+
+## What these share
+
+- **#1 and #3 are one item in two halves.** #1 is the behaviour; #3 is the
+  number that proves it stays fixed. Do #1 step 1, then #3.
+- **#1 and #2 are the same family** — *withholding*. One is a grain marked as
+  not-to-be-believed; the other is a value that must not return after deletion.
+  A single `Trust` concept should serve both; design #2 with #1's classifier in
+  hand, not before.
+- **#2 and #5 are the same principle from opposite sides.** #5 says the read path
+  must never mutate belief. That is exactly what makes a write-path rejection
+  ledger safe: the check belongs on write, and recall stays pure.
+- **#4 stands alone** and is the cheapest to act on.
+
+## Recommended order
+
+1. **#1 step 1** — shared trust classifier. Real defect, small, no behaviour change.
+2. **#5** — document the guarantee, add the conformance test. We already hold it.
+3. **#4** — measure both legs, publish with the replica caveat.
+4. **#3** — the two counters, as #1's regression test.
+5. **#2** — define `SP-1` first, then design. Largest, and the erasure
+   interaction must be settled before any code.

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -103,7 +103,24 @@ and committed transcripts in
   unreproducible claims, so we publish the receipts.
 - **Memory integrity** (deterministic, no LLM):
   `cargo run -p areev-bench --bin honesty_metrics` asserts the dedup,
-  staleness, provenance, and write-cost claims on every run.
+  staleness, provenance, write-cost, trust-withholding, and write-to-readable
+  claims on every run.
+- **Write-to-readable** (`honesty_metrics` M6): a written grain is readable on
+  the **next call** — structural, free-text and vector — with no reopen and no
+  reindex, and the same holds on a replica immediately after a bundle import.
+  **6 of 6 legs.** Capture is synchronous and there is no background extractor,
+  so the honest unit here is a boolean per leg rather than a latency
+  distribution that would be zero by construction. This is the axis where the
+  field has no baseline at all: every benchmark ingests the full history before
+  it asks anything, so the window is invisible to all of them.
+- **Trust withholding, reported in both directions** (`honesty_metrics` M5):
+  context assembly surfaces **0 of 4** retracted grains (a leak) and drops
+  **0 of 12** live ones (a loss). Both are published because they move in
+  opposite directions — tighten withholding and the second number rises — so a
+  single figure could improve while the system got worse in use. The store
+  still returns all 16, because the DSAR selector depends on it, and the opt-in
+  audit read still sees 4 of 4: a retraction hides a grain from a model, never
+  from a person.
 - **Loop precision**: 1.00 on the labeled fixture, with a 0.90 failure floor
   when the fixture runner is invoked
   (`cargo run -p areev-bench --bin loop_precision`).

--- a/docs/why-areev.md
+++ b/docs/why-areev.md
@@ -228,6 +228,43 @@ background process that can drift while you aren't looking.
 Eight kinds over four primitives, the connector contract, composite gates and
 correlation windows: [`triggers.md`](triggers.md).
 
+## Reading never changes what is believed
+
+Rank memories by how often they are retrieved and a popular error becomes
+indistinguishable from a settled fact. Retrieval would be certifying its own
+output: a broad recurring query keeps an attractive but wrong grain alive
+forever, and the number that says "this is trusted" is really saying "this is
+frequently asked about."
+
+**No read path in Areev writes to the memory.** Recall, hybrid recall, text and
+vector search, the graph walk, `entity_at`, `history`, CAL `RECALL` and
+`ASSEMBLE`, and the DSAR `subject_report` all leave every grain exactly as they
+found it. There is no `last_seen`, no access counter, and no confidence nudge.
+`success_count` and `failure_count` exist as fields an author may set; nothing
+on the read path touches them.
+
+Recall's only write is an event in the **telemetry sidecar**, and the sidecar is
+built so it cannot become belief:
+
+- a separate file, host config rather than a file-truth, never persisted in the
+  memory;
+- it **never syncs** — bundles carry the memory file only;
+- it is rebuildable, so losing it costs evidence detail and never state;
+- it feeds the hygiene analyzers (cold grains, coverage gaps, budget pressure)
+  and **nothing that ranks**.
+
+That last point is enforced by something stronger than intent. A ranking that
+read the sidecar would make the same query return different answers on different
+hosts, because each host keeps its own — and that would break the guarantee that
+a synced file behaves identically wherever it lands. **Replication determinism
+is what holds this property in place**, so it cannot be quietly undone by adding
+a boost.
+
+Pinned by `recall_never_mutates_belief` and
+`recall_writes_nothing_that_survives_reopen` in the conformance suite, which run
+against both backends and fail if any read path ever writes a field or appends
+to the op log.
+
 ## Erasure is a real operation
 
 Because the record is content-addressed and subject-indexed rather than baked


### PR DESCRIPTION
Five questions about what a memory promises: which grains may be acted on, whether a deleted value can return, how abstention is measured, how long a write takes to become readable, and whether reading changes belief. Three commits, one concern each. Two of the five are deliberately not built, with the reasoning recorded in `docs/memory-guarantees.md` so they read as decisions rather than oversights.

## A retraction withholds a memory instead of ranking it lower

`verification_status = "retracted"` applied a `-0.3` priority penalty and the grain still reached the model. The field replaced OMS 1.2's deprecated `contradicted` **boolean**, and a boolean is a filter — three of its four values describe evidence (`unverified`/`verified`/`contested`) while `retracted` describes an **act**. Adding an act to the same float as a confidence boost re-merged in the scorer what the schema deliberately holds apart.

Underneath sat the larger defect: **four readers parsed the field independently and disagreed.**

| Reader | Before | After |
|---|---|---|
| `areev-store` recall | ignored it | unchanged — still returns them, deliberately |
| `areev-cal` render | metadata only | unchanged |
| `areev-context` | `-0.3` demotion | **withheld** |
| `areev-cli` corpus | excluded (`0.0`) | excluded, via the shared classifier |

The non-OMS value `"rejected"` was excluded by one and ignored by the other; it now maps to `retracted` consistently. `areev_core::verification::Trust` is the single classification, exhaustive and without a wildcard over the states.

**Withholding covers the Knowledge Update path too.** Chains are extracted *before* the body filter runs, so a retracted grain reached the context through `<knowledge_updates>` and stated the withdrawn value as the thing that changed. A chain touching a withheld grain is now dropped whole.

**Withholding lives in `areev-context` and must never move into `areev-store`.** `subject_report` shares one selector with erasure so a disclosure covers exactly what an erasure removes; a filter in the store would silently make a DSAR under-disclose. `store_recall_still_returns_retracted_grains` pins that on both backends. `contested` keeps its `-0.15` — a degree, not a withdrawal — and `include_retracted(true)` admits the withdrawn record for audit reads, which want it precisely because it was withdrawn.

## Bundle import writes the BM25 postings it was skipping

`insert_blob` wrote the grain row and its embedding but never the text postings, so a memory that had just imported answered `search_text` with nothing. Reopening appeared to fix it, because `finish_open` self-heals an empty text index — a heal written for files predating the current BM25 leg that happened to cover a fresh replica too. **That is also why no test caught it: every other import case reopens before it searches.**

The self-heal only runs at open. A follower — `areev stream` / `follow` — that imports and serves free-text recall from one long-lived handle answered every such query empty **for the life of the process**, which the erase path already names as the worst available failure because it is indistinguishable from an honest empty result.

`prep_from_blob` was already computing `tokens` and `doc_len`, honouring `index_text` and `fts_deferred`, so the write mirrors `insert_prepped` and the bulk-load escape hatch (`defer_text_index` plus one rebuild) is untouched. Corpus statistics advance after the transaction commits, as the other write paths do — which also removes a latent drift where an import followed by a `forget` decremented a counter nothing had incremented.

## Two measurements, and one guarantee stated

**M5 — trust withholding, both directions.** Returning a grain the trust state said to withhold, and failing to return one the memory holds, are opposite failures: a single number lets a tightening look like an improvement while the other side rots. M5 prints both — `0 of 4` retracted surfaced, `0 of 12` live dropped — alongside the store's own 16, because the DSAR selector depends on the store returning everything, and the opt-in audit read still sees `4 of 4`. Withholding hides a grain from a model, never from a person.

**M6 — write-to-readable.** The axis nothing in the field measures, because every benchmark ingests the whole history before it asks anything. Capture is synchronous and there is no background extractor, so the honest unit is a **boolean per leg** rather than a latency distribution that is zero by construction.

| | structural | text | vector |
|---|---|---|---|
| local, next call | ✅ | ✅ | ✅ |
| replica, straight after import | ✅ | ✅ | ✅ |

The replica text leg is the regression guard for the import fix — remove that write and M6 goes red at `text=false`, 5 of 6.

**Recall changes no belief, and now says so.** Ranking by how often a memory is retrieved makes a popular error indistinguishable from a settled fact. No read path writes to the memory: recall's only write is a telemetry event, and that sidecar is host-local, never syncs, is rebuildable, and feeds hygiene analyzers rather than anything that ranks. This is held by **replication determinism** rather than by intent — a ranking that read the sidecar would make one query answer differently on two hosts — so it cannot be undone quietly by adding a boost.

## Not built, on purpose

A rejected-value tombstone — refusing a value the memory has already rejected — is absent. Refusing a value later means remembering something about it, and `docs/gdpr.md` states a content address is **pseudonymous rather than anonymous**, so whether a rejection ledger may retain a hash of erased content is a **compliance judgement rather than an engineering one**. The design is ready behind that answer: key shape, the seven write paths a non-decorative check must cover, one shared normalizer, and ledger bounding. `SP-1`, referenced by `honesty_metrics` and defined nowhere in the repo, is named as the first thing to write.

## Verification

Every test added here was **mutation-tested** — the code was broken first to confirm each goes red, so none of them are decorative.

| Check | Result |
|---|---|
| `cargo test --workspace` | **2,605 passed, 0 failed** |
| `cargo clippy --workspace --all-targets -- -D warnings` | clean |
| `honesty_metrics` | 6 passed, 0 failed |
| Conformance, both backends | `recall_never_mutates_belief`, its reopen twin, `store_recall_still_returns_retracted_grains`, `imported_grains_are_text_searchable_without_reopen` |

Rebased on `v1.7.1`. `docs/quality.md`, `docs/why-areev.md`, `crates/areev-context/CLAUDE.md` and `CHANGELOG.md` move with the surfaces they describe.