### PR TITLE
Ignore the getrandom major on the areev-js lockfile too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,12 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: deps
+    ignore:
+      # Same blocker as the rustcrypto group on "/": getrandom 0.3 reworked the
+      # API and 0.2 is what the tree still compiles against. This lockfile needs
+      # its own entry because it is a separate cargo ecosystem.
+      - dependency-name: "getrandom"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     groups:
       areev-js-cargo:
         patterns:


### PR DESCRIPTION
Follow-up to #169, which grouped all four ecosystems but left one gap.

`getrandom` is held back on `/` by the `rustcrypto` group, because 0.3 reworked the API and the tree still compiles against 0.2 — the existing config comment records that it waits for turso to leave the digest-0.10 line.

**`areev-js` is a separate cargo ecosystem with its own `Cargo.lock`**, so that group never reached it and the identical major arrives there as its own pull request: **#62, sixteen failing checks**, the same break one directory over.

Grouping does not solve this one. The `areev-js-cargo` group covers minor and patch, and a major deliberately arrives alone — which is correct for majors in general, and means this specific one returns every week until it is ignored.

| | root `/` | `crates/areev-js` |
|---|---|---|
| getrandom held back | ✅ via `rustcrypto` group | ✅ **this PR** |

One rule, one file. Drop it when the rustcrypto migration is scheduled — both entries move together.

## After this merges

CI is currently re-running across the open dependency PRs, because merging #169 triggered rebases. Once it settles, `#62` and `#158` are the two genuinely blocked ones to close, then a manual **Check for updates** collapses the rest into the grouped PRs.

`#61 lru` is worth a separate look rather than a close: it fails `coverage`, which is a required check, so that is a real signal rather than bot noise.