### PR TITLE
Group dependency updates per ecosystem, and stop the review job failing on them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,13 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: deps
+    groups:
+      areev-js-cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Node bindings (napi) — standalone package, not in the Cargo workspace.
   - package-ecosystem: npm
@@ -60,12 +67,25 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: deps
+    groups:
+      areev-js-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions workflow dependencies.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      # These bumps edit the same workflow files, so separate PRs conflict with
+      # each other and every rebase dismisses the approval.
+      actions:
+        patterns:
+          - "*"
     ignore:
       # dtolnay/rust-toolchain is versioned by TOOLCHAIN (e.g. @1.90.0), not by
       # action release — Dependabot misreads it and proposes nonexistent bumps

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,28 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: deps
+    ignore:
+      # Known-blocked majors: each needs migration work, not a version bump.
+      # logos 0.15+ changes `#[regex]` semantics, and the CAL lexer is an OMS
+      # conformance surface — a lexer that parses differently is a spec change.
+      - dependency-name: "logos"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # croner 3 reworked the schedule API the trigger evaluator is built on.
+      - dependency-name: "croner"
+        update-types: ["version-update:semver-major"]
     groups:
       # The RustCrypto crates version in lockstep around `digest`: sha2 0.11 /
       # hkdf 0.13 / aes-gcm 0.11 are digest-0.11, and mixing generations does
       # not compile (see PRs #12, #8, #13). One grouped PR keeps the migration
       # atomic — and it should wait until turso leaves the digest-0.10 line,
       # or the tree carries two copies of the AES/GCM stack.
+      # One PR a week instead of eight. A major still arrives on its own.
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
       rustcrypto:
         patterns:
           - "sha2"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,9 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Secrets are withheld from Dependabot PRs by design, so this job can only
+    # fail there — and a check that is always red teaches everyone to skip CI.
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Eighteen dependency pull requests are open, twelve of them green. They accumulated because nothing said which could merge without a person, and the queue grew faster than anyone read it. Two causes, both config, no code touched.

## The review job could only ever fail on them

GitHub withholds secrets from Dependabot pull requests by design, so `CLAUDE_CODE_OAUTH_TOKEN` is empty there and `claude-review` failed on **every single dependency bump** while passing everywhere else — it succeeded on #166 an hour earlier.

Twelve otherwise-green pull requests each carried one red check for a reason that had nothing to do with their contents. That is how a team learns to stop reading CI at all. The job now skips that author; the change replaces a commented-out filter block, so it is a net reduction in lines.

## One pull request per ecosystem instead of eighteen

| Ecosystem | Open PRs today | After |
|---|---|---|
| cargo `/` | 8 | 1 |
| cargo `/crates/areev-js` | 5 | 1 |
| github-actions | 4 | 1 |
| npm `/crates/areev-js` | 1 | 1 |

Patch and minor bumps of already-vetted dependencies group into one weekly pull request. **Majors are unaffected and still arrive alone**, which is where a breaking change belongs.

The workflow bumps matter most. #1, #4, #5 and #102 all edit `ci.yml` or the release workflows, so they conflict with each other — and because the ruleset dismisses stale reviews on push, every rebase throws away the approval that was just given. Four conflicting pull requests become one.

`areev-js` is a detached cargo workspace with its own `Cargo.lock`, and `release-npm.yml` builds `--locked`, so drift there breaks a **release** rather than a build. It produced the most duplicates — #9 and #64 are the same `thiserror` bump, once per lockfile.

## Two majors ignored until someone schedules the migration

Both fail the build today, and an `ignore` keeps a known-blocked upgrade out of the weekly queue instead of reopening it every week.

- **logos** — 0.15+ changed `#[regex]` semantics, and the CAL lexer is an OMS conformance surface, so a lexer that parses differently is a spec change rather than a dependency update. 16 test failures on #2.
- **croner** — 3.0 reworked the schedule API the trigger evaluator is built on. 13 failures on #60.

`getrandom` is deliberately left alone: it already sits in the `rustcrypto` group, which the existing config comment explains is blocked until turso leaves the digest-0.10 line.

## After this merges

Close #2, #60, #62 (redundant — #158 contains the same getrandom bump) and #158, then trigger a run from **Insights → Dependency graph → Dependabot → Check for updates** rather than waiting on the weekly schedule. The eighteen should collapse to about four.

Config only — `.github/dependabot.yml` and `.github/workflows/claude-code-review.yml`. No dependency versions change in this pull request.