### PR TITLE
docs: enhance cookbook with bulk-loading vectors and ANN index setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **The vector-at-scale surface reaches the bindings and the CLI** (#141).
+  A host that manages memories through Python or Node alone could not build
+  the ANN index, could only write embeddings one transaction at a time, and
+  had no way to check what the index cost it. Now, in both bindings and as
+  `areev vector-index <status|build|drop|check>`:
+  - `add_embeddings([{hash, vector}, …])` writes a batch in **one
+    transaction**, chunked two hundred rows per statement — the per-vector
+    path was a transaction and three round trips each, which is why a bulk
+    re-ingest measured round-trip-bound (~545 vectors/s) rather than
+    embedding-bound. All-or-nothing: one unknown hash or wrong dimension
+    refuses the batch before anything is written, and the error names the row.
+  - `ensure_vector_index(m, ef_construction, ef_search)`, `drop_vector_index()`
+    and `vector_index()` expose the pgvector HNSW index that was Rust-only.
+    The embedded engine still refuses to build one (`STO-E007`) and reports
+    `index: null`, because its reads are exact.
+  - `vector_recall_check(queries, k, ns, ef_search)` grades the index against
+    the exact scan **with the caller's own query vectors** — recall is a
+    property of the embedding model's geometry, so nobody else's number
+    transfers — over the scope named (the CLI insists on `--ns`, because the
+    default scope is a narrow one the structural index serves exactly). The
+    report carries the `ef_search` it graded at, and `ef_search` retunes the
+    session first without a rebuild. With no index built it reports
+    `recall: 1.0, index: null` and runs nothing; a scope with no exact
+    neighbours reports `recall: null` rather than a 1.0 that reads as a pass.
+    The exact side and a tuned `ef_search` both survive a Postgres reconnect,
+    which a replayed read would otherwise land on default settings.
+  Pinned on both backends by the conformance case
+  `bulk_embeddings_land_atomically`. Not added as an MCP tool: building an
+  index is an operator action, not something an agent should reach for
+  mid-conversation.
+- **Recorded late:** 1.7.0 made `nearest_vector` / `nearest_semantic` accept
+  an `"org.*"` prefix scope like every other plural read, and added the
+  `(ns, s, p)` index that turns a filtered vector scan from a full scan into a
+  seek (`46e6a79`). The change shipped without a changelog line; this is it.
 - **Postgres: a steady-state open issues no DDL at all** (#180). A bootstrapped
   schema is stamped with its schema version in `meta.pg_schema`; the next open
   reads that stamp before taking any lock and skips the 43 DDL statements, the
@@ -253,6 +287,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **`drop_vector_index` on the embedded backend is a no-op, not `STO-E007`.**
+  What a drop promises is exact reads, and a file memory's reads are exact
+  already; Postgres answers the same way (`DROP INDEX IF EXISTS`) when none
+  is built. A caller branching on the old refusal sees `Ok` now. Building one
+  there still refuses, because that would promise an index that cannot exist.
+- **`set_grain_embedding` is the one-row form of `set_grain_embeddings`** and
+  so now honours `--read-only` (`STO-E004` instead of a raw permission error,
+  and no DDL), and re-checks the grain under the row lock before writing —
+  on the multi-writer backend a forget landing between resolve and insert no
+  longer leaves a vector behind for erased content.
 - **Successful tool calls reach the evidence bundle when skill authoring is
   on** — after the failures, inside the same reserved share, so a busy desk's
   successes cannot bury the failure signal. With `skills.enabled: false` the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,7 +336,7 @@ grain selection, dynamic planning, do/don't) is
   queue: **`run.respond` refuses shared-token and anonymous callers** — only
   a per-principal credential (`areev ui --auth`) may approve, because the
   approver's identity IS the audit record; cancel keeps the low bar.
-- **areev**: ~29 verbs (incl. `migrate` from other memory systems,
+- **areev**: ~30 verbs (incl. `migrate` from other memory systems,
   `reindex`, the graph/time reads `related`/`entity-at`/`step-actions`, the
   join `run-trace`/`runs-touching`, the DSAR read `subject-report`, the
   credential lifecycle `auth mint|list|revoke`, and `provision` — the last two

--- a/crates/areev-bench/src/bin/pe_scale.rs
+++ b/crates/areev-bench/src/bin/pe_scale.rs
@@ -388,7 +388,7 @@ fn main() {
 
     if a.drop_ann {
         match m.drop_vector_index() {
-            Ok(()) => println!("ANN index dropped — vector recall is exact again"),
+            Ok(()) => println!("no ANN index in place — vector recall is exact"),
             Err(e) => println!("drop_vector_index: {e}"),
         }
     }

--- a/crates/areev-cli/src/main.rs
+++ b/crates/areev-cli/src/main.rs
@@ -206,6 +206,17 @@ COMMANDS:
   reindex                             backfill + rebuild the BM25 text index
                                       (e.g. after --index-text true on a file
                                       written with indexing off)
+  vector-index <status|build|drop|check> [--m N] [--ef-construction N]
+           [--ef-search N] [--queries FILE.json --ns SCOPE] [--k N]
+                                      the ANN (pgvector HNSW) index over the
+                                      stored vectors. Postgres only: build
+                                      answers STO-E007 on a file memory, which
+                                      scans exactly. `check` grades the index
+                                      against the exact scan with YOUR query
+                                      vectors (recall@k) over the WIDE --ns
+                                      scope you actually query; --ef-search
+                                      retunes the session first (no rebuild).
+                                      `status` says whether reads are exact.
   stream   --to DIR [--interval-ms N] [--once] [--checkpoint] [--retain 30d]
                                       continuous op-log shipping; --checkpoint
                                       opens a new generation with a full
@@ -2356,6 +2367,60 @@ Nothing was written — apply the snippet yourself (or rerun with your own paths
             // until this runs.
             let links = m.rebuild_link_indexes().map_err(|e| e.to_string())?;
             println!("link indexes rebuilt: {links} rows (provenance, runs, cross-links)");
+        }
+        // ── areev vector-index: the ANN index, from the shell (#141) ──
+        "vector-index" => {
+            let usage = "usage: areev vector-index <status|build|drop|check> --db DSN \
+                         [build: --m N --ef-construction N --ef-search N] \
+                         [check: --queries FILE.json --ns SCOPE --k N --ef-search N]";
+            let num = |key: &str, default: usize| -> Result<usize, String> {
+                flag(&flags, key)
+                    .map_or(Ok(default), |v| v.parse::<usize>())
+                    .map_err(|_| format!("--{key} must be a number"))
+            };
+            match positional.first().map(String::as_str).unwrap_or("status") {
+                "status" => {
+                    let name = m.vector_index().map_err(|e| e.to_string())?;
+                    println!("{}", serde_json::json!({"index": name}));
+                }
+                "build" => {
+                    let (hm, efc, efs) =
+                        (num("m", 16)?, num("ef-construction", 64)?, num("ef-search", 40)?);
+                    m.ensure_vector_index(hm, efc, efs).map_err(|e| e.to_string())?;
+                    let name = m.vector_index().map_err(|e| e.to_string())?;
+                    println!("{}", serde_json::json!({"index": name, "m": hm, "ef_construction": efc, "ef_search": efs}));
+                }
+                "drop" => {
+                    m.drop_vector_index().map_err(|e| e.to_string())?;
+                    println!("{}", serde_json::json!({"index": serde_json::Value::Null}));
+                }
+                "check" => {
+                    // The queries are the caller's own vectors: recall is a
+                    // property of THEIR model's geometry, not of the index.
+                    let path = flag(&flags, "queries")
+                        .ok_or("vector-index check requires --queries FILE.json (a JSON array of vectors)")?;
+                    // An explicit scope, because the global default ("shared")
+                    // is a narrow one the structural index serves exactly —
+                    // grading it says nothing about the ANN graph.
+                    if !flags.contains_key("ns") {
+                        return Err("vector-index check requires --ns SCOPE — the WIDE scope you actually \
+                                    query (e.g. --ns 'firm.deals.*'); a narrow scope is exact regardless"
+                            .into());
+                    }
+                    let text = std::fs::read_to_string(&path)
+                        .map_err(|e| format!("cannot read --queries {path}: {e}"))?;
+                    let queries: Vec<Vec<f32>> = serde_json::from_str(&text)
+                        .map_err(|e| format!("--queries must be a JSON array of number arrays: {e}"))?;
+                    let k = num("k", 10)?;
+                    if let Some(ef) = flag(&flags, "ef-search") {
+                        let ef: usize = ef.parse().map_err(|_| "--ef-search must be a number")?;
+                        m.set_vector_ef_search(ef).map_err(|e| e.to_string())?;
+                    }
+                    let report = m.vector_recall_check(&ns, &queries, k).map_err(|e| e.to_string())?;
+                    println!("{}", serde_json::to_string_pretty(&report).unwrap());
+                }
+                _ => return Err(usage.into()),
+            }
         }
         "related" => {
             let start = flag(&flags, "start").ok_or("related requires --start")?;

--- a/crates/areev-cli/tests/cli_smoke.rs
+++ b/crates/areev-cli/tests/cli_smoke.rs
@@ -1526,3 +1526,51 @@ fn trigger_context_query_is_validated_at_declaration() {
     assert!(!ok, "a pointer without '/' must be refused");
     assert!(err.contains("JSON pointer"), "{err}");
 }
+
+/// #141: the ANN index is reachable from the shell. On a file memory the
+/// status is honest (no index, exact reads), a build is refused by code, and
+/// `check` insists on the caller's own query vectors.
+#[test]
+fn vector_index_verb_reports_refuses_and_grades() {
+    let dir = TempDir::new().unwrap();
+    let db = dir.path().join("v.db");
+    let db = db.to_str().unwrap();
+    let (ok, _, err) = areev(&[
+        "add", "--db", db, "--ns", "caller", "--subject", "a", "--relation", "r", "--object", "o",
+    ]);
+    assert!(ok, "{err}");
+
+    let (ok, out, err) = areev(&["vector-index", "status", "--db", db]);
+    assert!(ok, "{err}");
+    assert!(out.contains("\"index\":null"), "{out}");
+
+    let (ok, _, err) = areev(&["vector-index", "build", "--db", db]);
+    assert!(!ok);
+    assert!(err.contains("STO-E007"), "{err}");
+
+    let (ok, _, err) = areev(&["vector-index", "check", "--db", db]);
+    assert!(!ok);
+    assert!(err.contains("--queries"), "{err}");
+
+    let q = dir.path().join("q.json");
+    std::fs::write(&q, "[[1.0, 0.0, 0.0]]").unwrap();
+    // The scope must be explicit: the global default is a narrow one.
+    let (ok, _, err) = areev(&["vector-index", "check", "--db", db, "--queries", q.to_str().unwrap()]);
+    assert!(!ok);
+    assert!(err.contains("--ns"), "{err}");
+    let (ok, out, err) = areev(&[
+        "vector-index", "check", "--db", db, "--ns", "caller", "--queries", q.to_str().unwrap(), "--k", "3",
+    ]);
+    assert!(ok, "{err}");
+    assert!(out.contains("\"index\": null") && out.contains("\"recall\": 1.0"), "{out}");
+    // Retuning needs an index to tune.
+    let (ok, _, err) = areev(&[
+        "vector-index", "check", "--db", db, "--ns", "caller", "--queries", q.to_str().unwrap(), "--ef-search", "100",
+    ]);
+    assert!(!ok);
+    assert!(err.contains("STO-E007"), "{err}");
+
+    let (ok, _, err) = areev(&["vector-index", "bogus", "--db", db]);
+    assert!(!ok);
+    assert!(err.contains("usage: areev vector-index"), "{err}");
+}

--- a/crates/areev-conformance/src/cases/blobs_hybrid.rs
+++ b/crates/areev-conformance/src/cases/blobs_hybrid.rs
@@ -188,6 +188,35 @@ pub fn external_vectors_need_no_embedder(b: &dyn Backend) {
     assert!(near[0].1 > 0.9, "self-similarity should be ~1, got {}", near[0].1);
 }
 
+/// #141: the bulk embedding write is one transaction on both backends —
+/// every vector lands and reads back, a repeated hash keeps its last vector,
+/// and a batch with one bad row writes NOTHING. Storage semantics, so it must
+/// hold identically on the embedded engine and on Postgres, where the point
+/// of the batch (round trips per chunk, not per vector) actually shows.
+pub fn bulk_embeddings_land_atomically(b: &dyn Backend) {
+    let mut m = b.open();
+    let n = areev_store::EMBEDDING_BATCH_CHUNK + 5;
+    let mut items = Vec::with_capacity(n);
+    for i in 0..n {
+        let h = m.add(&fact("caller", &format!("s{i}"), "has", "vector")).unwrap();
+        let a = i as f32 * 0.7;
+        items.push((h, vec![a.cos(), a.sin(), 0.0, 0.0]));
+    }
+    assert_eq!(m.set_grain_embeddings(&items).unwrap(), n);
+    assert_eq!(m.declared_embedding(), Some(("external", 4)));
+    for (h, v) in items.iter().step_by(41) {
+        let near = m.nearest_vector("caller", None, None, v, 1).unwrap();
+        assert_eq!(near[0].0, *h, "each vector is its own nearest neighbour");
+    }
+
+    // One unknown address refuses the whole batch, and nothing is written.
+    let fresh = m.add(&fact("caller", "unvectored", "has", "nothing")).unwrap();
+    let ghost = areev_core::error::Hash::from_hex(&"e".repeat(64)).unwrap();
+    assert!(m.set_grain_embeddings(&[(fresh, vec![1.0, 0.0, 0.0, 0.0]), (ghost, vec![0.0, 1.0, 0.0, 0.0])]).is_err());
+    let near = m.nearest_vector("caller", None, None, &[1.0, 0.0, 0.0, 0.0], 1).unwrap();
+    assert_ne!(near[0].0, fresh, "the refused batch left no vector behind");
+}
+
 /// Provenance must not outlive a failed write.
 pub fn a_refused_vector_declares_nothing(b: &dyn Backend) {
     let mut m = b.open();

--- a/crates/areev-conformance/src/lib.rs
+++ b/crates/areev-conformance/src/lib.rs
@@ -243,6 +243,7 @@ macro_rules! for_each_conformance_case {
         $per_case!(vector_leg_roundtrip);
         $per_case!(external_vectors_need_no_embedder);
         $per_case!(a_refused_vector_declares_nothing);
+        $per_case!(bulk_embeddings_land_atomically);
         // bulk erasure (right-to-erasure + retention)
         $per_case!(subject_erasure_is_complete);
         $per_case!(partition_keys_and_text_mentions_erase);

--- a/crates/areev-conformance/tests/pg.rs
+++ b/crates/areev-conformance/tests/pg.rs
@@ -775,3 +775,55 @@ fn a_least_privilege_role_opens_a_current_schema_read_write() {
 
     let _ = areev_store::pg::execute_raw(&url, &cleanup);
 }
+
+/// #141: the recall check grades a REAL HNSW index against the exact scan
+/// (needs pgvector on the server). With no index it reports 1.0 and runs
+/// nothing; with one it runs every query, names the index, and the bypass it
+/// uses for the exact side is lifted afterwards so ordinary reads still work.
+#[test]
+fn vector_recall_check_grades_a_real_hnsw_index() {
+    let Some(b) = backend() else { return };
+    let mut m = b.open_named("recall_check");
+    let n = 300usize;
+    let mut items = Vec::with_capacity(n);
+    for i in 0..n {
+        let h = m.add(&areev_conformance::fact("caller", &format!("s{i}"), "has", "vector")).unwrap();
+        let a = i as f32 * 0.137;
+        items.push((h, vec![a.cos(), a.sin(), (a * 0.3).cos(), 1.0]));
+    }
+    assert_eq!(m.set_grain_embeddings(&items).unwrap(), n);
+    let queries: Vec<Vec<f32>> = items.iter().step_by(30).map(|(_, v)| v.clone()).collect();
+
+    // No index: exact by construction, nothing run.
+    let before = m.vector_recall_check("caller", &queries, 5).unwrap();
+    assert_eq!((before.index.as_deref(), before.queries, before.recall), (None, 0, Some(1.0)));
+
+    m.ensure_vector_index(16, 64, 40).unwrap();
+    assert_eq!(m.vector_index().unwrap().as_deref(), Some("idx_embeddings_hnsw"));
+    let graded = m.vector_recall_check("caller", &queries, 5).unwrap();
+    assert_eq!(graded.index.as_deref(), Some("idx_embeddings_hnsw"));
+    assert_eq!((graded.queries, graded.k, graded.ef_search), (queries.len(), 5, Some(40)));
+    let recall = graded.recall.expect("neighbours existed to grade against");
+    // 300 well-separated vectors at pgvector's defaults: the graph should
+    // find essentially everything. A floor, not an equality — HNSW is
+    // approximate by definition.
+    assert!((0.8..=1.0).contains(&recall), "{graded:?}");
+
+    // Retuning is session-scoped, needs no rebuild, and is reported.
+    m.set_vector_ef_search(200).unwrap();
+    let retuned = m.vector_recall_check("caller", &queries, 5).unwrap();
+    assert_eq!(retuned.ef_search, Some(200));
+    assert!(m.set_vector_ef_search(0).is_err(), "out of pgvector's range");
+
+    // A scope with nothing in it grades nothing — `None`, not a 1.0 pass.
+    let empty = m.vector_recall_check("nobody", &queries, 5).unwrap();
+    assert_eq!((empty.queries, empty.recall), (queries.len(), None));
+
+    // The exact-scan bypass was lifted: a plain read still answers.
+    let (h3, v3) = &items[3];
+    let near = m.nearest_vector("caller", None, None, v3, 1).unwrap();
+    assert_eq!(&near[0].0, h3);
+
+    m.drop_vector_index().unwrap();
+    assert_eq!(m.vector_index().unwrap(), None);
+}

--- a/crates/areev-js/__test__/pg_smoke.mjs
+++ b/crates/areev-js/__test__/pg_smoke.mjs
@@ -76,3 +76,33 @@ test('subject erasure and retention sweep', { skip }, async () => {
     dropPostgresSchema(url, schema)
   }
 })
+
+test('the ANN index and its grade, from the binding alone (#141)', { skip }, async () => {
+  const schema = `js_vec_${process.pid}`
+  try {
+    const m = new Areev(dsnFor(schema), 'caller')
+    const hs = []
+    for (let i = 0; i < 60; i++) hs.push(await m.addFact(`s${i}`, 'has', 'vector'))
+    const items = hs.map((hash, i) => ({ hash, vector: [Math.cos(i * 0.31), Math.sin(i * 0.31), 0.05 * i, 1.0] }))
+    assert.deepEqual(JSON.parse(await m.addEmbeddings(JSON.stringify(items))), { written: 60 })
+    assert.deepEqual(JSON.parse(await m.vectorIndex()), { index: null })
+
+    const built = JSON.parse(await m.ensureVectorIndex(16, 64, 40))
+    assert.equal(built.index, 'idx_embeddings_hnsw')
+
+    const rep = JSON.parse(await m.vectorRecallCheck(JSON.stringify(items.slice(0, 8).map(it => it.vector)), 5))
+    assert.equal(rep.index, 'idx_embeddings_hnsw')
+    assert.equal(rep.queries, 8)
+    assert.equal(rep.ef_search, 40)
+    assert.ok(rep.recall >= 0 && rep.recall <= 1, `recall ${rep.recall}`)
+    const retuned = JSON.parse(await m.vectorRecallCheck(JSON.stringify(items.slice(0, 8).map(it => it.vector)), 5, null, 200))
+    assert.equal(retuned.ef_search, 200)
+    const near = JSON.parse(await m.nearestVector(items[3].vector, null, null, 1))
+    assert.equal(near[0].hash, hs[3], 'the exact-scan bypass was lifted afterwards')
+
+    assert.deepEqual(JSON.parse(await m.dropVectorIndex()), { index: null })
+    m.close()
+  } finally {
+    dropPostgresSchema(url, schema)
+  }
+})

--- a/crates/areev-js/__test__/smoke.mjs
+++ b/crates/areev-js/__test__/smoke.mjs
@@ -1712,3 +1712,31 @@ test('a subscriber does not change what the run recorded', async () => {
   assert.deepEqual(await shape('obs-on'), await shape('obs-off'))
   await m.close()
 })
+
+test('bulk embeddings and the vector-index surface (#141)', async () => {
+  const m = makeDb()
+  const hs = []
+  for (let i = 0; i < 3; i++) hs.push(await m.addFact(`s${i}`, 'has', 'vector'))
+  const items = hs.map((hash, i) => ({ hash, vector: [0, 1, 2].map(j => (j === i ? 1.0 : 0.0)) }))
+  assert.deepEqual(JSON.parse(await m.addEmbeddings(JSON.stringify(items))), { written: 3 })
+  const near = JSON.parse(await m.nearestVector([0.0, 1.0, 0.0], null, null, 1))
+  assert.equal(near[0].hash, hs[1])
+
+  // all-or-nothing, with the bad row named
+  await assert.rejects(
+    () => m.addEmbeddings(JSON.stringify([{ hash: hs[0], vector: [1, 0, 0] }, { hash: hs[1], vector: [1, 0] }])),
+    /dimensions/)
+  await assert.rejects(() => m.addEmbeddings(JSON.stringify([{ hash: 'nope', vector: [1] }])), /item 0/)
+  await assert.rejects(() => m.addEmbeddings('not json'), /JSON array/)
+
+  // a file memory scans exactly
+  assert.deepEqual(JSON.parse(await m.vectorIndex()), { index: null })
+  await assert.rejects(() => m.ensureVectorIndex(), /STO-E007/)
+  const rep = JSON.parse(await m.vectorRecallCheck(JSON.stringify([[1, 0, 0]]), 2))
+  assert.deepEqual(rep, { index: null, ef_search: null, k: 2, queries: 0, recall: 1.0 })
+  await assert.rejects(() => m.vectorRecallCheck('[[1,0,0]]', 0), /k >= 1/)
+  await assert.rejects(() => m.vectorRecallCheck('[]', 2), /at least one/)
+  await assert.rejects(() => m.vectorRecallCheck('[[1,0,0]]', 2, null, 100), /STO-E007/)
+  assert.deepEqual(JSON.parse(await m.dropVectorIndex()), { index: null })
+  m.close()
+})

--- a/crates/areev-js/index.d.ts
+++ b/crates/areev-js/index.d.ts
@@ -275,6 +275,36 @@ export declare class Areev {
    */
   declaredEmbedding(): Promise<string>
   /**
+   * The bulk form of `addEmbedding`: one transaction for
+   * `itemsJson = [{"hash": "<64-hex>", "vector": [..]}, ...]`. An unknown
+   * hash or a dimension mismatch refuses the whole batch before anything
+   * is written. Resolves to `{"written": n}`.
+   */
+  addEmbeddings(itemsJson: string): Promise<string>
+  /**
+   * Build the ANN (pgvector HNSW) index over the stored vectors. Postgres
+   * only — the embedded engine rejects with `STO-E007`. Defaults are
+   * pgvector's (`m` 16, `efConstruction` 64, `efSearch` 40). Resolves to
+   * `{"index": name}`. Grade it with `vectorRecallCheck` before relying on it.
+   */
+  ensureVectorIndex(m?: number | undefined | null, efConstruction?: number | undefined | null, efSearch?: number | undefined | null): Promise<string>
+  /**
+   * Drop the ANN index, returning vector recall to an exact scan.
+   * Resolves to `{"index": null}`.
+   */
+  dropVectorIndex(): Promise<string>
+  /** `{"index": name}` if an ANN index is built, `{"index": null}` if not. */
+  vectorIndex(): Promise<string>
+  /**
+   * Grade the ANN index against the exact scan with YOUR query vectors:
+   * `queriesJson` is a JSON array of vectors, `k` the cutoff (default 10),
+   * `ns` the scope you really query with, `efSearch` an optional retune of
+   * the index for this session first. Resolves to
+   * `{"index", "ef_search", "k", "queries", "recall"}`; with no index built
+   * the read path is exact and the report says so.
+   */
+  vectorRecallCheck(queriesJson: string, k?: number | undefined | null, ns?: string | undefined | null, efSearch?: number | undefined | null): Promise<string>
+  /**
    * Which runs produced or refined this grain — the reverse join.
    *
    * Runs that merely *read* the grain are not recorded: a read leaves no

--- a/crates/areev-js/src/lib.rs
+++ b/crates/areev-js/src/lib.rs
@@ -47,6 +47,7 @@ fn err<E: std::fmt::Display>(e: E) -> napi::Error {
     napi::Error::from_reason(e.to_string())
 }
 
+
 /// A host-supplied 32-byte anonymization root, given as 64 hex characters.
 ///
 /// The FFI convention is scalars in, so the key arrives as hex rather than as
@@ -1876,6 +1877,107 @@ impl Areev {
                 Some((model, dim)) => json!({"model": model, "dim": dim}).to_string(),
                 None => "null".to_string(),
             })
+        })
+    }
+
+    /// The bulk form of `addEmbedding`: one transaction for
+    /// `itemsJson = [{"hash": "<64-hex>", "vector": [..]}, ...]`. An unknown
+    /// hash or a dimension mismatch refuses the whole batch before anything
+    /// is written. Resolves to `{"written": n}`.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn add_embeddings(&self, items_json: String) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let slot = self.facade.clone();
+        StringJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            let items = areev_store::parse_embedding_items(&items_json).map_err(err)?;
+            let n = facade.with_store(|m| m.set_grain_embeddings(&items)).map_err(err)?;
+            Ok(json!({"written": n}).to_string())
+        })
+    }
+
+    /// Build the ANN (pgvector HNSW) index over the stored vectors. Postgres
+    /// only — the embedded engine rejects with `STO-E007`. Defaults are
+    /// pgvector's (`m` 16, `efConstruction` 64, `efSearch` 40). Resolves to
+    /// `{"index": name}`. Grade it with `vectorRecallCheck` before relying on it.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn ensure_vector_index(
+        &self,
+        m: Option<u32>,
+        ef_construction: Option<u32>,
+        ef_search: Option<u32>,
+    ) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let slot = self.facade.clone();
+        let (m, efc, efs) = (
+            m.unwrap_or(16) as usize,
+            ef_construction.unwrap_or(64) as usize,
+            ef_search.unwrap_or(40) as usize,
+        );
+        StringJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            let name = facade
+                .with_store(|s| {
+                    s.ensure_vector_index(m, efc, efs)?;
+                    s.vector_index()
+                })
+                .map_err(err)?;
+            Ok(json!({"index": name}).to_string())
+        })
+    }
+
+    /// Drop the ANN index, returning vector recall to an exact scan.
+    /// Resolves to `{"index": null}`.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn drop_vector_index(&self) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let slot = self.facade.clone();
+        StringJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            facade.with_store(|s| s.drop_vector_index()).map_err(err)?;
+            Ok(json!({"index": serde_json::Value::Null}).to_string())
+        })
+    }
+
+    /// `{"index": name}` if an ANN index is built, `{"index": null}` if not.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn vector_index(&self) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let slot = self.facade.clone();
+        StringJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            let name = facade.with_store(|s| s.vector_index()).map_err(err)?;
+            Ok(json!({"index": name}).to_string())
+        })
+    }
+
+    /// Grade the ANN index against the exact scan with YOUR query vectors:
+    /// `queriesJson` is a JSON array of vectors, `k` the cutoff (default 10),
+    /// `ns` the scope you really query with, `efSearch` an optional retune of
+    /// the index for this session first. Resolves to
+    /// `{"index", "ef_search", "k", "queries", "recall"}`; with no index built
+    /// the read path is exact and the report says so.
+    #[napi(ts_return_type = "Promise<string>")]
+    pub fn vector_recall_check(
+        &self,
+        queries_json: String,
+        k: Option<u32>,
+        ns: Option<String>,
+        ef_search: Option<u32>,
+    ) -> napi::bindgen_prelude::AsyncTask<StringJob> {
+        let slot = self.facade.clone();
+        let ns = ns.unwrap_or_else(|| self.ns.clone());
+        let k = k.unwrap_or(10) as usize;
+        StringJob::spawn(move || {
+            let facade = take_facade(&slot)?;
+            let queries: Vec<Vec<f32>> = serde_json::from_str(&queries_json).map_err(|e| {
+                err(format!("queries must be a JSON array of number arrays: {e}"))
+            })?;
+            let report = facade
+                .with_store(|s| {
+                    if let Some(ef) = ef_search {
+                        s.set_vector_ef_search(ef as usize)?;
+                    }
+                    s.vector_recall_check(&ns, &queries, k)
+                })
+                .map_err(err)?;
+            serde_json::to_string(&report).map_err(err)
         })
     }
 

--- a/crates/areev-py/src/lib.rs
+++ b/crates/areev-py/src/lib.rs
@@ -140,6 +140,7 @@ fn err<E: std::fmt::Display>(e: E) -> PyErr {
     PyValueError::new_err(e.to_string())
 }
 
+
 /// Verb check for the binding methods that reach the store directly instead
 /// of through a gated `cal_*` facade method. `principal=` is documented to
 /// fail closed (CAL 1.3 §9), so a sandboxed handle must not be able to erase
@@ -1573,6 +1574,90 @@ impl Areev {
             Some((model, dim)) => json!({"model": model, "dim": dim}).to_string(),
             None => "null".to_string(),
         })
+    }
+
+    /// The bulk form of `add_embedding`: one transaction for
+    /// `items_json = [{"hash": "<64-hex>", "vector": [..]}, ...]`. An unknown
+    /// hash or a dimension mismatch refuses the whole batch before anything
+    /// is written. Returns `{"written": n}`.
+    fn add_embeddings(&self, py: Python<'_>, items_json: String) -> PyResult<String> {
+        let n = py
+            .detach(|| {
+                let items = areev_store::parse_embedding_items(&items_json)?;
+                self.facade.with_store(|m| m.set_grain_embeddings(&items))
+            })
+            .map_err(err)?;
+        Ok(json!({"written": n}).to_string())
+    }
+
+    /// Build the ANN (pgvector HNSW) index over the stored vectors, trading
+    /// exact recall for sublinear whole-corpus k-NN. Postgres only — the
+    /// embedded engine raises `STO-E007`. `ef_search` is session-scoped.
+    /// Returns `{"index": name}`. Grade it with `vector_recall_check` before
+    /// relying on it: the accuracy cost belongs to your model's geometry.
+    #[pyo3(signature = (m = 16, ef_construction = 64, ef_search = 40))]
+    fn ensure_vector_index(
+        &self,
+        py: Python<'_>,
+        m: usize,
+        ef_construction: usize,
+        ef_search: usize,
+    ) -> PyResult<String> {
+        let name = py
+            .detach(|| {
+                self.facade.with_store(|s| {
+                    s.ensure_vector_index(m, ef_construction, ef_search)?;
+                    s.vector_index()
+                })
+            })
+            .map_err(err)?;
+        Ok(json!({"index": name}).to_string())
+    }
+
+    /// Drop the ANN index, returning vector recall to an exact scan. Returns
+    /// `{"index": null}`.
+    fn drop_vector_index(&self, py: Python<'_>) -> PyResult<String> {
+        py.detach(|| self.facade.with_store(|s| s.drop_vector_index())).map_err(err)?;
+        Ok(json!({"index": serde_json::Value::Null}).to_string())
+    }
+
+    /// `{"index": name}` if an ANN index is built, `{"index": null}` if not —
+    /// the honest answer to "are my vector results exact right now?".
+    fn vector_index(&self, py: Python<'_>) -> PyResult<String> {
+        let name = py.detach(|| self.facade.with_store(|s| s.vector_index())).map_err(err)?;
+        Ok(json!({"index": name}).to_string())
+    }
+
+    /// Grade the ANN index against the exact scan with YOUR query vectors:
+    /// `queries_json` is a JSON array of vectors, `k` the cutoff, `ns` the
+    /// scope you really query with (a narrow one is exact anyway), and
+    /// `ef_search` optionally retunes the index for this session first.
+    /// Returns `{"index", "ef_search", "k", "queries", "recall"}`; with no
+    /// index built the read path is exact and the report says so.
+    #[pyo3(signature = (queries_json, k = 10, ns = None, ef_search = None))]
+    fn vector_recall_check(
+        &self,
+        py: Python<'_>,
+        queries_json: String,
+        k: usize,
+        ns: Option<String>,
+        ef_search: Option<usize>,
+    ) -> PyResult<String> {
+        let queries: Vec<Vec<f32>> = serde_json::from_str(&queries_json).map_err(|e| {
+            PyValueError::new_err(format!("queries must be a JSON array of number arrays: {e}"))
+        })?;
+        let ns = ns.unwrap_or_else(|| self.ns.clone());
+        let report = py
+            .detach(|| {
+                self.facade.with_store(|s| {
+                    if let Some(ef) = ef_search {
+                        s.set_vector_ef_search(ef)?;
+                    }
+                    s.vector_recall_check(&ns, &queries, k)
+                })
+            })
+            .map_err(err)?;
+        serde_json::to_string(&report).map_err(err)
     }
 
     // ---- the `areev run` runtime (Wave 5 parity) ---------------------------

--- a/crates/areev-py/tests/test_areev.py
+++ b/crates/areev-py/tests/test_areev.py
@@ -1459,3 +1459,42 @@ def test_adapter_promotion_is_gated_end_to_end(tmp_path):
         'RECALL facts WHERE relation = "mg:adapter_promotion" AND namespace = "areev-loop"'
     ))["grains"]
     assert promos == []
+
+
+# --------------------------------------------------------------------------
+# the vector-at-scale surface (#141): bulk embeddings, the ANN index, recall@k
+# --------------------------------------------------------------------------
+
+def test_bulk_embeddings_and_the_vector_index_surface(tmp_path):
+    m = make_db(tmp_path)
+    hs = [m.add_fact(f"s{i}", "has", "vector", ns="caller") for i in range(3)]
+    items = [{"hash": h, "vector": [1.0 if j == i else 0.0 for j in range(3)]}
+             for i, h in enumerate(hs)]
+    assert json.loads(m.add_embeddings(json.dumps(items)))["written"] == 3
+    near = json.loads(m.nearest_vector([0.0, 1.0, 0.0], k=1))
+    assert near[0]["hash"] == hs[1]
+
+    # all-or-nothing, and malformed input is named, not swallowed
+    with pytest.raises(ValueError, match="dimensions"):
+        m.add_embeddings(json.dumps([{"hash": hs[0], "vector": [1.0, 0.0, 0.0]},
+                                     {"hash": hs[1], "vector": [1.0, 0.0]}]))
+    with pytest.raises(ValueError, match="item 0"):
+        m.add_embeddings(json.dumps([{"hash": "nope", "vector": [1.0]}]))
+    with pytest.raises(ValueError):
+        m.add_embeddings("not json")
+    assert json.loads(m.add_embeddings("[]"))["written"] == 0
+
+    # a file memory scans exactly: no index, build refused by code, the
+    # recall check says so rather than pretending to grade anything
+    assert json.loads(m.vector_index())["index"] is None
+    with pytest.raises(ValueError, match="STO-E007"):
+        m.ensure_vector_index()
+    rep = json.loads(m.vector_recall_check(json.dumps([[1.0, 0.0, 0.0]]), k=2))
+    assert rep == {"index": None, "ef_search": None, "k": 2, "queries": 0, "recall": 1.0}
+    with pytest.raises(ValueError, match="k >= 1"):
+        m.vector_recall_check("[[1.0, 0.0, 0.0]]", k=0)
+    with pytest.raises(ValueError, match="at least one"):
+        m.vector_recall_check("[]", k=2)
+    with pytest.raises(ValueError, match="STO-E007"):
+        m.vector_recall_check("[[1.0, 0.0, 0.0]]", k=2, ef_search=100)
+    assert json.loads(m.drop_vector_index())["index"] is None

--- a/crates/areev-py/tests/test_postgres.py
+++ b/crates/areev-py/tests/test_postgres.py
@@ -83,3 +83,39 @@ def test_subject_erasure_and_retention():
         assert json.loads(m.stats())["grains"] == 0
     finally:
         areev.drop_postgres_schema(URL, schema)
+
+
+def test_vector_index_lifecycle_and_recall_check():
+    """#141: the ANN index and its grade, from the binding alone. Needs the
+    pgvector extension on the server (the recommended image has it)."""
+    import math
+
+    schema = f"py_vec_{os.getpid()}"
+    try:
+        m = areev.Areev(dsn_for(schema), ns="caller", telemetry="off")
+        hs = [m.add_fact(f"s{i}", "has", "vector") for i in range(60)]
+        items = [{"hash": h, "vector": [math.cos(i * 0.31), math.sin(i * 0.31), 0.05 * i, 1.0]}
+                 for i, h in enumerate(hs)]
+        assert json.loads(m.add_embeddings(json.dumps(items)))["written"] == 60
+        assert json.loads(m.vector_index())["index"] is None
+
+        built = json.loads(m.ensure_vector_index(m=16, ef_construction=64, ef_search=40))
+        assert built["index"] == "idx_embeddings_hnsw"
+        assert json.loads(m.vector_index())["index"] == "idx_embeddings_hnsw"
+
+        rep = json.loads(m.vector_recall_check(
+            json.dumps([it["vector"] for it in items[:8]]), k=5))
+        assert rep["index"] == "idx_embeddings_hnsw"
+        assert rep["queries"] == 8 and rep["k"] == 5 and rep["ef_search"] == 40
+        assert 0.0 <= rep["recall"] <= 1.0
+        retuned = json.loads(m.vector_recall_check(
+            json.dumps([it["vector"] for it in items[:8]]), k=5, ef_search=200))
+        assert retuned["ef_search"] == 200
+        # the exact-scan bypass was lifted: ordinary reads still work after
+        near = json.loads(m.nearest_vector(items[3]["vector"], k=1))
+        assert near[0]["hash"] == hs[3]
+
+        assert json.loads(m.drop_vector_index())["index"] is None
+        assert json.loads(m.vector_index())["index"] is None
+    finally:
+        areev.drop_postgres_schema(URL, schema)

--- a/crates/areev-store/CLAUDE.md
+++ b/crates/areev-store/CLAUDE.md
@@ -2,7 +2,12 @@
 
 The store: backend-agnostic store logic (src/lib.rs) over an internal sync
 `Db` seam (src/db.rs — `execute/query/query_hot/begin/commit/rollback`, plus
-the `prefers_batched_reads`/`ensure_embeddings` capability hooks). Two
+the `prefers_batched_reads`/`ensure_embeddings` capability hooks, the ANN
+trio `ensure_ann_index`/`drop_ann_index`/`ann_index_name`, and
+`set_exact_vector_scan`, which `vector_recall_check` uses to get the exact
+top-k it grades the index against — Postgres disables index scans for the
+handle's session and re-enables them after; the embedded default is a no-op
+because its reads are exact already, as is its `drop_ann_index`). Two
 transports implement it:
 
 - **`TursoDb`** (default; embedded): one memory = one Turso database file.
@@ -74,6 +79,11 @@ Pg-only multi-writer race cases); extend it whenever store semantics change.
   open refuses a schema without the column (`STO-E005`). The scrub path
   re-keys the row through the `Db::scrub_term` seam. Conformance:
   `incompressible_values_of_any_size_are_stored` (both backends).
+- `embeddings(seq, vec)` — one row per vectorized grain, written by
+  `set_grain_embedding` (one txn per vector) or `set_grain_embeddings` (#141:
+  one txn per batch, `EMBEDDING_BATCH_CHUNK` rows per statement, all-or-
+  nothing — hashes and dimensions are checked before the first write). On
+  Postgres the `vec vector(dim)` column arrives at the first vector.
 - `grains` — `seq` PK, `hash` (content address), ns/gtype/created_at,
   s/p/o dict ids, `vf/vt` (world-time validity), `svf/svt` (knowledge-time /
   supersession), `superseded_by/supersedes`, `text` (FTS source), and the

--- a/crates/areev-store/src/db.rs
+++ b/crates/areev-store/src/db.rs
@@ -108,11 +108,31 @@ pub(crate) trait Db: Send {
         ))
     }
 
-    /// Remove the ANN index, returning vector recall to an exact scan.
+    /// Remove the ANN index, returning vector recall to an exact scan. A
+    /// no-op where none can exist: reads there are exact already, which is
+    /// what a drop promises (Postgres answers the same with `IF EXISTS`).
     fn drop_ann_index(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Set the ANN index's query-time candidate-list size for this handle's
+    /// session. Refused where there is no index to tune.
+    fn set_ann_ef_search(&self, _ef_search: usize) -> Result<()> {
         Err(AreevError::AnnIndexUnsupported(
-            "no ANN index exists on this backend".into(),
+            "no ANN index on this backend to tune".into(),
         ))
+    }
+
+    /// The session's current `ef_search`, `None` where there is no ANN index.
+    fn ann_ef_search(&self) -> Result<Option<usize>> {
+        Ok(None)
+    }
+
+    /// Route this handle's vector reads past any ANN index (an exact scan)
+    /// until switched back — the ground truth `vector_recall_check` grades
+    /// against. No-op where reads are exact already.
+    fn set_exact_vector_scan(&self, _on: bool) -> Result<()> {
+        Ok(())
     }
 
     /// The ANN index's name if one is built, `None` if not. Never errors on a

--- a/crates/areev-store/src/lib.rs
+++ b/crates/areev-store/src/lib.rs
@@ -1414,6 +1414,51 @@ impl Areev {
 }
 
 
+/// Rows per statement in [`Areev::set_grain_embeddings`]: well under the
+/// embedded engine's bind-variable ceiling (two binds per row), and large
+/// enough that a networked backend's round trips are per chunk, not per row.
+pub const EMBEDDING_BATCH_CHUNK: usize = 200;
+
+/// What [`Areev::vector_recall_check`] measured.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct VectorRecallReport {
+    /// The ANN index graded; `None` means every read is exact already.
+    pub index: Option<String>,
+    /// The session's `hnsw.ef_search` the grade was taken at (`None` off Postgres).
+    pub ef_search: Option<usize>,
+    pub k: usize,
+    /// Query vectors actually run (0 when there was no index to grade).
+    pub queries: usize,
+    /// Fraction of the exact top-k the indexed read returned; `None` when the
+    /// scope yielded no exact neighbours to grade against.
+    pub recall: Option<f32>,
+}
+
+#[derive(serde::Deserialize)]
+struct EmbeddingItemRaw {
+    hash: String,
+    vector: Vec<f32>,
+}
+
+/// `[{"hash": "<64-hex>", "vector": [..]}, …]` — the shape every binding and
+/// the CLI accept — as [`Areev::set_grain_embeddings`] takes it. A bad row is
+/// named by index.
+pub fn parse_embedding_items(json: &str) -> Result<Vec<(Hash, Vec<f32>)>> {
+    let rows: Vec<EmbeddingItemRaw> = serde_json::from_str(json).map_err(|e| {
+        AreevError::Validation(format!(
+            "items must be a JSON array of {{\"hash\", \"vector\"}} objects: {e}"
+        ))
+    })?;
+    rows.into_iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let hash = Hash::from_hex(&r.hash)
+                .map_err(|e| AreevError::Validation(format!("item {i}: {e}")))?;
+            Ok((hash, r.vector))
+        })
+        .collect()
+}
+
 fn vec_to_json(v: &[f32]) -> String {
     let mut s = String::with_capacity(v.len() * 8);
     s.push('[');
@@ -3695,43 +3740,177 @@ impl Areev {
     }
 
     /// Install or replace the indexed embedding for an already-stored grain,
-    /// by content address. The backfill primitive behind
-    /// [`Self::add_with_embedding`]; also what an adapter uses to carry a
-    /// framework's own vectors onto grains that were added earlier.
+    /// by content address. The one-row form of
+    /// [`set_grain_embeddings`](Self::set_grain_embeddings), and the same path.
     pub fn set_grain_embedding(&mut self, hash: &Hash, embedding: &[f32]) -> Result<Hash> {
-        self.check_embedding_dim(embedding.len())?;
-        let rows = self.db.query(
-            "SELECT seq FROM grains WHERE hash=?1",
-            vec![pb(hash.as_bytes().to_vec())],
-        )?;
-        let Some(seq) = rows.first().and_then(|r| r.i64(0)) else {
-            return Err(AreevError::NotFound(*hash));
+        match self.set_grain_embeddings(&[(*hash, embedding.to_vec())])? {
+            0 => Err(AreevError::NotFound(*hash)),
+            _ => Ok(*hash),
+        }
+    }
+
+    /// Install or replace the indexed embeddings for many stored grains in
+    /// one transaction, [`EMBEDDING_BATCH_CHUNK`] rows per statement. Nothing
+    /// is written unless every hash resolves and every vector has the batch's
+    /// dimension; a grain another writer forgets mid-batch is skipped, so the
+    /// count returned can be lower than `items.len()`.
+    pub fn set_grain_embeddings(&mut self, items: &[(Hash, Vec<f32>)]) -> Result<usize> {
+        self.check_writable("write embeddings")?;
+        let Some((_, first)) = items.first() else {
+            return Ok(0);
         };
-        // As `set_embedder` does: Postgres creates its `vector(dim)` column
-        // here, and a host supplying its own vectors never takes that path.
-        self.db.ensure_embeddings(embedding.len())?;
-        let dbr = self.db.as_ref();
-        let qjson = vec_to_json(embedding);
-        with_txn(dbr, || {
-            // DELETE + INSERT rather than an upsert: portable across the
-            // embedded and Postgres backends without dialect-specific
-            // ON CONFLICT / OR REPLACE translation.
-            dbr.execute("DELETE FROM embeddings WHERE seq=?1", vec![pi(seq)])?;
-            dbr.execute(
-                "INSERT INTO embeddings(seq, vec) VALUES (?1, vector32(?2))",
-                vec![pi(seq), pt(&qjson)],
+        let dim = first.len();
+        self.check_embedding_dim(dim)?;
+        for (h, v) in items {
+            if v.len() != dim {
+                return Err(AreevError::Validation(format!(
+                    "embedding for {} has {} dimensions; this batch is {dim}-dimensional",
+                    h.to_hex(),
+                    v.len()
+                )));
+            }
+        }
+        let mut by_hash: HashMap<Vec<u8>, i64> = HashMap::new();
+        for chunk in items.chunks(EMBEDDING_BATCH_CHUNK) {
+            let placeholders: Vec<String> = (1..=chunk.len()).map(|i| format!("?{i}")).collect();
+            let params: Vec<Value> = chunk.iter().map(|(h, _)| pb(h.as_bytes().to_vec())).collect();
+            let rows = self.db.query(
+                &format!("SELECT seq, hash FROM grains WHERE hash IN ({})", placeholders.join(",")),
+                params,
             )?;
-            Ok(())
+            for r in &rows {
+                if let (Some(seq), Some(hash)) = (r.i64(0), r.blob(1)) {
+                    by_hash.insert(hash, seq);
+                }
+            }
+        }
+        // Last write wins for a hash that appears twice.
+        let mut rows: Vec<(i64, String)> = Vec::with_capacity(items.len());
+        let mut seen: HashMap<i64, usize> = HashMap::new();
+        for (h, v) in items {
+            let Some(seq) = by_hash.get(h.as_bytes().as_slice()) else {
+                return Err(AreevError::NotFound(*h));
+            };
+            match seen.get(seq) {
+                Some(&at) => rows[at].1 = vec_to_json(v),
+                None => {
+                    seen.insert(*seq, rows.len());
+                    rows.push((*seq, vec_to_json(v)));
+                }
+            }
+        }
+        self.db.ensure_embeddings(dim)?;
+        let dbr = self.db.as_ref();
+        let written = with_txn(dbr, || {
+            let mut written = 0usize;
+            for chunk in rows.chunks(EMBEDDING_BATCH_CHUNK) {
+                let seqs: Vec<i64> = chunk.iter().map(|(seq, _)| *seq).collect();
+                // Under the row lock: on the multi-writer backend a forget can
+                // land between the resolve above and this insert, and a vector
+                // left behind for an erased grain would undo the erasure.
+                let alive: HashSet<i64> = dbr
+                    .query(
+                        &format!(
+                            "SELECT seq FROM grains WHERE seq IN ({}){}",
+                            seq_csv(&seqs),
+                            dbr.for_update()
+                        ),
+                        vec![],
+                    )?
+                    .iter()
+                    .filter_map(|r| r.i64(0))
+                    .collect();
+                let live: Vec<&(i64, String)> =
+                    chunk.iter().filter(|(seq, _)| alive.contains(seq)).collect();
+                if live.is_empty() {
+                    continue;
+                }
+                let live_seqs: Vec<i64> = live.iter().map(|(seq, _)| *seq).collect();
+                dbr.execute(
+                    &format!("DELETE FROM embeddings WHERE seq IN ({})", seq_csv(&live_seqs)),
+                    vec![],
+                )?;
+                let mut values: Vec<String> = Vec::with_capacity(live.len());
+                let mut params: Vec<Value> = Vec::with_capacity(live.len() * 2);
+                for (i, (seq, qjson)) in live.iter().enumerate() {
+                    values.push(format!("(?{}, vector32(?{}))", 2 * i + 1, 2 * i + 2));
+                    params.push(pi(*seq));
+                    params.push(pt(qjson));
+                }
+                dbr.execute(
+                    &format!("INSERT INTO embeddings(seq, vec) VALUES {}", values.join(", ")),
+                    params,
+                )?;
+                written += live.len();
+            }
+            Ok(written)
         })?;
-        // After the write: a declaration the memory cannot serve is worse
-        // than none.
-        if self.meta_embed.is_none() {
-            let dim = embedding.len();
+        if written > 0 && self.meta_embed.is_none() {
             self.meta_put("embedding_model", "external")?;
             self.meta_put("embedding_dim", &dim.to_string())?;
             self.meta_embed = Some(("external".to_string(), dim));
         }
-        Ok(*hash)
+        Ok(written)
+    }
+
+    /// Grade the ANN index against the exact scan with the caller's own
+    /// query vectors over the scope they really query with — recall is a
+    /// property of their model's geometry. With no index the read path is
+    /// exact already: `recall` is 1.0 and nothing runs. The exact side is a
+    /// per-handle planner bypass, lifted before returning on every path.
+    pub fn vector_recall_check(
+        &mut self,
+        ns: &str,
+        queries: &[Vec<f32>],
+        k: usize,
+    ) -> Result<VectorRecallReport> {
+        if k == 0 {
+            return Err(AreevError::Validation("recall@k needs k >= 1".into()));
+        }
+        if queries.is_empty() {
+            return Err(AreevError::Validation(
+                "recall@k needs at least one query vector".into(),
+            ));
+        }
+        for q in queries {
+            self.check_embedding_dim(q.len())?;
+        }
+        let ef_search = self.db.ann_ef_search()?;
+        let Some(index) = self.vector_index()? else {
+            return Ok(VectorRecallReport {
+                index: None,
+                ef_search,
+                k,
+                queries: 0,
+                recall: Some(1.0),
+            });
+        };
+        let mut approx = Vec::with_capacity(queries.len());
+        for q in queries {
+            approx.push(self.nearest_vector(ns, None, None, q, k)?);
+        }
+        self.db.set_exact_vector_scan(true)?;
+        let exact: Result<Vec<Vec<(Hash, f32)>>> =
+            queries.iter().map(|q| self.nearest_vector(ns, None, None, q, k)).collect();
+        self.db.set_exact_vector_scan(false)?;
+        let exact = exact?;
+        let (mut hits, mut possible) = (0usize, 0usize);
+        for (a, e) in approx.iter().zip(&exact) {
+            possible += e.len();
+            let truth: HashSet<&Hash> = e.iter().map(|(h, _)| h).collect();
+            hits += a.iter().filter(|(h, _)| truth.contains(h)).count();
+        }
+        // No exact neighbours at all (a scope with nothing in it) grades
+        // nothing; that is `None`, never a 1.0 that reads as a pass.
+        let recall = (possible > 0).then(|| hits as f32 / possible as f32);
+        Ok(VectorRecallReport { index: Some(index), ef_search, k, queries: queries.len(), recall })
+    }
+
+    /// Set the ANN index's query-time candidate-list size (`hnsw.ef_search`)
+    /// for this handle's session — the accuracy/latency knob that needs no
+    /// rebuild. Refused where there is no index (`STO-E007`).
+    pub fn set_vector_ef_search(&mut self, ef_search: usize) -> Result<()> {
+        self.db.set_ann_ef_search(ef_search)
     }
 
     /// Build an approximate-nearest-neighbour index over the stored vectors,

--- a/crates/areev-store/src/pg.rs
+++ b/crates/areev-store/src/pg.rs
@@ -369,6 +369,11 @@ pub(crate) struct PgDb {
     /// it is: the transaction died with the connection, so silently re-running
     /// one statement would apply it outside the atomic unit it was written for.
     in_txn: std::cell::Cell<bool>,
+    /// Session settings that must SURVIVE a reconnect: `reconnect` builds a
+    /// fresh session with Postgres defaults, and a replayed read on it would
+    /// silently grade the HNSW answer against itself.
+    ann_ef_search: std::cell::Cell<Option<usize>>,
+    exact_scan: std::cell::Cell<bool>,
     /// Cached BM25 collection stats — a COUNT/SUM over fts_doc is O(corpus)
     /// and would otherwise run on EVERY text query. Invalidated on this
     /// handle's own writes (reserve_write); other writers' documents stay
@@ -534,6 +539,8 @@ impl PgDb {
             client: RefCell::new(std::sync::Arc::new(client)),
             cache: RefCell::new(HashMap::new()),
             in_txn: std::cell::Cell::new(false),
+            ann_ef_search: std::cell::Cell::new(None),
+            exact_scan: std::cell::Cell::new(false),
             stats: RefCell::new(None),
             bootstrap_skipped,
         })
@@ -753,11 +760,17 @@ impl PgDb {
     /// caches that belonged to the old session have to go.
     fn reconnect(&self) -> Result<()> {
         let client = crate::pgtls::connect(&self.rt, &self.url)?;
-        self.rt.block_on(client.batch_execute(&format!(
-            "SET search_path TO \"{}\", public, ext",
-            self.schema
-        )))
-        .map_err(pg_err)?;
+        let mut session = format!("SET search_path TO \"{}\", public, ext", self.schema);
+        // Re-apply what the dead session carried, or a replayed read lands
+        // on Postgres defaults: an `ef_search` a host tuned, and the exact-scan
+        // bypass mid `vector_recall_check`.
+        if let Some(ef) = self.ann_ef_search.get() {
+            session.push_str(&format!("; SET hnsw.ef_search = {ef}"));
+        }
+        if self.exact_scan.get() {
+            session.push_str("; SET enable_indexscan = off; SET enable_bitmapscan = off");
+        }
+        self.rt.block_on(client.batch_execute(&session)).map_err(pg_err)?;
         // Order matters only in that both must happen before the next call:
         // a Statement from the old session is invalid, and the BM25 collection
         // stats were cached against a connection that can no longer confirm them.
@@ -1232,7 +1245,38 @@ impl Db for PgDb {
                 .batch_execute(&format!("SET hnsw.ef_search = {ef_search}"))
                 .await
                 .map_err(pg_err)?;
+            self.ann_ef_search.set(Some(ef_search));
             Ok(())
+        })
+    }
+
+    fn set_ann_ef_search(&self, ef_search: usize) -> Result<()> {
+        if !(1..=1000).contains(&ef_search) {
+            return Err(AreevError::Validation(format!(
+                "hnsw ef_search must be 1..=1000, got {ef_search}"
+            )));
+        }
+        self.rt.block_on(async {
+            let client = self.client.borrow().clone();
+            client
+                .batch_execute(&format!("SET hnsw.ef_search = {ef_search}"))
+                .await
+                .map_err(pg_err)
+        })?;
+        self.ann_ef_search.set(Some(ef_search));
+        Ok(())
+    }
+
+    fn ann_ef_search(&self) -> Result<Option<usize>> {
+        // `current_setting(_, true)` is NULL rather than an error when the
+        // extension has never been loaded in this session.
+        self.rt.block_on(async {
+            let client = self.client.borrow().clone();
+            let row = client
+                .query_one("SELECT current_setting('hnsw.ef_search', true)", &[])
+                .await
+                .map_err(pg_err)?;
+            Ok(row.get::<_, Option<String>>(0).and_then(|v| v.parse().ok()))
         })
     }
 
@@ -1245,6 +1289,26 @@ impl Db for PgDb {
                 .map_err(pg_err)?;
             Ok(())
         })
+    }
+
+    fn set_exact_vector_scan(&self, on: bool) -> Result<()> {
+        // pgvector serves an approximate k-NN through an index scan over the
+        // HNSW graph; with index scans disabled the planner falls back to the
+        // sequential scan that computes every distance, which is the exact
+        // answer. Session-scoped like `hnsw.ef_search`, and this backend
+        // holds one connection per handle, so it affects only this handle —
+        // and only until it is switched back.
+        let sql = if on {
+            "SET enable_indexscan = off; SET enable_bitmapscan = off"
+        } else {
+            "RESET enable_indexscan; RESET enable_bitmapscan"
+        };
+        self.rt.block_on(async {
+            let client = self.client.borrow().clone();
+            client.batch_execute(sql).await.map_err(pg_err)
+        })?;
+        self.exact_scan.set(on);
+        Ok(())
     }
 
     fn ann_index_name(&self) -> Result<Option<String>> {

--- a/crates/areev-store/tests/vector_in_tests.rs
+++ b/crates/areev-store/tests/vector_in_tests.rs
@@ -190,3 +190,92 @@ fn a_prefix_scope_still_honours_the_subject_filter() {
     let none = m.nearest_vector("deal.*", Some("ghost"), None, &[1.0, 0.0, 0.0], 10).unwrap();
     assert!(none.is_empty(), "an uninterned subject short-circuits instead of scanning");
 }
+
+/// #141: the bulk write lands many vectors in one transaction, across more
+/// than one statement chunk, and reads back exactly like the per-grain path.
+#[test]
+fn set_grain_embeddings_writes_a_multi_chunk_batch_atomically() {
+    let (mut m, _d) = open_mem();
+    let n = areev_store::EMBEDDING_BATCH_CHUNK + 50; // forces a second chunk
+    let mut items = Vec::with_capacity(n);
+    for i in 0..n {
+        let h = m.add(&fact(&format!("g{i}"), "is", "a grain", 100 + i as i64)).unwrap();
+        // Distinct directions in a 4-dim space so nearest() can tell them apart.
+        let a = i as f32;
+        items.push((h, vec![a.cos(), a.sin(), (a * 0.5).cos(), (a * 0.5).sin()]));
+    }
+    assert_eq!(m.set_grain_embeddings(&items).unwrap(), n);
+    assert_eq!(m.declared_embedding(), Some(("external", 4)));
+    // Every vector is its own nearest neighbour.
+    for (h, v) in items.iter().step_by(37) {
+        let near = m.nearest_vector("kb", None, None, v, 1).unwrap();
+        assert_eq!(near[0].0, *h);
+        assert!(near[0].1 > 0.999, "{}", near[0].1);
+    }
+
+    // A repeated hash takes its LAST vector.
+    let (h0, _) = items[0].clone();
+    let twice = vec![(h0, vec![1.0, 0.0, 0.0, 0.0]), (h0, vec![0.0, 1.0, 0.0, 0.0])];
+    assert_eq!(m.set_grain_embeddings(&twice).unwrap(), 1);
+    let near = m.nearest_vector("kb", None, None, &[0.0, 1.0, 0.0, 0.0], 1).unwrap();
+    assert_eq!(near[0].0, h0);
+
+    // An empty batch is a no-op, not an error.
+    assert_eq!(m.set_grain_embeddings(&[]).unwrap(), 0);
+}
+
+/// One bad entry refuses the WHOLE batch before anything is written —
+/// whether the fault is a dimension or an unknown address.
+#[test]
+fn set_grain_embeddings_is_all_or_nothing() {
+    let (mut m, _d) = open_mem();
+    let a = m.add(&fact("a", "is", "x", 1)).unwrap();
+    let b = m.add(&fact("b", "is", "y", 2)).unwrap();
+    let missing = areev_core::error::Hash::from_hex(&"9".repeat(64)).unwrap();
+
+    let err = m
+        .set_grain_embeddings(&[(a, vec![1.0, 0.0]), (b, vec![0.0, 1.0, 0.0])])
+        .unwrap_err();
+    assert!(err.to_string().contains("dimensions"), "{err}");
+    assert!(m.nearest_vector("kb", None, None, &[1.0, 0.0], 5).unwrap().is_empty(), "nothing written");
+    assert!(m.declared_embedding().is_none(), "and no provenance stamped");
+
+    let err = m
+        .set_grain_embeddings(&[(a, vec![1.0, 0.0]), (missing, vec![0.0, 1.0])])
+        .unwrap_err();
+    assert!(err.to_string().contains("MEM-E") || err.to_string().contains("not found"), "{err}");
+    assert!(m.nearest_vector("kb", None, None, &[1.0, 0.0], 5).unwrap().is_empty(), "nothing written");
+}
+
+/// The embedded engine has no ANN index, so its reads are exact by
+/// construction: the check says so (`index: None`, recall 1.0) and runs no
+/// queries, rather than pretending to grade an index that is not there.
+#[test]
+fn vector_recall_check_is_trivially_exact_without_an_index() {
+    let (mut m, _d) = open_mem();
+    let a = m.add_with_embedding(&fact("a", "is", "x", 1), &[1.0, 0.0]).unwrap();
+    let _ = a;
+    let report = m.vector_recall_check("kb", &[vec![1.0, 0.0], vec![0.0, 1.0]], 3).unwrap();
+    assert_eq!((report.index, report.ef_search), (None, None));
+    assert_eq!((report.queries, report.k), (0, 3));
+    assert_eq!(report.recall, Some(1.0));
+    assert!(m.vector_recall_check("kb", &[vec![1.0, 0.0]], 0).is_err(), "k = 0 is refused");
+    assert!(m.vector_recall_check("kb", &[], 3).is_err(), "no queries is refused");
+    assert!(
+        m.vector_recall_check("kb", &[vec![1.0, 0.0, 0.0]], 3).is_err(),
+        "a query of the wrong dimension is refused even when no index exists"
+    );
+    assert!(
+        m.set_vector_ef_search(100).unwrap_err().to_string().starts_with("STO-E007"),
+        "nothing to tune on the embedded engine"
+    );
+    assert!(
+        m.ensure_vector_index(16, 64, 40).unwrap_err().to_string().starts_with("STO-E007"),
+        "the embedded engine still refuses to build one"
+    );
+    assert_eq!(m.vector_index().unwrap(), None);
+    // Dropping what was never built is a no-op, not a refusal: the point of
+    // a drop is exact reads, and they already are.
+    m.drop_vector_index().unwrap();
+    assert_eq!(m.vector_index().unwrap(), None);
+}

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1571,6 +1571,42 @@ Three things worth knowing:
 
 ---
 
+## 23. Bulk-load vectors, build the ANN index, and check what it costs you
+
+Postgres tier, external embeddings, a corpus large enough that the exact scan
+stopped fitting the budget (#141). Three steps, in this order, from Python;
+Node is the same names in camelCase, and `areev vector-index` is the shell.
+
+```python
+import json, areev
+m = areev.Areev("postgres://…?schema=firm", ns="firm.deals.*", telemetry="off")
+
+# 1. Vectors in bulk — one transaction, not one per grain.
+items = [{"hash": h, "vector": embed(text)} for h, text in corpus]
+print(m.add_embeddings(json.dumps(items)))          # {"written": 100000}
+
+# 2. The index, only for the genuinely corpus-wide query. A k-NN scoped to
+#    one deal is exact and faster WITHOUT it.
+print(m.ensure_vector_index(m=16, ef_construction=64, ef_search=40))
+#    → {"index": "idx_embeddings_hnsw"}
+
+# 3. Grade it with YOUR queries, over the WIDE scope you actually search.
+sample = [embed(q) for q in held_out_queries[:200]]
+print(m.vector_recall_check(json.dumps(sample), k=10, ns="firm.deals.*"))
+#    → {"index": "idx_embeddings_hnsw", "k": 10, "queries": 200, "recall": 0.97}
+```
+
+If the recall is not what you need, raise `ef_search` — pass it straight to
+the check, `vector_recall_check(..., ef_search=200)`, session-scoped and no
+rebuild — or `m` / `ef_construction` (rebuild), or `drop_vector_index()` and
+go back to exact. From the shell the same check is `areev vector-index check
+--queries q.json --ns 'firm.deals.*' --k 10 --ef-search 200`; the scope is
+mandatory there because the CLI's default namespace is a narrow one. A recall that does not move when `ef_search` does is measuring
+your embedder, not the index (`scale-and-tenancy.md`). On a file memory every
+one of these answers honestly: `vector_index()` is `null`, a build is
+`STO-E007`, and the check reports `recall: 1.0` without running anything,
+because the reads were exact to begin with.
+
 ## See also
 
 - [`../ARCHITECTURE.md`](../ARCHITECTURE.md) — how Areev is built

--- a/docs/deployment-profile.md
+++ b/docs/deployment-profile.md
@@ -151,6 +151,17 @@ milliseconds, fine as a provisioning step and unacceptable inside a request.
 Steady-state open of an existing, populated schema is tens of milliseconds.
 Create the tenant's schema when the tenant is created, not on their first turn.
 
+**Open handles before bulk operations.** A bootstrapping open — the first
+open of a schema, or the first open of a build that carries a migration —
+runs DDL that takes a `ShareLock` on the tables it touches, and that lock
+waits behind any long transaction already in flight: a second `open()` on a
+schema mid-way through a bulk `add_embeddings` or a reindex blocks until that
+transaction commits, and looks like a hang. Steady-state opens issue no DDL
+(#180) and are unaffected, and so is `--read-only`, which never issues DDL at
+all. So: provision the schema (`areev provision`) and open every handle you
+will need *before* starting a bulk load, rather than opening a fresh one in
+the middle of it.
+
 **Outage recovery: automatic for reads, explicit for writes.** A managed
 Postgres restarts, fails over, and drops connections as routine maintenance.
 The handle now replaces a dead session in place — clearing the

--- a/docs/scale-and-tenancy.md
+++ b/docs/scale-and-tenancy.md
@@ -110,10 +110,13 @@ Three levers, in the order to reach for them:
    by into the namespace at ingest** — it is not addable later without
    rewriting the corpus, for the same reason §1's partition map is not.
 3. **Then, and only for the genuinely corpus-wide query, an ANN index.**
-   `Areev::ensure_vector_index` builds a pgvector HNSW index (Postgres only;
-   the embedded backend answers `STO-E007`), taking the unfiltered query from
+   `ensure_vector_index` builds a pgvector HNSW index (Postgres only; the
+   embedded backend answers `STO-E007`), taking the unfiltered query from
    24 ms to 1.0 ms at 100k grains. It is opt-in because it makes recall
-   approximate.
+   approximate. It is reachable from every surface that manages a memory —
+   Rust, Python and Node (`ensure_vector_index` / `ensureVectorIndex`), and
+   the shell (`areev vector-index build`) — and `vector_index()` /
+   `areev vector-index status` answers whether reads are exact right now.
 
 **Measure recall with your own model before trusting an ANN index.** The
 latency win is unconditional. The accuracy cost is a property of your embedding
@@ -125,9 +128,20 @@ build parameters, 1.00 at `m=32, ef_construction=200`, for a 12× speedup. The
 recall number is measuring the embedder rather than the index is that it does
 not move when `ef_search` does (RESULTS.md §8e).
 
-Two commands settle it for your corpus: `pe_scale --dump-topk` against the
-exact scan, then `--compare-topk` with `--ann`. Do it before an ANN index
-reaches a corpus anyone relies on.
+Measure it with your own query vectors: `vector_recall_check(queries, k, ns)`
+in either binding, or `areev vector-index check --queries FILE.json --ns
+'org.*'`, grades the index against the exact scan over the scope you name and
+reports recall@k at the `ef_search` it ran with (pass `ef_search` to retune
+the session first, no rebuild). (`pe_scale --dump-topk` / `--compare-topk` is the same measurement
+as a benchmark harness.) Do it before an ANN index reaches a corpus anyone
+relies on, and do it over the *wide* scope you actually query — a k-NN
+narrowed to one namespace is served exactly from the structural index and
+will report 1.0 without telling you anything about the graph.
+
+Bulk vectors go in through `add_embeddings` (one transaction, chunked), not
+one `add_embedding` call per grain — the per-vector path is a transaction and
+three round trips each, and on the Postgres tier that made a re-ingest
+round-trip-bound at ~545 vectors/s against ~911 grains/s for `add_batch`.
 
 A note on tiers: the PostgreSQL backend is **faster** at the vector scan than
 the embedded one (24 ms vs 121 ms at 100k), because `pgvector`'s `<=>` is SIMD


### PR DESCRIPTION
Closes #141.

A host that manages memories through Python or Node alone could not build
the ANN index, could only write embeddings one transaction at a time, and
had no way to check what the index cost it. Everything below is in both
bindings, in parity, and as `areev vector-index <status|build|drop|check>`.

## Bulk embedding writes

`add_embeddings([{hash, vector}, …])` writes a batch in one transaction,
two hundred rows per statement. The per-vector path was a transaction and
three round trips each, which is why a bulk re-ingest measured
round-trip-bound (~545 vectors/s) rather than embedding-bound. All-or-
nothing: an unknown hash or a wrong dimension refuses the batch before
anything is written, and the error names the row. Inside the transaction
each chunk re-checks its grains under the row lock, so on the multi-writer
Postgres backend a forget landing mid-batch cannot leave a vector behind
for erased content. `set_grain_embedding` is now the one-row form of the
same path, which also means it honours `--read-only` and issues no DDL.

## The index, reachable

`ensure_vector_index(m, ef_construction, ef_search)`, `drop_vector_index()`
and `vector_index()` expose the pgvector HNSW index that was Rust-only. A
file memory still refuses to build one (`STO-E007`) and reports
`index: null`, because its reads are exact. Dropping where none can exist
is now a no-op rather than an error: what a drop promises is exact reads,
and they already are — Postgres answers the same way with `IF EXISTS`.

## A recall check the host can run

`vector_recall_check(queries, k, ns, ef_search)` grades the index against
the exact scan **with the caller's own query vectors**, because recall is a
property of the embedding model's geometry and nobody else's number
transfers. The exact side is obtained by disabling index scans for the
handle's session only, confirmed in Postgres to route the k-NN to a
sequential scan, and lifted before returning on every path. The report
carries the `ef_search` it graded at; passing one retunes the session
first, no rebuild. With no index built it reports `recall: 1.0` and runs
nothing; a scope with no exact neighbours reports `recall: null` rather
than a 1.0 that reads as a pass. The CLI insists on `--ns`, because its
default scope is a narrow one the structural index serves exactly.

Both the exact-scan bypass and a tuned `ef_search` are stored on the
handle and re-applied on reconnect. Without that, a connection drop mid-
check replayed the "exact" read on a fresh session with default settings,
and the index graded itself at 1.0.

Not added as an MCP tool: building an index is an operator action, not
something an agent should reach for mid-conversation.

## Docs moved with the code

Cookbook recipe 23, the scale guide, a deployment-profile note on opening
handles before bulk loads (a bootstrapping open's DDL waits on a
`ShareLock` behind a long transaction; steady-state opens skip DDL), the
store's CLAUDE.md, the CLI help text and verb count, and the changelog —
including the 1.7.0 change that made `nearest_vector` accept a prefix
scope, which shipped without a line.

## Verification

- `cargo test --workspace` green.
- Postgres conformance 82/82 against PostgreSQL 16 with pgvector 0.8.0,
  including the new `bulk_embeddings_land_atomically` case on both backends
  and a Postgres-only test that builds a real HNSW index, grades it,
  retunes `ef_search`, and checks an empty scope reports `null`.
- Python: 88 embedded + 5 Postgres. Node: 72 embedded + 5 Postgres, twice.
- Clippy clean on every changed crate for default, `postgres`, and the Node
  crate. `cargo doc` as CI runs it has no warnings on the new items.
- `scripts/repo_stats.py --check` within tolerance.