### PR TITLE
cal: a WHERE predicate that cannot be answered narrows, and validity is queryable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1443,6 +1443,34 @@ Leniency was deliberately NOT kept behind an opt-in: a filter that cannot be
 honoured has no honest lenient reading, and the safe direction must be the
 default direction.
 
+**Amendment (2026-09-08, issue #207): absence is UNKNOWN, not FALSE.** The
+planning pass above routes a predicate to the per-grain evaluator; the
+evaluator itself was two-valued, and read "this grain has no such field" as
+`false`. That is correct for a bare comparison and wrong for every negation
+of one — `!false` is `true`, so `object != "retired"`, `NOT (object =
+"retired")` and `object NOT IN ("retired")` each matched **every** grain of a
+type with no `object`. The same widening #91 retired, reached one rewrite
+later.
+
+The evaluator is now three-valued (Kleene): a leaf whose field the grain does
+not carry is UNKNOWN, `AND`/`OR` combine by SQL's truth tables, `NOT UNKNOWN`
+is UNKNOWN, and UNKNOWN does not match at the top. This is the smallest model
+that can express "fails closed" under negation — fixing only `!=` would leave
+the identical bug in `NOT`, and refusing the predicate outright (the other
+candidate) would reject queries against fields the grain genuinely holds,
+since `subject`/`object` are declared by Fact, Observation *and* Goal and any
+type may carry them in `extra_fields`. Nothing that already matched stops
+matching: `T ∧ U` and `F ∧ U` both collapsed to no-match before, and `T ∨ U`
+already matched.
+
+Two consequences worth stating. `IS NULL`/`IS NOT NULL` are the operators
+*about* absence and stay definite, or they would become unanswerable. And the
+evaluator is shared: `areev-trigger`'s composite gates project fired members
+into the same tree, where an absent field means "has not fired" — a definite
+FALSE, not UNKNOWN. That gate now materializes every referenced member rather
+than encoding its answer in a gap, because one evaluator serving two meanings
+of absence has to be told which one it is looking at.
+
 ### Framework adapters live outside the repo
 
 **Decision (2026-08-23):** the ecosystem adapters that put Areev underneath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `WHERE` predicate on a field the grain does not carry no longer matches
+  everything** (#207). `object` is a real field name in general — Fact,
+  Observation and Goal all declare it — but means nothing for a Skill, and the
+  per-grain evaluator read that absence as `false`, which made every *negation*
+  of it `true`. So `RECALL skills WHERE object != "retired"` returned every
+  skill, the retired one included, with nothing in the payload to distinguish
+  "the filter ran and matched everything" from "the filter did not run" — the
+  opposite of the fails-closed contract §3.4 states. Evaluation is now
+  three-valued: absence is UNKNOWN, `AND`/`OR` combine by SQL's truth tables,
+  and UNKNOWN does not match. `!=`, `NOT (… = …)` and `NOT IN` all narrow.
+  Nothing that already matched stops matching (`T ∧ U` and `F ∧ U` already
+  collapsed to no-match, `T ∨ U` already matched), and the omit-default
+  discriminators still resolve their defaults, so `kind != "definition"` keeps
+  returning legacy execution grains. `areev-trigger`'s composite gates share
+  the evaluator and mean the opposite by an absent field — "this member has not
+  fired" is definite, not unknown — so `gate_satisfied` now materializes every
+  referenced member instead of encoding the answer in a gap.
+
+- **`description` is queryable on skills** (#207). Required on the Skill struct
+  since 1.4 but absent from the registry's `queryable_fields`, so the one field
+  every Skill must carry was the one `WHERE` refused with `CAL-E060`.
+
+- **`{{… | date}}` renders the right year** (#206). Every timestamp a template
+  can name is epoch milliseconds, but the filter handed its input to a
+  seconds-based formatter, so `{{created_at | date}}` rendered *58657-02-23*
+  for a grain written today. `relative` never had the bug because
+  `humanize_time(created_ms, now_secs)` names its units. `_now` is milliseconds
+  too, so the whole filter surface speaks one unit; `format_epoch` keeps its
+  public seconds signature.
+
+### Added
+
+- **World-time validity is queryable and renderable** (#206). `valid_from`,
+  `valid_to`, `system_valid_from` and `system_valid_to` are `GrainCommon`
+  fields on every grain type — serialized since 1.0, read by the loop's
+  `staleness` analyzer, and present in every JSON payload — but they were
+  absent from CAL's filterable set, so the one read that makes a validity
+  window worth writing answered `CAL-E060`. They now filter and sort on every
+  type with the usual comparators and `IS NULL`, resolve in templates
+  (`{{grain.valid_to | date}}`), and appear in `DESCRIBE FIELDS`. "What is
+  currently valid" is a query:
+
+  ```sql
+  RECALL facts WHERE namespace = "desk"
+    AND (valid_to IS NULL OR valid_to > 1788866000000)
+  ```
+
+  This is what a waiver, a delegation, an out-of-office or a price valid until
+  a date needs. Every host previously over-fetched and post-filtered, which
+  also defeated `BUDGET` — the budget was spent on grains about to be
+  discarded.
+
 ## [1.7.3] — 2026-09-07
 
 ### Added

--- a/crates/areev-cal/CLAUDE.md
+++ b/crates/areev-cal/CLAUDE.md
@@ -28,6 +28,32 @@ scope/scope_path/tags) in a position it cannot be honoured is CAL-E061. A
 filter is pushed, evaluated, or refused — NEVER dropped. If you add a
 push-down arm, extend the truth table and its pin test in the same change.
 
+**…and absence is UNKNOWN, not FALSE (#207, 1.7.4).** The per-grain walk is
+three-valued (`grain_condition_truth`): a leaf whose field the grain does not
+carry is UNKNOWN, `AND`/`OR` combine by SQL's truth tables, `NOT UNKNOWN` is
+UNKNOWN, and `grain_matches_condition_tree` treats UNKNOWN as no-match. Two-
+valued evaluation cannot express "fails closed" under negation — reading
+absence as `false` made every negation of it `true`, so `object != "retired"`,
+`NOT (object = "retired")` and `object NOT IN ("retired")` each matched every
+grain of a type that has no `object`. Only negation moved; `T ∧ U` and `F ∧ U`
+already collapsed to no-match and `T ∨ U` already matched. `resolve_grain_field`
+is the ONE answer to "does this grain carry the field" — envelope properties
+(`hash`, `type`, `score`) and the omit-default discriminators (`kind`,
+`status` on tools) resolve there, so a materialized default reads as *present*
+and `kind != "definition"` keeps matching legacy execution grains.
+
+Note the shared-evaluator hazard: `areev-trigger` uses the same tree for
+composite gates, where an absent field means "this member has not fired" — a
+definite FALSE, not UNKNOWN. `gate_satisfied` therefore materializes every
+`referenced_members` name rather than projecting only the fired ones.
+
+**World-time validity is queryable (#206, 1.7.4).** `valid_from`/`valid_to`/
+`system_valid_from`/`system_valid_to` are `GrainCommon` fields on every type,
+already serialized and expanded back into `fields` — they were simply missing
+from `COMMON_FIELDS` and `GRAIN_EVALUABLE_COMMON`, so the one read that makes a
+validity window worth writing refused with CAL-E060. No push-down: they
+post-filter over the widened scan like any other in-blob key.
+
 **LET eval writes its results onto `CalQuery::let_values`** (`#[serde(skip)]` —
 execution state, not query text); `apply_where_clause` expands `IN $var` from
 it, and surrogate/nested queries plus ASSEMBLE sources inherit it. The scope

--- a/crates/areev-cal/src/executor.rs
+++ b/crates/areev-cal/src/executor.rs
@@ -3739,6 +3739,14 @@ impl CalExecutor {
                         serde_json::json!({"name": "confidence", "type": "number", "filterable": true, "sortable": true}),
                         serde_json::json!({"name": "importance", "type": "number", "filterable": true, "sortable": true}),
                         serde_json::json!({"name": "tags", "type": "array", "filterable": true, "sortable": false}),
+                        // §6.1 world-time validity — filterable and sortable
+                        // on every type (#206). `DESCRIBE FIELDS` is the
+                        // source of truth for what filters, so a field the
+                        // executor honours has to appear here.
+                        serde_json::json!({"name": "valid_from", "type": "timestamp", "filterable": true, "sortable": true}),
+                        serde_json::json!({"name": "valid_to", "type": "timestamp", "filterable": true, "sortable": true}),
+                        serde_json::json!({"name": "system_valid_from", "type": "timestamp", "filterable": true, "sortable": true}),
+                        serde_json::json!({"name": "system_valid_to", "type": "timestamp", "filterable": true, "sortable": true}),
                     ];
                     // …plus, for a typed DESCRIBE, exactly the registry's
                     // queryable set for that type (#91): every advertised
@@ -6602,6 +6610,16 @@ const COMMON_FIELDS: &[&str] = &[
     "scope_path",
     "priority",
     "status",
+    // §6.1 world-time validity. These are `GrainCommon` fields on EVERY type,
+    // serialized into the blob and expanded back into `fields` on read — the
+    // engine has carried them since 1.0 and the loop's `staleness` analyzer
+    // reads them. They were simply absent from this list, so the one read
+    // that makes a validity window worth writing ("what is currently valid")
+    // refused with CAL-E060 (#206).
+    "valid_from",
+    "valid_to",
+    "system_valid_from",
+    "system_valid_to",
 ];
 
 /// Return the known type-specific fields for a grain type plural name.
@@ -6691,6 +6709,14 @@ const GRAIN_EVALUABLE_COMMON: &[&str] = &[
     "grain_type",
     "type",
     "score",
+    // §6.1 world-time validity (#206). No push-down: they live inside the
+    // immutable blob like every other type-specific sort key, so they are
+    // post-filtered over the widened scan — the shape `ORDER BY confidence`
+    // already uses, and `CAL-W015` still reports a scan that filled.
+    "valid_from",
+    "valid_to",
+    "system_valid_from",
+    "system_valid_to",
 ];
 
 /// Does `apply_where_clause` consume this leaf into `RecallParams`?
@@ -6883,6 +6909,60 @@ fn validate_residual_leaf(
     Ok(())
 }
 
+/// Resolve one field on a grain, envelope properties included.
+///
+/// The ONE answer to "does this grain carry `field`, and with what value?".
+/// Both the comparator ([`grain_matches_condition`]) and the tri-state
+/// evaluator ([`grain_leaf_truth`]) resolve through it, because a predicate
+/// that reads a value and a predicate that decides whether the value exists
+/// must not disagree about what exists.
+///
+/// Returns an owned value: envelope properties are synthesized, not borrowed.
+fn resolve_grain_field(grain: &CalGrainResult, field: &str) -> Option<serde_json::Value> {
+    // Envelope fields are not in `fields` — a grain's content address is a
+    // property *of* the blob, so it cannot be inside it. Looking `hash` up in
+    // `fields` therefore always missed, which is why `hash IN ("<real hash>")`
+    // matched nothing. A `sha256:` prefix is accepted because that is how the
+    // rest of CAL spells an address.
+    match field {
+        "hash" => return Some(serde_json::Value::String(grain.hash.clone())),
+        // `type` is the OMS §5.2 spelling of the same envelope property.
+        "grain_type" | "type" => {
+            return Some(serde_json::Value::String(grain.grain_type.clone()))
+        }
+        // The fused relevance score lives on the envelope, not in `fields`.
+        "score" => return serde_json::Number::from_f64(grain.score).map(serde_json::Value::Number),
+        // Omit-default discriminators (#91): canonical serialization omits
+        // the default value to keep legacy blobs byte-identical, so an
+        // absent field MEANS the default and a filter must see it that way
+        // (`kind = "execution"` has to match a grain that never wrote
+        // `kind`). This is also why the omit-default arms must live HERE and
+        // not only in the comparator: `kind != "definition"` has to see the
+        // materialized default as *present*, or the fails-closed rule below
+        // would drop every legacy execution grain.
+        "kind" if grain.grain_type == "tool" && json_field(&grain.fields, "kind").is_none() => {
+            return Some(serde_json::Value::String("execution".into()))
+        }
+        "status" if grain.grain_type == "tool" && json_field(&grain.fields, "status").is_none() => {
+            return Some(serde_json::Value::String("completed".into()))
+        }
+        _ => {}
+    }
+    json_field(&grain.fields, field).cloned()
+}
+
+/// Does this grain carry `field` at all?
+///
+/// A JSON `null` counts as *absent*: `IS NULL` already treats the two the
+/// same, and a filter must not read "the field is explicitly null" as "the
+/// field holds a value that differs from yours".
+fn grain_carries_field(grain: &CalGrainResult, field: &str) -> bool {
+    !matches!(
+        resolve_grain_field(grain, field),
+        None | Some(serde_json::Value::Null)
+    )
+}
+
 /// Apply a type-specific field condition to a single grain result.
 ///
 /// Returns `true` if the grain matches the condition.
@@ -6892,34 +6972,8 @@ pub fn grain_matches_condition(
     comparator: &Comparator,
     value: &Value,
 ) -> bool {
-    // Envelope fields are not in `fields` — a grain's content address is a
-    // property *of* the blob, so it cannot be inside it. Looking `hash` up in
-    // `fields` therefore always missed, which is why `hash IN ("<real hash>")`
-    // matched nothing. A `sha256:` prefix is accepted because that is how the
-    // rest of CAL spells an address.
-    let envelope: Option<serde_json::Value> = match field {
-        "hash" => Some(serde_json::Value::String(grain.hash.clone())),
-        // `type` is the OMS §5.2 spelling of the same envelope property.
-        "grain_type" | "type" => Some(serde_json::Value::String(grain.grain_type.clone())),
-        // The fused relevance score lives on the envelope, not in `fields`.
-        "score" => serde_json::Number::from_f64(grain.score).map(serde_json::Value::Number),
-        // Omit-default discriminators (#91): canonical serialization omits
-        // the default value to keep legacy blobs byte-identical, so an
-        // absent field MEANS the default and a filter must see it that way
-        // (`kind = "execution"` has to match a grain that never wrote
-        // `kind`).
-        "kind" if grain.grain_type == "tool" && json_field(&grain.fields, "kind").is_none() => {
-            Some(serde_json::Value::String("execution".into()))
-        }
-        "status" if grain.grain_type == "tool" && json_field(&grain.fields, "status").is_none() => {
-            Some(serde_json::Value::String("completed".into()))
-        }
-        _ => None,
-    };
-    let grain_value = match &envelope {
-        Some(v) => Some(v),
-        None => json_field(&grain.fields, field),
-    };
+    let resolved = resolve_grain_field(grain, field);
+    let grain_value = resolved.as_ref();
     let value = &match (field, value) {
         ("hash", Value::String { value: v }) => Value::String {
             value: v.strip_prefix("sha256:").unwrap_or(v).to_string(),
@@ -6943,7 +6997,18 @@ pub fn grain_matches_condition(
                 .unwrap_or(false),
             _ => false,
         },
-        Comparator::NotEq => !grain_matches_condition(grain, field, &Comparator::Eq, value),
+        // Fails closed on absence (#207). `!Eq` alone read a missing field as
+        // "differs from your value", so `RECALL skills WHERE object !=
+        // "retired"` returned every skill — a filter that silently no-ops is
+        // worse than one that errors, because the caller believes they
+        // narrowed the set. A grain that does not carry the field matches
+        // neither `= x` nor `!= x`, which is what SQL means by `NULL != 'x'`
+        // being UNKNOWN and what this module's own contract already promised:
+        // "narrowing, never widening".
+        Comparator::NotEq => {
+            grain_carries_field(grain, field)
+                && !grain_matches_condition(grain, field, &Comparator::Eq, value)
+        }
         Comparator::Gte => match value {
             Value::Number { value: target } => grain_value
                 .and_then(|v| v.as_f64())
@@ -6993,48 +7058,137 @@ pub fn grain_matches_condition(
 ///
 /// Used by `PipelineStage::Filter` (post-pipeline WHERE) to filter grains
 /// by conditions after pipeline stages like SELECT have been applied.
+///
+/// **Totality is preserved and UNKNOWN never escapes**: internally the walk
+/// is three-valued ([`grain_condition_truth`]), but a leaf whose field the
+/// grain does not carry resolves to UNKNOWN and UNKNOWN does not match. See
+/// that function for why the negations need it.
 pub fn grain_matches_condition_tree(grain: &CalGrainResult, condition: &Condition) -> bool {
+    // UNKNOWN does not match: the whole point of #207 is that a predicate the
+    // grain cannot answer must not widen the result.
+    grain_condition_truth(grain, condition).unwrap_or(false)
+}
+
+/// Three-valued (Kleene) evaluation of a condition tree: `Some(true)`,
+/// `Some(false)`, or `None` for UNKNOWN — the grain does not carry the field
+/// the leaf names.
+///
+/// Two-valued evaluation cannot express "fails closed" under negation, which
+/// is the #207 bug. Reading an absent field as `false` makes every negation
+/// of it `true`, so `object != "retired"`, `subject NOT IN (…)` and `NOT
+/// (object = "retired")` each matched **every** grain of a type that has no
+/// `object` — silently, with nothing in the payload to distinguish "the
+/// filter ran and matched everything" from "the filter did not run". Fixing
+/// only `!=` would leave the identical widening one rewrite away, so absence
+/// is modelled where it belongs: at the leaf, as UNKNOWN, propagated by the
+/// standard truth tables.
+///
+/// The tables are SQL's, and they keep every non-negated result identical to
+/// before: `T ∧ U = U` and `F ∧ U = F` both collapse to no-match at the top,
+/// and `T ∨ U = T` already matched. Only negation changes — which is the bug.
+///
+/// `IS NULL` / `IS NOT NULL` are never UNKNOWN: they are the operators *about*
+/// absence, so they are always a definite answer.
+fn grain_condition_truth(grain: &CalGrainResult, condition: &Condition) -> Option<bool> {
     match condition {
         Condition::Comparison {
             field,
             comparator,
             value,
             ..
-        } => grain_matches_condition(grain, field, comparator, value),
+        } => {
+            // `!=` fails closed inside `grain_matches_condition` too (the
+            // comparator is public and callers reach it directly), so this
+            // arm only has to surface absence as UNKNOWN for the tree.
+            if !grain_carries_field(grain, field) {
+                return None;
+            }
+            Some(grain_matches_condition(grain, field, comparator, value))
+        }
         Condition::And { left, right, .. } => {
-            grain_matches_condition_tree(grain, left) && grain_matches_condition_tree(grain, right)
+            match (
+                grain_condition_truth(grain, left),
+                grain_condition_truth(grain, right),
+            ) {
+                // A definite FALSE decides the conjunction whatever the other
+                // side turns out to be.
+                (Some(false), _) | (_, Some(false)) => Some(false),
+                (Some(true), Some(true)) => Some(true),
+                _ => None,
+            }
         }
         Condition::Or { left, right, .. } => {
-            grain_matches_condition_tree(grain, left) || grain_matches_condition_tree(grain, right)
+            match (
+                grain_condition_truth(grain, left),
+                grain_condition_truth(grain, right),
+            ) {
+                // A definite TRUE decides the disjunction.
+                (Some(true), _) | (_, Some(true)) => Some(true),
+                (Some(false), Some(false)) => Some(false),
+                _ => None,
+            }
         }
-        Condition::Not { inner, .. } => !grain_matches_condition_tree(grain, inner),
-        Condition::In { field, values, .. } => values
-            .iter()
-            .any(|v| grain_matches_condition(grain, field, &Comparator::Eq, v)),
-        Condition::NotIn { field, values, .. } => !values
-            .iter()
-            .any(|v| grain_matches_condition(grain, field, &Comparator::Eq, v)),
-        Condition::IsNull { field, .. } => {
-            json_field(&grain.fields, field).is_none()
-                || json_field(&grain.fields, field) == Some(&serde_json::Value::Null)
+        // NOT UNKNOWN is UNKNOWN — this is the arm that stops `NOT (object =
+        // "x")` from being the widening route `!=` used to be.
+        Condition::Not { inner, .. } => grain_condition_truth(grain, inner).map(|b| !b),
+        Condition::In { field, values, .. } => {
+            if !grain_carries_field(grain, field) {
+                return None;
+            }
+            Some(
+                values
+                    .iter()
+                    .any(|v| grain_matches_condition(grain, field, &Comparator::Eq, v)),
+            )
         }
-        Condition::IsNotNull { field, .. } => {
-            matches!(json_field(&grain.fields, field), Some(v) if !v.is_null())
+        Condition::NotIn { field, values, .. } => {
+            if !grain_carries_field(grain, field) {
+                return None;
+            }
+            Some(
+                !values
+                    .iter()
+                    .any(|v| grain_matches_condition(grain, field, &Comparator::Eq, v)),
+            )
         }
-        Condition::Contains { field, value, .. } => json_field(&grain.fields, field)
-            .and_then(|v| v.as_str())
-            .map(|s| s.contains(value.as_str()))
-            .unwrap_or(false),
-        Condition::StartsWith { field, value, .. } => json_field(&grain.fields, field)
-            .and_then(|v| v.as_str())
-            .map(|s| s.starts_with(value.as_str()))
-            .unwrap_or(false),
+        // The two operators that ask about absence always answer definitely.
+        Condition::IsNull { field, .. } => Some(!grain_carries_field(grain, field)),
+        Condition::IsNotNull { field, .. } => Some(grain_carries_field(grain, field)),
+        Condition::Contains { field, value, .. } => {
+            if !grain_carries_field(grain, field) {
+                return None;
+            }
+            Some(
+                json_field(&grain.fields, field)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.contains(value.as_str()))
+                    .unwrap_or(false),
+            )
+        }
+        Condition::StartsWith { field, value, .. } => {
+            if !grain_carries_field(grain, field) {
+                return None;
+            }
+            Some(
+                json_field(&grain.fields, field)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.starts_with(value.as_str()))
+                    .unwrap_or(false),
+            )
+        }
         Condition::IsCategory {
             field, category, ..
-        } => json_field(&grain.fields, field)
-            .and_then(|v| v.as_str())
-            .map(|s| s.eq_ignore_ascii_case(category))
-            .unwrap_or(false),
+        } => {
+            if !grain_carries_field(grain, field) {
+                return None;
+            }
+            Some(
+                json_field(&grain.fields, field)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.eq_ignore_ascii_case(category))
+                    .unwrap_or(false),
+            )
+        }
     }
 }
 
@@ -9746,8 +9900,11 @@ mod tests {
                 value: "anything".into()
             }
         ));
-        // Missing field DOES match NotEq (since !false = true).
-        assert!(super::grain_matches_condition(
+        // …and does not match NotEq either (#207). `!Eq` used to read absence
+        // as "differs from your value", which is how `RECALL skills WHERE
+        // object != "retired"` came back with every skill. A grain that
+        // cannot answer the predicate must not widen the result.
+        assert!(!super::grain_matches_condition(
             &grain,
             "tool",
             &super::super::ast::Comparator::NotEq,
@@ -9755,6 +9912,199 @@ mod tests {
                 value: "anything".into()
             }
         ));
+    }
+
+    /// #207 — the case that shipped: `object` is a real field name in
+    /// general (Fact, Observation and Goal all declare it) but means nothing
+    /// for a Skill, so the leaf resolved to absent and every negation of it
+    /// matched. The whole point is that a caller who writes a filter and
+    /// gets back the unfiltered set cannot tell the difference.
+    #[test]
+    fn test_207_negations_fail_closed_on_a_field_the_grain_lacks() {
+        use super::super::ast::{Comparator, Condition, Value};
+        let skill = CalGrainResult {
+            hash: "abc".into(),
+            grain_type: "skill".into(),
+            score: 1.0,
+            fields: serde_json::json!({ "name": "beta", "description": "retired" }),
+            score_breakdown: None,
+            explanation: None,
+            relative_time: None,
+            is_deterministic: false,
+            contested_by: None,
+        };
+        let retired = || Value::String {
+            value: "retired".into(),
+        };
+        let object_ne = Condition::Comparison {
+            field: "object".into(),
+            comparator: Comparator::NotEq,
+            value: retired(),
+            span: None,
+        };
+        // `object != "retired"` — the reported form.
+        assert!(!super::grain_matches_condition_tree(&skill, &object_ne));
+        // `NOT (object = "retired")` — the same widening, one rewrite away.
+        assert!(!super::grain_matches_condition_tree(
+            &skill,
+            &Condition::Not {
+                inner: Box::new(Condition::Comparison {
+                    field: "object".into(),
+                    comparator: Comparator::Eq,
+                    value: retired(),
+                    span: None,
+                }),
+                span: None,
+            }
+        ));
+        // `object NOT IN ("retired")` — and the membership form.
+        assert!(!super::grain_matches_condition_tree(
+            &skill,
+            &Condition::NotIn {
+                field: "object".into(),
+                values: vec![retired()],
+                span: None,
+            }
+        ));
+        // A field the grain DOES carry still negates normally — the fix
+        // narrows on absence, it does not disable `!=`.
+        assert!(super::grain_matches_condition_tree(
+            &skill,
+            &Condition::Comparison {
+                field: "description".into(),
+                comparator: Comparator::NotEq,
+                value: Value::String {
+                    value: "active".into()
+                },
+                span: None,
+            }
+        ));
+    }
+
+    /// Kleene propagation: UNKNOWN must not flip a conjunction or a
+    /// disjunction that a definite value already decides, or the fix for
+    /// #207 would narrow queries it has no business touching.
+    #[test]
+    fn test_207_unknown_propagates_by_the_sql_truth_tables() {
+        use super::super::ast::{Comparator, Condition, Value};
+        let skill = CalGrainResult {
+            hash: "abc".into(),
+            grain_type: "skill".into(),
+            score: 1.0,
+            fields: serde_json::json!({ "name": "beta" }),
+            score_breakdown: None,
+            explanation: None,
+            relative_time: None,
+            is_deterministic: false,
+            contested_by: None,
+        };
+        let known_true = Condition::Comparison {
+            field: "name".into(),
+            comparator: Comparator::Eq,
+            value: Value::String {
+                value: "beta".into(),
+            },
+            span: None,
+        };
+        let unknown = Condition::Comparison {
+            field: "object".into(),
+            comparator: Comparator::Eq,
+            value: Value::String {
+                value: "anything".into(),
+            },
+            span: None,
+        };
+        // T ∨ U = T — a disjunction a present field already satisfied.
+        assert!(super::grain_matches_condition_tree(
+            &skill,
+            &Condition::Or {
+                left: Box::new(known_true.clone()),
+                right: Box::new(unknown.clone()),
+                span: None,
+            }
+        ));
+        // T ∧ U = U → no match at the top. Unchanged from before the fix
+        // (it was T ∧ F), which is why non-negated queries do not move.
+        assert!(!super::grain_matches_condition_tree(
+            &skill,
+            &Condition::And {
+                left: Box::new(known_true),
+                right: Box::new(unknown),
+                span: None,
+            }
+        ));
+        // IS NULL / IS NOT NULL are the operators *about* absence, so they
+        // stay definite — UNKNOWN would make them unanswerable.
+        assert!(super::grain_matches_condition_tree(
+            &skill,
+            &Condition::IsNull {
+                field: "object".into(),
+                span: None,
+            }
+        ));
+        assert!(super::grain_matches_condition_tree(
+            &skill,
+            &Condition::IsNotNull {
+                field: "name".into(),
+                span: None,
+            }
+        ));
+    }
+
+    /// The omit-default discriminators must keep matching after #207: an
+    /// absent `kind` MEANS `"execution"`, so the fails-closed rule has to see
+    /// the materialized default as present or `kind != "definition"` — the
+    /// documented results-without-definitions query — would return nothing.
+    #[test]
+    fn test_207_omit_default_discriminators_survive_fails_closed() {
+        use super::super::ast::{Comparator, Condition, Value};
+        let legacy_execution = CalGrainResult {
+            hash: "abc".into(),
+            grain_type: "tool".into(),
+            score: 1.0,
+            fields: serde_json::json!({ "tool_name": "db_query" }),
+            score_breakdown: None,
+            explanation: None,
+            relative_time: None,
+            is_deterministic: false,
+            contested_by: None,
+        };
+        assert!(super::grain_matches_condition_tree(
+            &legacy_execution,
+            &Condition::Comparison {
+                field: "kind".into(),
+                comparator: Comparator::NotEq,
+                value: Value::String {
+                    value: "definition".into()
+                },
+                span: None,
+            }
+        ));
+    }
+
+    /// #206 — the world-time validity axis is queryable on every type. These
+    /// are `GrainCommon` fields the engine has serialized since 1.0; the only
+    /// thing missing was their presence in the filterable set.
+    #[test]
+    fn test_206_validity_fields_are_filterable_and_sortable() {
+        for f in [
+            "valid_from",
+            "valid_to",
+            "system_valid_from",
+            "system_valid_to",
+        ] {
+            assert!(
+                super::COMMON_FIELDS.contains(&f),
+                "{f} must be pipeline-valid (ORDER BY / SELECT / GROUP BY)"
+            );
+            assert!(
+                super::GRAIN_EVALUABLE_COMMON.contains(&f),
+                "{f} must be evaluable per grain (WHERE residual)"
+            );
+            // Never engine-only: they have a per-grain value, so a NOT/OR
+            // subtree over them must post-filter rather than refuse E061.
+            assert!(!super::ENGINE_ONLY_FIELDS.contains(&f));
+        }
     }
 
     #[test]

--- a/crates/areev-cal/src/templates.rs
+++ b/crates/areev-cal/src/templates.rs
@@ -66,6 +66,14 @@ const ALLOWED_FIELDS: &[&str] = &[
     "confidence",
     "importance",
     "created_at",
+    // §6.1 world-time validity, carried by every grain type (#206).
+    // `{{valid_to | date}}` is the label half of "what is currently valid";
+    // the filter half is the WHERE clause, and a render that can drop an
+    // expired note but not say when the others lapse is half an answer.
+    "valid_from",
+    "valid_to",
+    "system_valid_from",
+    "system_valid_to",
     "tags",
     "session_id",
     "content",
@@ -203,6 +211,14 @@ const ALL_VALID_VARIABLES: &[&str] = &[
     "confidence",
     "importance",
     "created_at",
+    // §6.1 world-time validity, carried by every grain type (#206).
+    // `{{valid_to | date}}` is the label half of "what is currently valid";
+    // the filter half is the WHERE clause, and a render that can drop an
+    // expired note but not say when the others lapse is half an answer.
+    "valid_from",
+    "valid_to",
+    "system_valid_from",
+    "system_valid_to",
     "tags",
     "session_id",
     "content",
@@ -1546,7 +1562,11 @@ fn resolve_variable(
         "_count" => return ResolvedValue::Integer(ctx.total_count as i64),
         "_first" => return ResolvedValue::Bool(index == Some(0)),
         "_last" => return ResolvedValue::Bool(index.is_some_and(|i| i + 1 == ctx.total_count)),
-        "_now" => return ResolvedValue::Integer(ctx.now_secs),
+        // Epoch **milliseconds**, matching every grain timestamp and what the
+        // `date`/`relative` filters take. `ctx.now_secs` stays seconds — it is
+        // the *now* argument of `humanize_time(created_ms, now_secs)`, a
+        // different role than the value a template renders.
+        "_now" => return ResolvedValue::Integer(ctx.now_secs.saturating_mul(1_000)),
         _ => {}
     }
 
@@ -1690,14 +1710,31 @@ pub fn apply_filter(
                 _ => Ok(ResolvedValue::Str(value.to_display())),
             }
         }
+        // `date` takes epoch **milliseconds**, because that is the unit of
+        // every timestamp a template can name: `created_at`, `valid_from`,
+        // `valid_to`, `deadline`, `expires_at`, `last_practiced_at`. It used
+        // to hand the value to `format_epoch` unconverted — and that function
+        // takes seconds — so `{{created_at | date}}` rendered the year 58657
+        // for a grain written today. `relative` never had the bug because
+        // `humanize_time(created_ms, now_secs)` names its units.
+        //
+        // `format_epoch` keeps its seconds signature: it is public, and the
+        // conversion belongs at the one place that knows the input is a grain
+        // timestamp.
         "date" => match value {
-            ResolvedValue::Integer(epoch) => {
+            ResolvedValue::Integer(epoch_ms) => {
                 let fmt = filter.arg.as_deref().unwrap_or("%Y-%m-%d");
-                Ok(ResolvedValue::Str(format_epoch(*epoch, fmt)))
+                Ok(ResolvedValue::Str(format_epoch(
+                    epoch_ms.div_euclid(1_000),
+                    fmt,
+                )))
             }
             ResolvedValue::Number(n) => {
                 let fmt = filter.arg.as_deref().unwrap_or("%Y-%m-%d");
-                Ok(ResolvedValue::Str(format_epoch(*n as i64, fmt)))
+                Ok(ResolvedValue::Str(format_epoch(
+                    (*n as i64).div_euclid(1_000),
+                    fmt,
+                )))
             }
             _ => Ok(ResolvedValue::Str(value.to_display())),
         },
@@ -3456,7 +3493,10 @@ mod tests {
     #[test]
     fn test_filter_date() {
         let ctx = test_ctx();
-        let val = ResolvedValue::Integer(1700000000);
+        // Epoch MILLISECONDS — the unit of every grain timestamp the filter
+        // is pointed at. Passing seconds here is what hid the bug that made
+        // `{{created_at | date}}` render the year 58657.
+        let val = ResolvedValue::Integer(1_700_000_000_000);
         let filter = Filter {
             name: "date".into(),
             arg: Some("%Y-%m-%d".into()),

--- a/crates/areev-conformance/tests/cal_smoke.rs
+++ b/crates/areev-conformance/tests/cal_smoke.rs
@@ -32,6 +32,9 @@ fn drive(facade: &AreevFacade) {
         other => panic!("expected Grains, got {other:?}"),
     }
 
+    drive_validity_window(&ex, facade);
+    drive_where_fails_closed(&ex, facade);
+
     // The destructive gate is identical on every backend: FORGET works when
     // allowed, and a no-destructive executor refuses it.
     let gated = CalExecutor::new(CalExecutorConfig {
@@ -55,6 +58,99 @@ fn drive(facade: &AreevFacade) {
         CalResultPayload::Grains { grains, .. } => assert!(grains.is_empty()),
         other => panic!("expected Grains, got {other:?}"),
     }
+}
+
+/// #206 — "what is currently valid" has to be expressible as a query.
+///
+/// `valid_to` is a `GrainCommon` field on every grain type, so this is a
+/// backend-blind property: the value rides inside the immutable blob and is
+/// post-filtered by the executor, which means it must answer identically
+/// wherever the bytes live.
+fn drive_validity_window(ex: &CalExecutor, facade: &AreevFacade) {
+    let count = |src: &str| -> usize {
+        match ex.execute(src, facade).unwrap().result {
+            CalResultPayload::Grains { grains, .. } => grains.len(),
+            other => panic!("expected Grains, got {other:?}"),
+        }
+    };
+
+    // A waiver that lapsed, and a policy with no expiry — the two shapes any
+    // memory modelling a temporary exception has.
+    ex.execute(
+        r#"ADD fact SET subject = "waiver" SET relation = "covers" SET object = "acme"
+           SET namespace = "vt" SET valid_to = 1000 REASON "expires""#,
+        facade,
+    )
+    .unwrap();
+    ex.execute(
+        r#"ADD fact SET subject = "policy" SET relation = "covers" SET object = "everyone"
+           SET namespace = "vt" REASON "no expiry""#,
+        facade,
+    )
+    .unwrap();
+
+    assert_eq!(count(r#"RECALL facts WHERE namespace = "vt""#), 2);
+
+    // Past its valid_to: excluded by the predicate…
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "vt" AND (valid_to IS NULL OR valid_to > 5000)"#),
+        1,
+        "an expired fact must not survive the currently-valid predicate"
+    );
+    // …and included without it.
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "vt" AND valid_to > 500"#),
+        1,
+        "the expired fact is still readable when the query asks for it"
+    );
+    // Sortable, not only filterable.
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "vt" ORDER BY valid_to DESC"#),
+        2
+    );
+}
+
+/// #207 — a `WHERE` predicate must never widen. A grain that does not carry
+/// the field matches neither `= x` nor `!= x`, and the same holds however the
+/// negation is spelled.
+fn drive_where_fails_closed(ex: &CalExecutor, facade: &AreevFacade) {
+    let count = |src: &str| -> usize {
+        match ex.execute(src, facade).unwrap().result {
+            CalResultPayload::Grains { grains, .. } => grains.len(),
+            other => panic!("expected Grains, got {other:?}"),
+        }
+    };
+
+    ex.execute(
+        r#"ADD skill SET name = "alpha" SET description = "active" SET namespace = "fc" REASON "seed""#,
+        facade,
+    )
+    .unwrap();
+    ex.execute(
+        r#"ADD skill SET name = "beta" SET description = "retired" SET namespace = "fc" REASON "seed""#,
+        facade,
+    )
+    .unwrap();
+    assert_eq!(count(r#"RECALL skills WHERE namespace = "fc""#), 2);
+
+    // `object` is a real field name (Fact/Observation/Goal declare it) that
+    // means nothing for a Skill. Every negation of it must match nothing —
+    // this is the exact query that shipped returning both skills, including
+    // the one whose description IS "retired".
+    for src in [
+        r#"RECALL skills WHERE namespace = "fc" AND object != "retired""#,
+        r#"RECALL skills WHERE namespace = "fc" AND NOT object = "retired""#,
+        r#"RECALL skills WHERE namespace = "fc" AND object NOT IN ("retired")"#,
+    ] {
+        assert_eq!(count(src), 0, "a predicate the grain cannot answer widened: {src}");
+    }
+
+    // A field the type DOES carry still filters — `description` is required
+    // on every Skill and was refused as unqueryable until #207.
+    assert_eq!(
+        count(r#"RECALL skills WHERE namespace = "fc" AND description != "retired""#),
+        1
+    );
 }
 
 #[test]

--- a/crates/areev-core/src/types/registry.rs
+++ b/crates/areev-core/src/types/registry.rs
@@ -249,6 +249,12 @@ pub const GRAIN_TYPES: &[GrainTypeMeta] = &[
         required_add_fields: &["name", "description"],
         queryable_fields: &[
             "name",
+            // Required on the struct since 1.4 but absent here, so the field
+            // every Skill MUST carry was the one `WHERE` refused (#207):
+            // `RECALL skills WHERE description != "retired"` answered
+            // CAL-E060 about a field that is right there in the blob. Goal
+            // has declared it since it shipped; Skill shares the `desc` key.
+            "description",
             "version",
             "domain",
             "holder_did",

--- a/crates/areev-trigger/src/predicate.rs
+++ b/crates/areev-trigger/src/predicate.rs
@@ -87,10 +87,22 @@ pub fn grain_matches(grain: &DeserializedGrain, condition: &Condition) -> bool {
 /// The condition's field names are member ids; a member that has fired is
 /// `true`. Reusing the same `Condition` shape means `(a AND b) OR c` over
 /// triggers is written and evaluated exactly like a predicate over grains.
+///
+/// **Every referenced member is materialized**, `false` when it has not fired.
+/// The two callers of the shared evaluator mean opposite things by an absent
+/// field: over a *grain* absence is UNKNOWN (the type does not carry the
+/// field, so the predicate has no answer — #207), while over a *gate* absence
+/// is a definite "has not fired". Projecting only the fired members left the
+/// evaluator to guess between them, and `NOT (a = true)` — "fire when `a` did
+/// not" — is exactly where the two readings diverge. Naming every member
+/// makes the gate's meaning explicit instead of encoding it in a gap.
 pub fn gate_satisfied(condition: &Condition, fired: &[String]) -> bool {
-    let fields: serde_json::Map<String, serde_json::Value> = fired
-        .iter()
-        .map(|m| (m.clone(), serde_json::Value::Bool(true)))
+    let fields: serde_json::Map<String, serde_json::Value> = referenced_members(condition)
+        .into_iter()
+        .map(|m| {
+            let has_fired = fired.contains(&m);
+            (m, serde_json::Value::Bool(has_fired))
+        })
         .collect();
     let projected = CalGrainResult {
         hash: String::new(),

--- a/docs/cal-reference.md
+++ b/docs/cal-reference.md
@@ -633,6 +633,45 @@ order. Now:
   support, they refuse with **`CAL-E061`** instead of widening.
 - Comparators the push-down alone never honoured (`confidence < 0.5`,
   `subject != "x"`, `deadline IS NULL`) are now applied per grain.
+- **A field the grain does not carry answers no predicate** (1.7.4, #206/#207).
+  Evaluation is three-valued: absence is UNKNOWN, and UNKNOWN does not match.
+  So a grain with no `object` matches neither `object = "x"` nor `object !=
+  "x"`, `NOT (object = "x")`, or `object NOT IN ("x")`. Before 1.7.4 the
+  negations read absence as "differs from your value" and matched **every**
+  row — `RECALL skills WHERE object != "retired"` returned the retired skill
+  too, with nothing in the payload to distinguish "the filter ran and matched
+  everything" from "the filter did not run". `IS NULL` / `IS NOT NULL` are the
+  operators *about* absence and stay definite; `AND`/`OR` use SQL's truth
+  tables, so nothing that already matched stops matching.
+
+#### World-time validity: `valid_from` / `valid_to`
+
+Every grain type carries the OMS §6.1 world-time axis, and since 1.7.4 all four
+fields (`valid_from`, `valid_to`, `system_valid_from`, `system_valid_to`) are
+**filterable and sortable** on every type, with the usual comparators and `IS
+NULL`. They live inside the immutable blob, so they post-filter over the widened
+scan like any other type-specific key — `CAL-W015` still reports a scan that
+filled.
+
+"What is currently valid" is therefore a query rather than host code:
+
+```sql
+RECALL facts WHERE namespace = "desk"
+  AND (valid_to IS NULL OR valid_to > 1788866000000)
+```
+
+`IS NULL` is load-bearing: a fact with no declared expiry never lapses, and
+dropping that leg would silently return only the facts that *do* expire. The
+label half lives in templates — `{{grain.valid_to | date}}` — so a render can
+say *(until 2026-10-01)* rather than the host re-deriving it. `DESCRIBE FIELDS
+<type>` lists all four.
+
+This is what makes a waiver, a delegation, an out-of-office, or a price valid
+until a date expressible without over-fetching: previously every host read the
+whole set and filtered in application code, which also defeated `BUDGET` — the
+budget was spent on grains the host was about to discard. The loop's `staleness`
+analyzer still proposes a tombstone eventually, but "eventually" is not the same
+as "not in this prompt".
 
 `EXISTS`, `HISTORY … WHERE`, and the ASSEMBLE-level `WHERE` share the same
 contract. `DESCRIBE FIELDS <type>` lists exactly the fields that filter for
@@ -912,6 +951,33 @@ Sections you do not define are inherited from `EXTENDS <parent>`, defaulting
 to `readable`. The three preset parents (`structured`, `readable`, `compact`)
 define element-level sections only, so inheriting never adds a header you did
 not ask for. `data` cannot be extended (`CAL-E119`).
+
+#### Filters
+
+A template variable may be piped through a **closed** list of filters, chained
+left to right: `{{relation | humanize | uppercase}}`. The set is closed on
+purpose — `DESCRIBE CAPABILITIES` reports what this host supports, and OMS
+conformance means two implementations must render a grain identically, which an
+open function library cannot promise.
+
+| Filter | Effect |
+|---|---|
+| `truncate(n)` | Clip to `n` characters |
+| `date` / `date "<fmt>"` | Format an epoch timestamp (default `%Y-%m-%d`) |
+| `relative` | "2 weeks ago"-style label |
+| `humanize` | Turn a relation name into prose (`lives_in` → "lives in") |
+| `percent` | Render `0.9` as `90%` |
+| `uppercase` / `lowercase` | Case |
+| `json` | **Serialise** the value as JSON — it does not parse one |
+| `default "<text>"` | Substitute when the value is absent or empty |
+| `join("<sep>")` | Join an array |
+
+**Timestamps are epoch milliseconds.** Every timestamp a template can name —
+`created_at`, `valid_from`, `valid_to`, `deadline`, `expires_at`,
+`last_practiced_at`, and `_now` — is epoch ms, and `date` and `relative` both
+read them that way. Before 1.7.4 `date` treated its input as *seconds*, so
+`{{created_at | date}}` rendered the year 58657 for a grain written today;
+`relative` never had the bug.
 
 | Limit (OMS CAL §10.8) | Value |
 |---|---|


### PR DESCRIPTION
Closes #206. Closes #207.

Two reads that could not be written, found while moving `areev-bench` onto the engine's own surfaces.

## #207 — a filter that silently no-ops

```sql
RECALL skills WHERE namespace = "x" AND object != "retired"
→ 2 grains        # both skills, including the one whose description IS "retired"
```

`object` is a real field name in general — Fact, Observation **and** Goal all declare it — but means nothing for a Skill. The per-grain evaluator resolved it as absent, and read absence as `false`, which makes every *negation* of it `true`. No warning, nothing in the payload to distinguish "the filter ran and matched everything" from "the filter did not run". That is the widening #91 retired, reached one rewrite later.

It was never `object`-specific, and never skills-specific. All three of these matched every row:

```sql
… AND object != "retired"
… AND NOT object = "retired"
… AND object NOT IN ("retired")
```

**The fix: evaluation is three-valued.** A leaf whose field the grain does not carry is UNKNOWN, `AND`/`OR` combine by SQL's truth tables, `NOT UNKNOWN` is UNKNOWN, and UNKNOWN does not match at the top.

That is the smallest model that can express fails-closed *under negation*. Fixing only `!=` would leave the identical bug in `NOT (… = …)` one rewrite away — a half-fix for a fails-closed contract is worse than none.

**On the ticket's proposed option 1 (blanket `CAL-E060`):** it is not safe, and I did not take it. `subject`/`object` are genuine struct fields on Fact, Observation and Goal, and any type may carry them via `extra_fields` — I confirmed a Skill grain storing `subject`. Refusing them per-type would reject queries against fields the grain actually holds.

**Nothing that already matched stops matching.** `T ∧ U` and `F ∧ U` both collapsed to no-match before; `T ∨ U` already matched. Only negation moves — which is the bug. `IS NULL`/`IS NOT NULL` stay definite: they are the operators *about* absence.

**The omit-default discriminators still work.** `resolve_grain_field` is now the one answer to "does this grain carry the field", and the `kind`/`status` defaults resolve there — so a materialized default reads as *present* and `kind != "definition"`, the documented results-without-definitions query, keeps returning legacy execution grains. Pinned by a test.

### The shared-evaluator interaction

`areev-trigger` uses the same tree for composite gates, and means the **opposite** by an absent field: there it is "this member has not fired" — definite, not unknown. Its `negation_works` test caught this. `gate_satisfied` now materializes every `referenced_members` name as `true`/`false` rather than projecting only the fired ones, so the gate's meaning is stated instead of encoded in a gap.

### A second bug the ticket's premise rested on

The issue treats `description != "retired"` → `CAL-E060` as the *honest* baseline. It is not: `description` is **required** on every Skill struct since 1.4 and was simply missing from the registry's `queryable_fields`. So the one field a Skill must carry was the one `WHERE` refused. Fixed here.

## #206 — "what is currently valid" could not be a query

`valid_from`/`valid_to`/`system_valid_from`/`system_valid_to` are `GrainCommon` fields on **every** grain type: serialized since 1.0, expanded back into `fields` on read, already visible in every JSON payload, and read by the loop's `staleness` analyzer. FAQ.md advertises the axis. They were simply absent from CAL's filterable set:

```
RECALL facts WHERE valid_to > 1788866000000
→ CAL-E060: Field "valid_to" is not available on grain type "facts"
```

So the engine advertised a bitemporal axis it could not query. Now:

```sql
RECALL facts WHERE namespace = "desk"
  AND (valid_to IS NULL OR valid_to > 1788866000000)
```

Filterable and sortable on every type with the usual comparators and `IS NULL`, resolving in templates (`{{grain.valid_to | date}}`), listed by `DESCRIBE FIELDS`. No push-down — they live inside the immutable blob and post-filter over the widened scan, the shape `ORDER BY` on a type-specific key already uses, so `CAL-W015` still reports a scan that filled.

`IS NULL` is load-bearing: a fact with no declared expiry never lapses, and dropping that leg silently returns only the facts that *do* expire.

This generalizes past the bench. Any memory modelling a temporary exception — a waiver, a delegation, an out-of-office, a price valid until a date — needed host code, which also defeats `BUDGET`: the budget was spent on grains the host was about to discard.

### A third bug found making the label half work

`{{created_at | date}}` rendered **58657-02-23** for a grain written today. Every timestamp a template can name is epoch **ms**, but `date` handed its input to a seconds-based formatter. `relative` never had it, because `humanize_time(created_ms, now_secs)` names its units. `date` and `_now` now speak ms; `format_epoch` keeps its public seconds signature, since the conversion belongs at the one place that knows the input is a grain timestamp.

## Scope note

No new CAL syntax, no new error codes — so no OMS spec decision is needed. These are all behaviour behind existing surfaces.

## Tests

- `cargo test --workspace`: **133 suites green**, no failures.
- `cargo clippy --workspace --all-targets`: clean.
- Conformance on **both backends**: `cal_smoke.rs`'s `drive()` gains `drive_validity_window` (expired fact excluded by the predicate, included without it, sortable) and `drive_where_fails_closed` (all three negation spellings match nothing; a field the type carries still filters).
- Unit: the `object`-on-skills case that shipped, Kleene propagation (`T∨U`, `T∧U`, `IS NULL` definite), omit-default survival, and the #206 field-table membership.
- Two tests updated because they pinned the bugs: `test_grain_matches_condition_missing_field_returns_false` asserted `NotEq` on a missing field returns **true**; `test_filter_date` passed seconds.

## Docs

`docs/cal-reference.md` §3.4 (absence rule + a world-time validity section), §6 (**the filter table it never had**, which is where the epoch-ms convention is now written down), `ARCHITECTURE.md` §10 (the #91 decision amended rather than duplicated), `crates/areev-cal/CLAUDE.md`, `CHANGELOG.md`.

https://claude.ai/code/session_01JEcv3k8mMwZ5YAa26jdLc2