### PR TITLE
A pooler in front of the Postgres store must run in session mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1493,8 +1493,9 @@ What this retires is a shape the deployment docs previously had to prescribe:
 a PgBouncer or Cloud SQL Auth Proxy inserted purely to compensate for a
 missing client capability — an extra component *inside* the trust boundary,
 and one more thing to hold a credential. The proxy stays supported for the
-cases where it earns its place (pooling, IAM auth); it is no longer the price
-of encryption. Raised as
+cases where it earns its place (pooling — in **session mode**, per
+`deployment-profile.md` — and IAM auth); it is no longer the price of
+encryption. Raised as
 [#117](https://github.com/AreevAI/areev/issues/117) from a fleet deployment on
 Azure Flexible Server. Contract:
 [docs/deployment-profile.md](docs/deployment-profile.md) §"Postgres connection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The deployment profile no longer recommends a pooler mode the store cannot
+  survive.** `docs/deployment-profile.md` suggested PgBouncer in transaction
+  mode for multi-tenant hosts. The store pins `search_path` once per session and
+  takes the bootstrap advisory lock per session; transaction pooling hands each
+  transaction to whichever backend is free, so a statement can land on a
+  connection whose `search_path` is unset or belongs to a different schema. One
+  schema is one memory, so that is a query answered from the wrong tenant rather
+  than a query that fails. Session mode is the requirement, and the safe and
+  unsafe proxies are now named
+  ([#189](https://github.com/AreevAI/areev/issues/189)).
+
 - **The Postgres dictionary no longer bounds what a grain may say.** `terms`
   was `text UNIQUE`, and a Postgres btree entry caps at ~2704 bytes *after*
   compression — so any subject, relation or object that did not compress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **The deployment profile no longer recommends a pooler mode the store cannot
   survive.** `docs/deployment-profile.md` suggested PgBouncer in transaction
-  mode for multi-tenant hosts. The store pins `search_path` once per session and
-  takes the bootstrap advisory lock per session; transaction pooling hands each
-  transaction to whichever backend is free, so a statement can land on a
-  connection whose `search_path` is unset or belongs to a different schema. One
-  schema is one memory, so that is a query answered from the wrong tenant rather
-  than a query that fails. Session mode is the requirement, and the safe and
-  unsafe proxies are now named
+  mode for multi-tenant hosts. The store keeps three things on the session —
+  `search_path` pinned at open, the bootstrap advisory lock (`pg_advisory_lock`,
+  not the `_xact_` form), and the hot-path queries as server-side named prepared
+  statements cached per connection — and transaction pooling hands each
+  transaction to whichever backend is free, so none of them survives. The
+  prepared-statement failure is the loud one (`prepared statement "s0" does not
+  exist`); the `search_path` failure is the dangerous one, because one schema is
+  one memory, so a statement landing on a connection scoped to a different
+  schema is a query answered from **another tenant** rather than a query that
+  fails. Session mode is now stated as the requirement, with the invariant a
+  proxy must satisfy (one client connection, one server session, for its whole
+  life) and a table of what is and is not safe — including Neon's `-pooler`
+  endpoint, which is transaction-mode PgBouncer and is the hostname its
+  quickstarts hand out
   ([#189](https://github.com/AreevAI/areev/issues/189)).
 
 - **The Postgres dictionary no longer bounds what a grain may say.** `terms`

--- a/docs/deployment-profile.md
+++ b/docs/deployment-profile.md
@@ -102,8 +102,8 @@ identically with and without the feature, so no existing deployment changes.
 
 This makes the local TLS-terminating proxy (Cloud SQL Auth Proxy, PgBouncer
 with a TLS upstream) optional rather than mandatory. It is still the right
-answer when the proxy is also pooling or doing IAM auth — point the DSN at it
-with `sslmode=disable`.
+answer when the proxy is also pooling (session mode only — see below) or doing
+IAM auth — point the DSN at it with `sslmode=disable`.
 
 **Connections per handle: 1, or 2 with telemetry.** One `tokio_postgres`
 client per `Areev` handle, plus a second for the recall-telemetry sidecar. The
@@ -111,9 +111,20 @@ client per `Areev` handle, plus a second for the recall-telemetry sidecar. The
 opens **two**. Pass `telemetry="off"` when you do not want the sidecar. A
 multi-tenant host with one memory per tenant multiplies this by tenants *and*
 by instances against the server's `max_connections` — cache handles per tenant
-with an LRU and close idle ones (`close()` in Node; drop in Rust/Python), or
-put a pooler (PgBouncer in transaction mode, Cloud SQL Auth Proxy) in front.
-There is no built-in pool.
+with an LRU and close idle ones (`close()` in Node; drop in Rust/Python). There
+is no built-in pool.
+
+**A pooler must run in session mode, never transaction mode.** The store pins
+`search_path` once per session and takes the bootstrap advisory lock per
+session. Transaction pooling hands each transaction to whichever backend is
+free, so neither survives: a statement lands on a connection whose `search_path`
+is unset or belongs to a different schema. Because one schema is one memory,
+that is not a failed query — it is a query answered from the wrong tenant.
+
+PgBouncer in `session` mode is safe and still caps server connections.
+`transaction` and `statement` modes are not. The Cloud SQL Auth Proxy and the
+Cloudflare/Neon-style connection proxies pass sessions through and are safe.
+Supavisor's transaction mode and PgCat's transaction mode are not.
 
 **Open cost: provision schemas ahead of the request path.** First open of a
 NEW schema runs the full DDL bootstrap under an advisory lock — hundreds of

--- a/docs/deployment-profile.md
+++ b/docs/deployment-profile.md
@@ -114,17 +114,36 @@ by instances against the server's `max_connections` — cache handles per tenant
 with an LRU and close idle ones (`close()` in Node; drop in Rust/Python). There
 is no built-in pool.
 
-**A pooler must run in session mode, never transaction mode.** The store pins
-`search_path` once per session and takes the bootstrap advisory lock per
-session. Transaction pooling hands each transaction to whichever backend is
-free, so neither survives: a statement lands on a connection whose `search_path`
-is unset or belongs to a different schema. Because one schema is one memory,
-that is not a failed query — it is a query answered from the wrong tenant.
+**A pooler must run in session mode, never transaction mode.** The store keeps
+three pieces of state on the session: `search_path`, pinned once at open; the
+bootstrap advisory lock (`pg_advisory_lock`, not the `_xact_` form); and the
+hot-path queries, held as server-side **named prepared statements** cached per
+connection. Transaction pooling hands each transaction to whichever backend is
+free, so none of the three survives.
 
-PgBouncer in `session` mode is safe and still caps server connections.
-`transaction` and `statement` modes are not. The Cloud SQL Auth Proxy and the
-Cloudflare/Neon-style connection proxies pass sessions through and are safe.
-Supavisor's transaction mode and PgCat's transaction mode are not.
+The prepared-statement cache is what an operator hits first — a later
+transaction lands on a backend that never prepared the statement, and the
+driver reports `prepared statement "s0" does not exist`. That one is loud. The
+`search_path` failure is the dangerous one: a statement lands on a connection
+whose `search_path` is unset or belongs to a **different schema**, and because
+one schema is one memory, that is not a failed query — it is a query answered
+from another tenant.
+
+The invariant a proxy has to satisfy: **one client connection maps to one
+server session for that connection's whole life.** Check any product against
+that sentence rather than against its marketing.
+
+| | |
+|---|---|
+| Safe | PgBouncer `session` mode; pass-through proxies that are not pooling at all (the Cloud SQL Auth Proxy is a TLS/IAM tunnel); Neon's **direct** endpoint |
+| Not safe | PgBouncer `transaction`/`statement`; Supavisor transaction mode; PgCat transaction mode; Neon's **`-pooler`** endpoint, which is transaction-mode PgBouncer |
+
+Neon deserves the explicit line because the pooled hostname is the one its
+quickstarts hand out, and the two endpoints differ by a substring.
+
+PgBouncer in `session` mode still caps server connections — but it caps by
+**queueing** clients, so the per-tenant handle cache above is what keeps the
+queue short rather than merely moving the contention.
 
 **Open cost: provision schemas ahead of the request path.** First open of a
 NEW schema runs the full DDL bootstrap under an advisory lock — hundreds of

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -398,7 +398,9 @@ Two properties are the security-relevant ones:
 enabling it changes no existing deployment. The TLS-terminating local proxy
 (Cloud SQL Auth Proxy, PgBouncer with a TLS upstream) remains supported and
 is still right when it is also pooling or doing IAM auth — point the DSN at
-it with `sslmode=disable`.
+it with `sslmode=disable`. A pooler must run in **session mode**: the store pins
+`search_path` per session, and transaction pooling can answer a query from
+another tenant's schema ([deployment-profile.md](deployment-profile.md)).
 
 Verification is pinned by a real handshake against a throwaway CA
 (`pgtls::handshake_tests` in `areev-store`): that `require` completes against

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -400,7 +400,9 @@ enabling it changes no existing deployment. The TLS-terminating local proxy
 is still right when it is also pooling or doing IAM auth — point the DSN at
 it with `sslmode=disable`. A pooler must run in **session mode**: the store pins
 `search_path` per session, and transaction pooling can answer a query from
-another tenant's schema ([deployment-profile.md](deployment-profile.md)).
+another tenant's schema. Neon's `-pooler` endpoint is transaction-mode
+PgBouncer; its direct endpoint is not
+([deployment-profile.md](deployment-profile.md)).
 
 Verification is pinned by a real handshake against a throwaway CA
 (`pgtls::handshake_tests` in `areev-store`): that `require` completes against


### PR DESCRIPTION
Closes #189.

`docs/deployment-profile.md` recommended PgBouncer in **transaction mode** for multi-tenant hosts. The Postgres store keeps state on the session, so that recommendation was actively unsafe — and in the one-schema-per-memory design the failure is a cross-tenant read, not a failed query.

## What the store keeps on the session

Three things, all verified in `crates/areev-store/src/pg.rs`:

| State | Where |
|---|---|
| `search_path`, pinned once at open | `:318`, again at read-only open `:374` and reconnect `:467` — never per transaction |
| Bootstrap advisory lock | `pg_advisory_lock` `:307`, not the `_xact_` form |
| Hot-path queries as server-side **named prepared statements**, cached per connection | `PgDb::prepared` `:520`; `reconnect()` clears the cache at `:474` because "a Statement from the old session is invalid" |

Transaction pooling hands each transaction to whichever backend is free, so none of the three survives. The prepared-statement failure is the **loud** one an operator hits first (`prepared statement "s0" does not exist`). The `search_path` failure is the **dangerous** one: one schema is one memory, so a statement landing on a connection scoped to a different schema is a query answered from another tenant.

## What changed

- Session mode stated as a requirement, with all three reasons and which is loud vs dangerous.
- The invariant a proxy must satisfy, so a reader can check a product this page has never heard of: **one client connection maps to one server session for that connection's whole life.**
- A table naming only what is confirmed. Neon's two endpoints sit on opposite rows — its `-pooler` hostname is transaction-mode PgBouncer and is the one the quickstarts hand out, so the two differ by a substring.
- The caveat repeated at every other place a reader might stop: the TLS sections of `deployment-profile.md` and `security-model.md`, and `ARCHITECTURE.md` §10, which said the proxy earns its place for "pooling, IAM auth" with no mode qualifier.
- Session-mode PgBouncer caps connections by **queueing** clients, so the per-tenant handle cache is what keeps the queue short rather than merely relocating the contention.

Docs only — no code, no tests, no version sites. 2,612 workspace tests, repo stats and versions green; every link resolves.
