### PR TITLE
feat(Postgres): schema-qualified SQL and stale-statement recovery

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1768,6 +1768,35 @@ and `areev-loop` keeps its no-Areev-dependency rule. A substrate that
 declares neither degrades those kinds to advisory rather than pretending to
 have checked them. Reference: [docs/loop.md](docs/loop.md) (DISCOVER).
 
+### The Postgres store keeps nothing on the session, because the session is not its to keep
+
+One memory = one schema, and the obvious way to address a schema is
+`SET search_path` once at open and write every statement against bare table
+names. That is what the store did, and it made a documented hazard of every
+transaction-mode pooler (PgBouncer, Supavisor, PgCat, Neon's pooled
+endpoint): each transaction lands on whichever backend is free, whose
+`search_path` belongs to someone else or to nobody, and a bare `grains` then
+reads another tenant's rows — silently, because the query is well-formed.
+Areev Cloud's spec (#181) wants a worker holding thousands of memories over
+one pool, which is the same constraint at a different scale.
+
+The decision: the store assumes every statement may run on a fresh session.
+Table references are schema-qualified by a pass after the dialect translator
+(`qualify_tables`), so nothing resolves through `search_path`; runtime DDL
+and catalog probes bind the schema name instead of `current_schema()`; the
+bootstrap lock is transaction-scoped; and a prepared statement the backend
+does not know is re-prepared rather than reported when that is possible
+(outside a transaction). The proof is a run of the whole conformance suite
+with `RESET ALL` before every statement outside a transaction, and the same
+suite through a real PgBouncer in transaction mode. What the store cannot
+absorb is stated rather than papered over: the driver names every
+parameterized statement, so the pooler must track prepared statements across
+backends (PgBouncer 1.21+ does) or run in session mode — inside a transaction
+a stale statement aborts it, and the error names both remedies. Two things
+stay session-scoped by design for now: `hnsw.ef_search`, whose loss under
+pooling is a silent accuracy regression, and the process-wide pool itself,
+which is the next increment.
+
 ### The dictionary is keyed by digest, because the index must be bounded and the value is not
 
 Every subject, relation and object string is interned into `terms` (§3): a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Postgres: the store holds nothing on the session** (#181, second
+  increment). Every statement names its tables schema-qualified, the bootstrap
+  lock is transaction-scoped (first increment), and a cached prepared
+  statement the backend no longer knows (`26000`) is re-prepared and retried.
+  Runtime DDL and catalog probes bind the schema name instead of reading
+  `current_schema()`. So a transaction-mode pooler in front of the store is
+  now correct rather than a documented hazard: the full conformance suite runs
+  with `RESET ALL` issued before every statement outside a transaction
+  (`tests/pg_chaos.rs`), which drops `search_path` and every GUC, and the
+  suite passes through a real PgBouncer in transaction mode. The one thing
+  the pooler must do itself is track prepared statements across backends —
+  the driver names every parameterized statement, so PgBouncer 1.21+ with
+  `max_prepared_statements > 0`, or session mode; a `26000` inside a
+  transaction now says exactly that instead of reading like a driver bug.
+  What is still session-scoped, and documented as such: `hnsw.ef_search`. The
+  in-process pool itself (one pool across N schemas) is the third increment.
+
 - **The vector-at-scale surface reaches the bindings and the CLI** (#141).
   A host that manages memories through Python or Node alone could not build
   the ANN index, could only write embeddings one transaction at a time, and

--- a/crates/areev-conformance/tests/pg_chaos.rs
+++ b/crates/areev-conformance/tests/pg_chaos.rs
@@ -1,0 +1,53 @@
+//! Postgres runner under session chaos (#181): the IDENTICAL conformance case
+//! list, with `RESET ALL` issued by the store itself before every statement
+//! outside a transaction. That drops `search_path` and every GUC — what a
+//! transaction-mode pooler's backend switch does between transactions — so a
+//! green run here is the proof that no statement resolves through the
+//! session. (Prepared statements are the pooler's half: the driver names every
+//! parameterized statement, so the pooler must track them; PgBouncer 1.21+
+//! with `max_prepared_statements > 0` does, and the deployment profile says
+//! so. `pg_stale.rs` pins the store's own recovery for the out-of-transaction
+//! case.)
+//!
+//! Same DSN contract as `pg.rs`: skips loudly without `DATABASE_URL`, hard-
+//! fails under `CI=true`. The hook only exists on a `conformance` build of
+//! `areev-store`, which this crate's `postgres` feature turns on.
+#![cfg(feature = "postgres")]
+
+use areev_conformance::{cases, PgBackend};
+
+fn pg_url() -> Option<String> {
+    std::env::var("AREEV_PG_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|u| u.starts_with("postgres"))
+}
+
+fn backend() -> Option<PgBackend> {
+    // Process-wide, read before every statement; every test in this binary
+    // wants it.
+    std::env::set_var("AREEV_PG_SESSION_CHAOS", "1");
+    match pg_url() {
+        Some(url) => Some(PgBackend::new(&url)),
+        None => {
+            if std::env::var("CI").as_deref() == Ok("true") {
+                panic!("CI=true but no DATABASE_URL — the postgres chaos job must not silently skip");
+            }
+            eprintln!("skipping: no DATABASE_URL/AREEV_PG_URL");
+            None
+        }
+    }
+}
+
+macro_rules! pg_chaos_case {
+    ($name:ident) => {
+        #[test]
+        fn $name() {
+            let Some(b) = backend() else { return };
+            cases::$name(&b);
+        }
+    };
+}
+
+areev_conformance::for_each_conformance_case!(pg_chaos_case);
+

--- a/crates/areev-conformance/tests/pg_stale.rs
+++ b/crates/areev-conformance/tests/pg_stale.rs
@@ -1,0 +1,71 @@
+//! The store's own recovery from a prepared statement the backend no longer
+//! knows (#181), in its own binary because the chaos form it uses
+//! (`DEALLOCATE ALL` before every statement outside a transaction) is process-
+//! wide and would break any concurrent test's transaction.
+//!
+//! Outside a transaction a `26000` is retried after re-preparing. Inside one
+//! it cannot be — the failed Bind aborted the transaction — and the error
+//! must say what a deployment needs (a pooler that tracks prepared
+//! statements, or session mode) rather than read like a driver bug.
+#![cfg(feature = "postgres")]
+
+use areev_conformance::{Backend, PgBackend};
+
+fn pg_url() -> Option<String> {
+    std::env::var("AREEV_PG_URL")
+        .or_else(|_| std::env::var("DATABASE_URL"))
+        .ok()
+        .filter(|u| u.starts_with("postgres"))
+}
+
+#[test]
+fn stale_statements_are_retried_outside_a_transaction_and_explained_inside_one() {
+    let Some(url) = pg_url() else {
+        if std::env::var("CI").as_deref() == Ok("true") {
+            panic!("CI=true but no DATABASE_URL — the postgres stale-statement job must not skip");
+        }
+        eprintln!("skipping: no DATABASE_URL/AREEV_PG_URL");
+        return;
+    };
+    // Open and write with no chaos: the hot statements get prepared and
+    // cached, and nothing has deallocated them yet.
+    std::env::remove_var("AREEV_PG_SESSION_CHAOS");
+    let b = PgBackend::new(&url);
+    let mut m = b.open_named("stale");
+    for i in 0..5 {
+        m.add(&areev_conformance::fact("ns", &format!("s{i}"), "is", "here")).unwrap();
+    }
+    // Reads outside a transaction: every statement is preceded by
+    // DEALLOCATE ALL, so every cached hot statement is stale on arrival and
+    // must be re-prepared — invisibly.
+    std::env::set_var("AREEV_PG_SESSION_CHAOS", "deallocate");
+    for i in 0..5 {
+        assert_eq!(m.recall("ns", &format!("s{i}"), Some("is"), 4).unwrap().len(), 1);
+        assert!(m.latest("ns", &format!("s{i}"), "is").unwrap().is_some());
+    }
+    assert_eq!(m.count().unwrap(), 5);
+    // The backend-switch shape: the statements go away AT transaction start.
+    // A write whose first statement runs outside the transaction (an `add`'s
+    // existence probe) heals the cache and lands; one whose first cached
+    // statement is inside the transaction trips, and the error must name the
+    // remedy. Which of the two a given write is depends on its statement
+    // order, so the contract pinned here is: every outcome is one of those,
+    // and the handle is never wedged.
+    std::env::set_var("AREEV_PG_SESSION_CHAOS", "deallocate-txn");
+    let mut landed = 0usize;
+    for i in 0..6 {
+        match m.add(&areev_conformance::fact("ns", &format!("late{i}"), "is", "here")) {
+            Ok(_) => landed += 1,
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(msg.contains("26000"), "{msg}");
+                assert!(msg.contains("max_prepared_statements") && msg.contains("session mode"), "{msg}");
+            }
+        }
+    }
+    std::env::remove_var("AREEV_PG_SESSION_CHAOS");
+    // Not wedged: the next write, unchaosed, lands, and the count reflects
+    // exactly what landed under chaos.
+    m.add(&areev_conformance::fact("ns", "after", "is", "here")).unwrap();
+    assert_eq!(m.count().unwrap(), 5 + landed + 1);
+}

--- a/crates/areev-store/CLAUDE.md
+++ b/crates/areev-store/CLAUDE.md
@@ -24,7 +24,20 @@ transports implement it:
   `collection_stats` hooks); in-txn rechecks use `Db::for_update`. An
   explicit statement translator handles the divergent dialect (per-table
   `ON CONFLICT` upserts, pgvector `<=>`/casts, `?N`→`$N`) and FAILS FAST on
-  anything unmapped, the `vector(dim)` column is added at the first
+  anything unmapped, then `qualify_tables` schema-qualifies every table
+  reference (#181) so nothing depends on the session's `search_path` — a
+  transaction-mode pooler may hand each transaction to a different backend.
+  Runtime DDL and catalog probes bind `self.schema` rather than reading
+  `current_schema()` for the same reason, and a `26000` (prepared statement
+  unknown to this backend) evicts the cache entry and retries once outside a
+  transaction; inside one it cannot (the Bind aborted it) and the error says
+  the pooler must track prepared statements or run session mode — the driver
+  names every parameterized statement, so no store-side switch substitutes.
+  Proven by the conformance suite run with `AREEV_PG_SESSION_CHAOS=1`
+  (`conformance` feature: `RESET ALL` before every statement outside a
+  transaction; `=deallocate` adds `DEALLOCATE ALL` there and `=deallocate-txn`
+  drops the statements at every `BEGIN` instead, the two halves `pg_stale.rs`
+  pins) and through a real transaction-mode PgBouncer, the `vector(dim)` column is added at the first
   `set_embedder` (dim mismatch = hard refusal), CAS blobs live in an
   in-schema table, and `prefers_batched_reads = true`. Page cipher and the
   telemetry sidecar are file-backend-only and rejected at open.

--- a/crates/areev-store/src/pg.rs
+++ b/crates/areev-store/src/pg.rs
@@ -824,16 +824,44 @@ impl PgDb {
         if let Some(st) = self.cache.borrow().get(sql) {
             return Ok(st.clone());
         }
-        let translated = translate(sql)?;
+        let translated = qualify_tables(&translate(sql)?, &self.schema);
         let client = self.client.borrow().clone();
         let st = self.rt.block_on(client.prepare(&translated)).map_err(|e| {
-            AreevError::Storage(format!("prepare failed: {e} — translated SQL: {translated}"))
+            // Keep the SQLSTATE and server message (`pg_err`), not the
+            // driver's bare "db error", so a failing prepare names its cause.
+            AreevError::Storage(format!(
+                "prepare failed: {} — translated SQL: {translated}",
+                pg_err(e)
+            ))
         })?;
         self.cache.borrow_mut().insert(sql.to_string(), st.clone());
         Ok(st)
     }
 
+    /// Conformance-only: reset the session before a statement, the way a
+    /// transaction-mode pooler's backend switch does between transactions.
+    /// `RESET ALL` drops `search_path` and every GUC, so a suite run under it
+    /// proves no statement resolves through the session. `deallocate` adds
+    /// `DEALLOCATE ALL`, the prepared-statement half, for the one probe that
+    /// exercises the `26000` retry on its own. Never inside a transaction — a
+    /// pooler keeps one backend for its length.
+    fn maybe_discard_session(&self) -> Result<()> {
+        if self.in_txn.get() {
+            return Ok(());
+        }
+        // Read per statement, so a probe can turn the reset on and off
+        // between its own calls; a shipped build compiles this to `None`.
+        let sql = match session_chaos_mode().as_deref() {
+            None => return Ok(()),
+            Some("deallocate") => "RESET ALL; DEALLOCATE ALL",
+            Some(_) => "RESET ALL",
+        };
+        let client = self.client.borrow().clone();
+        self.rt.block_on(client.batch_execute(sql)).map_err(pg_err)
+    }
+
     fn query_once(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<Vec<Row>> {
+        self.maybe_discard_session()?;
         let vals: Vec<PgVal> = params.into_iter().map(PgVal).collect();
         let refs: Vec<&(dyn ToSql + Sync)> =
             vals.iter().map(|v| v as &(dyn ToSql + Sync)).collect();
@@ -844,7 +872,7 @@ impl PgDb {
         } else {
             // Uncached path: the temporary statement is closed on drop, so
             // dynamic SQL leaves nothing behind on either side.
-            let translated = translate(sql)?;
+            let translated = qualify_tables(&translate(sql)?, &self.schema);
             let client = self.client.borrow().clone();
             self.rt.block_on(client.query(translated.as_str(), &refs))
         }
@@ -861,12 +889,56 @@ impl PgDb {
         match self.query_once(sql, params.clone(), hot) {
             Ok(rows) => Ok(rows),
             Err(e) => {
-                if self.recover(&e, true) {
+                if self.stale_statement(sql, &e, hot) || self.recover(&e, true) {
                     self.query_once(sql, params, hot)
                 } else {
-                    Err(e)
+                    Err(Self::explain_stale(e))
                 }
             }
+        }
+    }
+
+    /// A cached named statement the server no longer knows (SQLSTATE
+    /// `26000`): the session was reset under us, or a transaction-mode
+    /// pooler handed this call to a backend that never prepared it. Evict
+    /// it so the retry re-prepares. Safe for writes too — the server refused
+    /// at Bind, before anything executed.
+    fn stale_statement(&self, sql: &str, e: &AreevError, hot: bool) -> bool {
+        if !hot {
+            return false;
+        }
+        let AreevError::Storage(msg) = e else { return false };
+        if !msg.starts_with("postgres error 26000") {
+            return false;
+        }
+        // The whole cache, not the one entry: a 26000 means this session lost
+        // its statements wholesale (a reset, or a backend switch), so every
+        // cached name is suspect and the next one would trip the same way.
+        let _ = sql;
+        self.cache.borrow_mut().clear();
+        // Inside a transaction the failed Bind has already aborted it;
+        // a retry would only add `25P02`. The caller gets the 26000, with
+        // the remedy named (see `explain_stale`).
+        !self.in_txn.get()
+    }
+
+    /// A `26000` that could not be retried (it happened mid-transaction) is
+    /// a pooler handing transactions to backends that never saw the named
+    /// statement. Say so, and name what fixes it: the driver names every
+    /// parameterized statement, so the pooler must track them or run in
+    /// session mode — no store-side switch can substitute.
+    fn explain_stale(e: AreevError) -> AreevError {
+        match e {
+            AreevError::Storage(msg) if msg.starts_with("postgres error 26000") => {
+                AreevError::Storage(format!(
+                    "{msg} — a prepared statement was unknown to this backend \
+                     mid-transaction, which is what a transaction-mode pooler that does \
+                     not track prepared statements does; use PgBouncer 1.21+ with \
+                     max_prepared_statements > 0 (or another pooler that tracks them), \
+                     or session mode"
+                ))
+            }
+            other => other,
         }
     }
 
@@ -874,16 +946,20 @@ impl PgDb {
     /// [`recover`](Self::recover) for why a possibly-committed write must not
     /// be re-run.
     fn run_execute(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<u64> {
-        match self.execute_once(sql, params, hot) {
+        match self.execute_once(sql, params.clone(), hot) {
             Ok(n) => Ok(n),
             Err(e) => {
+                if self.stale_statement(sql, &e, hot) {
+                    return self.execute_once(sql, params, hot);
+                }
                 self.recover(&e, false);
-                Err(e)
+                Err(Self::explain_stale(e))
             }
         }
     }
 
     fn execute_once(&self, sql: &str, params: Vec<Value>, hot: bool) -> Result<u64> {
+        self.maybe_discard_session()?;
         let vals: Vec<PgVal> = params.into_iter().map(PgVal).collect();
         let refs: Vec<&(dyn ToSql + Sync)> =
             vals.iter().map(|v| v as &(dyn ToSql + Sync)).collect();
@@ -892,7 +968,7 @@ impl PgDb {
             let client = self.client.borrow().clone();
             self.rt.block_on(client.execute(&st, &refs)).map_err(pg_err)
         } else {
-            let translated = translate(sql)?;
+            let translated = qualify_tables(&translate(sql)?, &self.schema);
             let client = self.client.borrow().clone();
             self.rt
                 .block_on(client.execute(translated.as_str(), &refs))
@@ -920,6 +996,12 @@ impl Db for PgDb {
 
     fn begin(&self) -> Result<()> {
         let client = self.client.borrow().clone();
+        // Conformance-only `deallocate-txn`: a backend switch AT transaction
+        // start, which is what a non-tracking pooler does — the statements
+        // cached so far are unknown to the backend this transaction lands on.
+        if session_chaos_mode().as_deref() == Some("deallocate-txn") {
+            self.rt.block_on(client.batch_execute("DEALLOCATE ALL")).map_err(pg_err)?;
+        }
         let r = self.rt.block_on(client.batch_execute("BEGIN")).map_err(pg_err);
         // Set only on success, so a failed BEGIN does not wedge the handle
         // into "a transaction is open" and block every later recovery.
@@ -1138,7 +1220,8 @@ impl Db for PgDb {
                 .await;
             client
                 .batch_execute(&format!(
-                    "ALTER TABLE embeddings ADD COLUMN IF NOT EXISTS vec vector({dim})"
+                    "ALTER TABLE \"{}\".embeddings ADD COLUMN IF NOT EXISTS vec vector({dim})",
+                    self.schema
                 ))
                 .await
                 .map_err(|e| {
@@ -1153,9 +1236,9 @@ impl Db for PgDb {
                     "SELECT a.atttypmod FROM pg_attribute a
                       JOIN pg_class c ON a.attrelid = c.oid
                       JOIN pg_namespace n ON c.relnamespace = n.oid
-                     WHERE n.nspname = current_schema() AND c.relname = 'embeddings'
+                     WHERE n.nspname = $1 AND c.relname = 'embeddings'
                        AND a.attname = 'vec'",
-                    &[],
+                    &[&self.schema],
                 )
                 .await
                 .map_err(pg_err)?;
@@ -1213,9 +1296,9 @@ impl Db for PgDb {
                     "SELECT count(*) FROM pg_attribute a
                        JOIN pg_class c ON a.attrelid = c.oid
                        JOIN pg_namespace n ON c.relnamespace = n.oid
-                      WHERE n.nspname = current_schema() AND c.relname = 'embeddings'
+                      WHERE n.nspname = $1 AND c.relname = 'embeddings'
                         AND a.attname = 'vec' AND NOT a.attisdropped",
-                    &[],
+                    &[&self.schema],
                 )
                 .await
                 .map_err(pg_err)?
@@ -1229,8 +1312,9 @@ impl Db for PgDb {
             }
             client
                 .batch_execute(&format!(
-                    "CREATE INDEX IF NOT EXISTS idx_embeddings_hnsw ON embeddings \
-                     USING hnsw (vec vector_cosine_ops) WITH (m = {m}, ef_construction = {ef_construction})"
+                    "CREATE INDEX IF NOT EXISTS idx_embeddings_hnsw ON \"{}\".embeddings \
+                     USING hnsw (vec vector_cosine_ops) WITH (m = {m}, ef_construction = {ef_construction})",
+                    self.schema
                 ))
                 .await
                 .map_err(|e| {
@@ -1284,7 +1368,7 @@ impl Db for PgDb {
         self.rt.block_on(async {
             let client = self.client.borrow().clone();
             client
-                .batch_execute("DROP INDEX IF EXISTS idx_embeddings_hnsw")
+                .batch_execute(&format!("DROP INDEX IF EXISTS \"{}\".idx_embeddings_hnsw", self.schema))
                 .await
                 .map_err(pg_err)?;
             Ok(())
@@ -1317,9 +1401,9 @@ impl Db for PgDb {
             let rows = client
                 .query(
                     "SELECT indexname FROM pg_indexes
-                      WHERE schemaname = current_schema() AND tablename = 'embeddings'
+                      WHERE schemaname = $1 AND tablename = 'embeddings'
                         AND indexdef LIKE '%hnsw%'",
-                    &[],
+                    &[&self.schema],
                 )
                 .await
                 .map_err(pg_err)?;
@@ -1437,6 +1521,98 @@ fn replace_suffix(table: &str) -> Option<(&'static str, &'static str)> {
 /// Translate one statement from the store's SQLite dialect to Postgres.
 /// Every divergent construct is handled explicitly or the translation FAILS
 /// with the offending SQL — never execute something subtly different.
+/// Every table the Postgres backend creates (`PG_SCHEMA`, `ensure_embeddings`,
+/// and the telemetry sidecar's `TELEM_SCHEMA_PG`). The qualifier rewrites a
+/// reference to any of these; catalog tables (`pg_class`, `information_schema`)
+/// are deliberately absent, since they must resolve globally.
+pub(crate) const PG_TABLES: &[&str] = &[
+    "blobs", "corpus_idx", "counters", "embeddings", "entity_latest", "fts_doc", "fts_post",
+    "fts_vocab", "grains", "heads", "meta", "ns_reg", "oplog", "osp", "prov_idx", "run_idx",
+    "telem_budget_stat", "telem_grain_access", "telem_meta", "telem_query_stat",
+    "telem_recall_log", "terms", "thread_idx", "triples",
+];
+
+/// Schema-qualify every table reference in `sql` (#181): `FROM grains g` →
+/// `FROM "s".grains g`. This is what frees the store from the session's
+/// `search_path` — a transaction-mode pooler hands each transaction to
+/// whichever backend is free, and a statement that relied on `search_path`
+/// would then read another schema's tables or none. Quote-aware (a table name
+/// inside a string literal is data) and idempotent (an already-qualified name
+/// is left alone). Only the keywords a table name can follow trigger it, so
+/// `counters.v` in an `ON CONFLICT … DO UPDATE` stays the target's own name,
+/// which Postgres resolves without a schema.
+pub(crate) fn qualify_tables(sql: &str, schema: &str) -> String {
+    const TRIGGERS: &[&str] = &["FROM", "JOIN", "INTO", "UPDATE", "TABLE", "EXISTS"];
+    let mut out = String::with_capacity(sql.len() + 64);
+    let chars: Vec<char> = sql.chars().collect();
+    let n = chars.len();
+    let mut i = 0;
+    let mut in_str = false;
+    let mut in_ident = false;
+    let mut prev_word_is_trigger = false;
+    let is_word = |c: char| c.is_ascii_alphanumeric() || c == '_';
+    while i < n {
+        let c = chars[i];
+        if in_str {
+            out.push(c);
+            if c == '\'' {
+                in_str = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_ident {
+            out.push(c);
+            if c == '"' {
+                in_ident = false;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            '\'' => {
+                in_str = true;
+                prev_word_is_trigger = false;
+                out.push(c);
+                i += 1;
+            }
+            '"' => {
+                in_ident = true;
+                prev_word_is_trigger = false;
+                out.push(c);
+                i += 1;
+            }
+            c if is_word(c) => {
+                let start = i;
+                while i < n && is_word(chars[i]) {
+                    i += 1;
+                }
+                let word: String = chars[start..i].iter().collect();
+                let preceded_by_dot = start > 0 && chars[start - 1] == '.';
+                if prev_word_is_trigger && !preceded_by_dot && PG_TABLES.contains(&word.as_str()) {
+                    out.push('"');
+                    out.push_str(schema);
+                    out.push_str("\".");
+                }
+                out.push_str(&word);
+                prev_word_is_trigger = TRIGGERS.contains(&word.to_ascii_uppercase().as_str());
+            }
+            c if c.is_whitespace() => {
+                out.push(c);
+                i += 1;
+            }
+            _ => {
+                // Any other punctuation ends the "next word may be a table"
+                // window: `EXISTS (SELECT`, `FOR UPDATE)`, `DO UPDATE SET`.
+                prev_word_is_trigger = false;
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
 pub(crate) fn translate(sql: &str) -> Result<String> {
     let trimmed = sql.trim();
     // Exact-match specials first.
@@ -1682,6 +1858,22 @@ pub fn query_raw_i64(url: &str, sql: &str) -> Result<i64> {
     Ok(row.get::<_, i64>(0))
 }
 
+/// `AREEV_PG_SESSION_CHAOS` under the `conformance` feature: `1`/`reset`
+/// turns on `maybe_discard_session`, `deallocate` its harsher form, and
+/// `deallocate-txn` drops the statements at every `BEGIN` instead (the
+/// backend-switch shape). Read per statement. On a shipped build it is never
+/// consulted.
+fn session_chaos_mode() -> Option<String> {
+    #[cfg(feature = "conformance")]
+    {
+        std::env::var("AREEV_PG_SESSION_CHAOS").ok().filter(|v| !v.is_empty() && v != "0")
+    }
+    #[cfg(not(feature = "conformance"))]
+    {
+        None
+    }
+}
+
 /// Drop a memory schema entirely — the Postgres backend's memory-level
 /// erasure primitive (`DROP SCHEMA … CASCADE`), the analogue of deleting a
 /// memory file. Admin-surface only: not reachable from CAL, and hosts must
@@ -1805,6 +1997,79 @@ mod tests {
         )
         .unwrap();
         assert!(n.contains("(e.vec <=> (($2)::text::vector)) AS dist"), "{n}");
+    }
+
+    #[test]
+    fn a_stale_statement_error_names_both_remedies() {
+        let e = PgDb::explain_stale(AreevError::Storage(
+            "postgres error 26000: prepared statement \"s7\" does not exist".into(),
+        ));
+        let msg = e.to_string();
+        assert!(msg.contains("26000") && msg.contains("max_prepared_statements"), "{msg}");
+        assert!(msg.contains("session mode"), "{msg}");
+        // Anything else passes through untouched.
+        let other = PgDb::explain_stale(AreevError::Storage("postgres error 42P01: relation".into()));
+        assert_eq!(other.to_string(), "STO-E001: storage error: postgres error 42P01: relation");
+    }
+
+    #[test]
+    fn qualifies_every_table_reference_and_nothing_else() {
+        let q = |sql: &str| qualify_tables(sql, "s1");
+        // Aliases, joins, subqueries, and INSERT's column list.
+        assert_eq!(
+            q("SELECT g.hash FROM embeddings e JOIN grains g ON g.seq = e.seq WHERE g.ns = $1"),
+            "SELECT g.hash FROM \"s1\".embeddings e JOIN \"s1\".grains g ON g.seq = e.seq WHERE g.ns = $1"
+        );
+        assert_eq!(
+            q("INSERT INTO terms(term, term_hash) VALUES ($1, $2) ON CONFLICT (term_hash) DO NOTHING RETURNING id"),
+            "INSERT INTO \"s1\".terms(term, term_hash) VALUES ($1, $2) ON CONFLICT (term_hash) DO NOTHING RETURNING id"
+        );
+        assert_eq!(
+            q("DELETE FROM run_idx WHERE seq=$1 AND NOT EXISTS (SELECT 1 FROM triples WHERE s=$1)"),
+            "DELETE FROM \"s1\".run_idx WHERE seq=$1 AND NOT EXISTS (SELECT 1 FROM \"s1\".triples WHERE s=$1)"
+        );
+        assert_eq!(q("UPDATE terms SET term = $2 WHERE id = $1"), "UPDATE \"s1\".terms SET term = $2 WHERE id = $1");
+        assert_eq!(
+            q("ALTER TABLE telem_recall_log ADD COLUMN run_id TEXT"),
+            "ALTER TABLE \"s1\".telem_recall_log ADD COLUMN run_id TEXT"
+        );
+        assert_eq!(q("DROP TABLE IF EXISTS meta"), "DROP TABLE IF EXISTS \"s1\".meta");
+    }
+
+    #[test]
+    fn qualifier_leaves_data_catalogs_and_target_references_alone() {
+        let q = |sql: &str| qualify_tables(sql, "s1");
+        // A table name inside a string literal is data.
+        assert_eq!(q("SELECT k FROM meta WHERE v = 'FROM grains'"), "SELECT k FROM \"s1\".meta WHERE v = 'FROM grains'");
+        // Catalog tables resolve globally and are not ours to move.
+        let cat = "SELECT 1 FROM pg_class c JOIN pg_namespace n ON c.relnamespace = n.oid";
+        assert_eq!(q(cat), cat);
+        let info = "SELECT 1 FROM information_schema.columns WHERE table_name = 'terms'";
+        assert_eq!(q(info), info);
+        // The upsert's target reference and FOR UPDATE / DO UPDATE are not
+        // table positions.
+        assert_eq!(
+            q("INSERT INTO counters(name, v) VALUES ($1, $2) ON CONFLICT (name) DO UPDATE SET v = GREATEST(counters.v, EXCLUDED.v)"),
+            "INSERT INTO \"s1\".counters(name, v) VALUES ($1, $2) ON CONFLICT (name) DO UPDATE SET v = GREATEST(counters.v, EXCLUDED.v)"
+        );
+        assert_eq!(q("SELECT seq FROM grains WHERE hash=$1 FOR UPDATE"), "SELECT seq FROM \"s1\".grains WHERE hash=$1 FOR UPDATE");
+        // Idempotent: an already-qualified reference is left as it is, and a
+        // column that happens to share a table's name is not a table.
+        let done = "SELECT 1 FROM \"s1\".grains g WHERE g.meta = 1";
+        assert_eq!(q(done), done);
+        assert_eq!(q(&q("SELECT 1 FROM heads")), "SELECT 1 FROM \"s1\".heads");
+    }
+
+    #[test]
+    fn every_translated_special_qualifies_cleanly() {
+        // The integrity probe is emitted by translate itself; it must name
+        // its tables in positions the qualifier recognises, or it would read
+        // another schema's index rows under a pooler.
+        let out = qualify_tables(&translate("PRAGMA integrity_check").unwrap(), "s1");
+        for t in ["heads", "grains", "entity_latest", "triples"] {
+            assert!(out.contains(&format!("\"s1\".{t}")), "{t} unqualified in: {out}");
+        }
+        assert!(!out.contains(" heads h") || out.contains("\"s1\".heads h"), "{out}");
     }
 
     #[test]

--- a/docs/deployment-profile.md
+++ b/docs/deployment-profile.md
@@ -114,36 +114,45 @@ by instances against the server's `max_connections` — cache handles per tenant
 with an LRU and close idle ones (`close()` in Node; drop in Rust/Python). There
 is no built-in pool.
 
-**A pooler must run in session mode, never transaction mode.** The store keeps
-three pieces of state on the session: `search_path`, pinned once at open; the
-bootstrap advisory lock (`pg_advisory_lock`, not the `_xact_` form); and the
-hot-path queries, held as server-side **named prepared statements** cached per
-connection. Transaction pooling hands each transaction to whichever backend is
-free, so none of the three survives.
+**A pooler may run in transaction mode, on one condition and with one
+caveat.** The store no longer keeps anything it needs on the session: every
+statement names its tables schema-qualified (`"tenant_7".grains`, never
+`grains` resolved through `search_path`), runtime DDL and catalog probes bind
+the schema name instead of reading `current_schema()`, the bootstrap lock is
+transaction-scoped (`pg_advisory_xact_lock`), and a cached prepared statement
+the backend no longer knows (`26000`) is re-prepared and retried when it
+happens outside a transaction. The whole two-backend conformance suite runs
+with `RESET ALL` issued before every statement outside a transaction
+(`tests/pg_chaos.rs`), and — measured, not inferred — passes through a real
+PgBouncer in transaction mode (#181, second increment).
 
-The prepared-statement cache is what an operator hits first — a later
-transaction lands on a backend that never prepared the statement, and the
-driver reports `prepared statement "s0" does not exist`. That one is loud. The
-`search_path` failure is the dangerous one: a statement lands on a connection
-whose `search_path` is unset or belongs to a **different schema**, and because
-one schema is one memory, that is not a failed query — it is a query answered
-from another tenant.
+The **condition**: the pooler must track prepared statements across backends.
+The driver names every parameterized statement it sends, one-shot or cached,
+so behind a pooler that does not track them a statement prepared on one
+backend is unknown to the next — and when that happens *inside* a
+transaction the transaction is aborted, which nothing store-side can undo.
+PgBouncer 1.21+ tracks them when `max_prepared_statements` is above zero;
+below 1.21, or with it at zero, use **session mode**. The error you get
+otherwise names both remedies.
 
-The invariant a proxy has to satisfy: **one client connection maps to one
-server session for that connection's whole life.** Check any product against
-that sentence rather than against its marketing.
+The **caveat**: `hnsw.ef_search` is still a session setting (set by
+`ensure_vector_index` / `set_vector_ef_search`). Under transaction pooling it
+does not survive to the next transaction, and the loss is silent — ANN recall
+drops to pgvector's default of 40 with no error. Until the store scopes it
+per transaction, a pooled deployment that tunes `ef_search` must also set it
+at the pooler or database level (`ALTER DATABASE … SET hnsw.ef_search = 100`).
 
-| | |
+pgvector's `vector` type and `<=>` operator are resolved through
+`search_path` by Postgres itself, so the extension must live in a schema on
+the *default* `search_path` (`public`, where the store installs it), not in a
+private one only the store's session-level `search_path` reached.
+
+| | Pooler mode |
 |---|---|
-| Safe | PgBouncer `session` mode; pass-through proxies that are not pooling at all (the Cloud SQL Auth Proxy is a TLS/IAM tunnel); Neon's **direct** endpoint |
-| Not safe | PgBouncer `transaction`/`statement`; Supavisor transaction mode; PgCat transaction mode; Neon's **`-pooler`** endpoint, which is transaction-mode PgBouncer |
-
-Neon deserves the explicit line because the pooled hostname is the one its
-quickstarts hand out, and the two endpoints differ by a substring.
-
-PgBouncer in `session` mode still caps server connections — but it caps by
-**queueing** clients, so the per-tenant handle cache above is what keeps the
-queue short rather than merely moving the contention.
+| Fine | PgBouncer `session` mode; PgBouncer 1.21+ `transaction` mode with `max_prepared_statements > 0`; pass-through proxies (the Cloud SQL Auth Proxy is a TLS/IAM tunnel); Neon's direct endpoint |
+| Session mode only | A transaction-mode pooler that does not track prepared statements: PgBouncer below 1.21 or with `max_prepared_statements = 0` |
+| Check your pooler's docs | Supavisor, PgCat, Neon's `-pooler` endpoint: each has added prepared-statement tracking; the condition above is what to look for |
+| Not yet | Relying on a tuned `ef_search` through a transaction-mode pooler (see the caveat) |
 
 **Open cost: provision schemas ahead of the request path.** First open of a
 NEW schema runs the full DDL bootstrap under an advisory lock — hundreds of


### PR DESCRIPTION
Second increment of #181. The bootstrap lock became transaction-scoped in
the first (#195)

## The problem

The Postgres store addressed its schema by `SET search_path` once at open
and wrote every statement against bare table names. That made every
transaction-mode pooler a documented hazard: each transaction lands on
whichever backend is free, whose `search_path` belongs to someone else or to
nobody, and a bare `grains` then reads another tenant's tables — silently,
because the query is well-formed. The deployment profile said "session mode
only" for that reason.

## What changes

- **Every table reference is schema-qualified.** A pass after the dialect
  translator (`qualify_tables`) rewrites `FROM grains g` to
  `FROM "tenant_7".grains g` on every execution path, covering the 81 bare
  references in the store's SQL without touching them one by one. It is
  quote-aware (a table name inside a string literal is data), idempotent, and
  triggers only on the keywords a table can follow, so an upsert's
  `counters.v` target reference and `FOR UPDATE` / `DO UPDATE` stay as they
  are. Catalog tables are deliberately excluded.
- **Runtime DDL and catalog probes bind the schema name** instead of reading
  `current_schema()`: the `vector` column's `ALTER TABLE`, the dimension
  probe, and the HNSW index's create, drop and lookup.
- **Stale prepared statements recover.** A `26000` (the backend no longer
  knows a cached named statement) clears the whole cache — one stale name
  means the session lost them all — and retries once when it happens outside
  a transaction. Inside one it cannot: the failed Bind already aborted the
  transaction, so the error now says what a deployment needs rather than
  reading like a driver bug.
- **`prepare` failures carry their SQLSTATE.** They reported the driver's
  bare "db error" before; the `25P02` that led me to the transaction-abort
  finding was invisible without this.

## Proof

- **`tests/pg_chaos.rs`** runs the identical conformance case list with
  `RESET ALL` issued by the store before every statement outside a
  transaction — what a pooler's backend switch does — 68/68. The hook that
  makes this possible exists only under the store's `conformance` feature
  and compiles to nothing on a shipped build.
- **`tests/pg_stale.rs`** forces `DEALLOCATE ALL` between statements and
  pins: reads outside a transaction recover invisibly, a write that trips
  inside one fails with the remedy named, and the handle is never wedged.
  Its own binary, because the forcing is process-wide.
- **A real PgBouncer 1.25 in transaction mode**, `max_prepared_statements
  = 200`, role lookup via `auth_query`: the full conformance suite passes,
  82/82 on the rebased tree, repeated. With `max_prepared_statements = 0` it
  fails as the docs now say it will, with the explained error.
- Normal Postgres conformance 82/82. Store unit tests for the qualifier
  (aliases, joins, subqueries, INSERT column lists, string literals, catalog
  tables, upsert targets, idempotence, the translator's own integrity
  probe). Clippy clean for default, `postgres`, `conformance`. `cargo doc`
  clean. Repo stats within tolerance.

## Docs moved with the code

`docs/deployment-profile.md` (the pooler section, rewritten around the
measured condition), `CHANGELOG.md`, `crates/areev-store/CLAUDE.md`, and an
`ARCHITECTURE.md` §10 decision: the store keeps nothing on the session,
because the session is not its to keep.