### PR TITLE
cal: ASSEMBLE says what its budget dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,37 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   too, so the whole filter surface speaks one unit; `format_epoch` keeps its
   public seconds signature.
 
+- **`ASSEMBLE` says what its budget dropped** (#208). `ASSEMBLE` applies a
+  token budget whether or not the caller writes one — 4000 by default, ceiling
+  16000 — and when it bound it discarded the tail of each source in silence.
+  The payload actively hid it: `total_available` reported the **post**-budget
+  count, so `grains.len() == total_available` held for a truncated assembly
+  exactly as it did for a complete one. Measured on a real memory, 229
+  matching grains came back as 80 with `warnings: None`.
+
+  A budget that drops grains now emits **`CAL-W017`**, naming the sources and
+  the counts, and saying whether the budget was written or defaulted:
+
+  ```
+  CAL-W017: the default BUDGET 4000 tokens dropped 130 of 200 grains from
+  source(s) [e] — this assembly is a window, not the whole match.
+  ```
+
+  `total_available` is now the **pre**-budget count, so the drop is computable
+  rather than announced only in prose; each source'"'"'s `grain_count` still
+  reports what survived. `docs/cal-reference.md` states the default and the
+  ceiling where `BUDGET` is documented — neither number appeared there, so "no
+  `BUDGET` clause" read as "no budget".
+
+  The default itself was kept rather than removed: an unbudgeted assembly that
+  returned everything could overflow the context window it is being composed
+  for, which is the worse failure. Silence was the defect, not the number.
+
+  Why it matters: a host composing a prompt from an assembly had no way to
+  detect that its rules, its policies or its recent turns were trimmed — it
+  would publish a number produced from a truncated prompt and never know.
+  `RECALL` has announced the same kind of cut as `CAL-W015` since 1.5.1.
+
 ### Added
 
 - **World-time validity is queryable and renderable** (#206). `valid_from`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   RECALL facts WHERE object.error.code = "rate_limited"
   ```
 
-  `record_tool_call` round-trips a tool'"'"'s `input` as parsed JSON, so Python
+  `record_tool_call` round-trips a tool's `input` as parsed JSON, so Python
   and Node hosts already received the structure — it was specifically the CAL
   path that could not see inside. A field name may now be a dotted path of up
   to 8 segments (it accepted one dot before, which did not reach the shape a
@@ -79,17 +79,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   paved road is still to store the shape you want to read: two fields rather
   than one payload, which makes the value filterable as well as renderable.
 
+- **World-time validity is queryable and renderable** (#206). `valid_from`,
+  `valid_to`, `system_valid_from` and `system_valid_to` are `GrainCommon`
+  fields on every grain type — serialized since 1.0, read by the loop's
+  `staleness` analyzer, and present in every JSON payload — but they were
+  absent from CAL's filterable set, so the one read that makes a validity
+  window worth writing answered `CAL-E060`. They now filter and sort on every
+  type with the usual comparators and `IS NULL`, resolve in templates
+  (`{{grain.valid_to | date}}`), and appear in `DESCRIBE FIELDS`. "What is
+  currently valid" is a query:
+
+  ```sql
+  RECALL facts WHERE namespace = "desk"
+    AND (valid_to IS NULL OR valid_to > 1788866000000)
+  ```
+
+  This is what a waiver, a delegation, an out-of-office or a price valid until
+  a date needs. Every host previously over-fetched and post-filtered, which
+  also defeated `BUDGET` — the budget was spent on grains about to be
+  discarded.
+
 ### Fixed
 
 - **An `ASSEMBLE` source can carry its own pipeline, and no longer drops a
-  nested assembly'"'"'s grains.** Sources had no pipeline at all, so a source
+  nested assembly's grains.** Sources had no pipeline at all, so a source
   could not be ranked, bounded or summarised in place. Separately,
   `assemble.rs` carried a **second copy** of `extract_grains` that had drifted
-  from the executor'"'"'s: it saw only the `Grains` payload, so a nested
+  from the executor's: it saw only the `Grains` payload, so a nested
   `Assembled` result silently contributed nothing to the enclosing assembly.
   There is now one extractor.
-
-### Fixed
 
 - **A `WHERE` predicate on a field the grain does not carry no longer matches
   everything** (#207). `object` is a real field name in general — Fact,
@@ -138,7 +156,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ```
 
   `total_available` is now the **pre**-budget count, so the drop is computable
-  rather than announced only in prose; each source'"'"'s `grain_count` still
+  rather than announced only in prose; each source's `grain_count` still
   reports what survived. `docs/cal-reference.md` states the default and the
   ceiling where `BUDGET` is documented — neither number appeared there, so "no
   `BUDGET` clause" read as "no budget".
@@ -161,28 +179,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the whole match. All seventeen (`CAL-W001`–`W017`) now appear above the
   result on the Query page, in plain language, with the `CAL-Wnnn` code shown
   only in Developer mode.
-
-### Added
-
-- **World-time validity is queryable and renderable** (#206). `valid_from`,
-  `valid_to`, `system_valid_from` and `system_valid_to` are `GrainCommon`
-  fields on every grain type — serialized since 1.0, read by the loop's
-  `staleness` analyzer, and present in every JSON payload — but they were
-  absent from CAL's filterable set, so the one read that makes a validity
-  window worth writing answered `CAL-E060`. They now filter and sort on every
-  type with the usual comparators and `IS NULL`, resolve in templates
-  (`{{grain.valid_to | date}}`), and appear in `DESCRIBE FIELDS`. "What is
-  currently valid" is a query:
-
-  ```sql
-  RECALL facts WHERE namespace = "desk"
-    AND (valid_to IS NULL OR valid_to > 1788866000000)
-  ```
-
-  This is what a waiver, a delegation, an out-of-office or a price valid until
-  a date needs. Every host previously over-fetched and post-filtered, which
-  also defeated `BUDGET` — the budget was spent on grains about to be
-  discarded.
 
 ## [1.7.3] — 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   would publish a number produced from a truncated prompt and never know.
   `RECALL` has announced the same kind of cut as `CAL-W015` since 1.5.1.
 
+- **The console shows CAL warnings.** Every other surface honoured the
+  "silence means the query did what you asked" contract — the bindings and the
+  MCP tool return `warnings`, the CLI prints them to stderr — but the console
+  received them from `POST /api/cal` and dropped them on the floor. That was
+  the worst place for it: this is the surface a person reads an answer from,
+  and a warning is exactly the news that the answer is a window rather than
+  the whole match. All seventeen (`CAL-W001`–`W017`) now appear above the
+  result on the Query page, in plain language, with the `CAL-Wnnn` code shown
+  only in Developer mode.
+
 ### Added
 
 - **World-time validity is queryable and renderable** (#206). `valid_from`,

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -195,6 +195,7 @@ and are the source of truth. Ranges:
 | `CAL-W014` | A `WITH` option parsed and ran but cannot change the result on this statement (e.g. `score_breakdown` on `RECALL`) |
 | `CAL-W015` | A post-retrieval stage (`ORDER BY`, a type-specific `WHERE` filter, `COUNT`) widened its scan to `max_limit` and still filled it — the answer is the top-k of a window, not of the memory |
 | `CAL-W016` | A pipeline stage was attached to a payload it cannot act on (e.g. `ORDER BY` on a multi-source `ASSEMBLE`) and was skipped |
+| `CAL-W017` | An `ASSEMBLE` token budget dropped grains its sources had already retrieved, naming the sources and the counts — including when the 4000-token default applied because no `BUDGET` clause was written |
 
 `CAL-E116` is the "needs an external LLM, not implemented" error for
 `WITH hyde` / `WITH llm_rerank` — Areev takes no LLM dependency by policy.

--- a/crates/areev-cal/CLAUDE.md
+++ b/crates/areev-cal/CLAUDE.md
@@ -172,7 +172,13 @@ the audit hash.
   `*`-bearing namespaces except `*` itself (`parse_grant_parts`). E2E:
   `tests/ns_scope_cal_tests.rs`.
 - `assemble.rs` — `AssembleEngine`: multi-source ASSEMBLE, dedup, 2000-grain
-  cap, per-source budget weights, chars/4 token estimate.
+  cap, per-source budget weights, chars/4 token estimate. **The budget applies
+  written or not** (`DEFAULT_BUDGET_TOKENS` 4000, parser ceiling 16000), and a
+  budget that drops grains emits `CAL-W017` naming the sources, the counts, and
+  whether the default applied (#208). `total_available` is the PRE-budget
+  count — reporting the trimmed one made a truncated assembly arithmetically
+  indistinguishable from a complete one. If you add a path that discards grains
+  here, it warns or it is the same bug again.
 - `render.rs` — THE per-grain renderer every surface shares: semantic
   `sml`, the documented `markdown` assertion line, `text`, registry-driven
   `toon`, the `json` envelope, per-type summaries, and the one `chars/4`

--- a/crates/areev-cal/src/assemble.rs
+++ b/crates/areev-cal/src/assemble.rs
@@ -229,11 +229,24 @@ impl<'a> AssembleEngine<'a> {
         };
 
         // 4. Allocate budget.
+        //
+        // Note the default: an ASSEMBLE with no BUDGET clause is still
+        // budgeted. That stays (an unbudgeted assembly could otherwise
+        // overflow the context window it is being composed for — the worse
+        // failure), but it is now *reported*, because "no BUDGET clause"
+        // reads as "no budget" and used to behave as neither.
+        let budget_defaulted = stmt.budget.is_none();
         let budget_tokens = stmt
             .budget
             .as_ref()
             .map(|b| b.tokens)
             .unwrap_or(DEFAULT_BUDGET_TOKENS);
+
+        // How many grains the sources actually retrieved, before any of this
+        // spends them. `total_available` is reported from here rather than
+        // from the trimmed set: a caller cannot compute what a budget removed
+        // from a number the budget already reduced.
+        let available_pre_budget: usize = source_results.iter().map(|(_, g)| g.len()).sum();
 
         let labels: Vec<&str> = source_results.iter().map(|(l, _)| l.as_str()).collect();
 
@@ -296,6 +309,9 @@ impl<'a> AssembleEngine<'a> {
         let mut meta: Vec<SourceMeta> = Vec::new();
         let mut remaining_budget = budget_tokens;
         let mut dropped = 0usize; // grains the budget forced us to omit
+        // The labels behind that number: "149 grains went" is not actionable
+        // on a four-source assembly without knowing which section lost them.
+        let mut dropped_labels: Vec<String> = Vec::new();
 
         for (i, (label, mut grains)) in source_results.into_iter().enumerate() {
             // A pinned source was already costed in full and reserved off the
@@ -327,9 +343,14 @@ impl<'a> AssembleEngine<'a> {
             // — which is the opposite of what a budget is for.
             let (keep, tokens_used) = self.budget_prefix(&grains, effective_allocation);
             let budget_omitted = grains.split_off(keep);
+            if !budget_omitted.is_empty() {
+                dropped_labels.push(label.clone());
+            }
             dropped += budget_omitted.len();
             let mut omitted = budget_omitted;
             if let Some(cap_tail) = capped_omitted.remove(&label) {
+                // The post-dedup cap already warned for itself above; this
+                // only folds its tail into the omitted set for ELEMENT_OMIT.
                 dropped += cap_tail.len();
                 omitted.extend(cap_tail);
             }
@@ -352,15 +373,36 @@ impl<'a> AssembleEngine<'a> {
         // §8): overflow = the token budget forced grains to be dropped.
         store.note_assembly_budget(dropped > 0);
 
+        // Say what the budget cut. RECALL has announced the same kind of cut
+        // as CAL-W015 since 1.5.1 — an assembly making it silently is how a
+        // host ends up composing a prompt from 79 of 229 grains and
+        // publishing a number it produced.
+        if !dropped_labels.is_empty() {
+            warnings.push(
+                super::errors::CalWarning::AssembleBudgetDropped {
+                    labels: dropped_labels,
+                    dropped,
+                    available: available_pre_budget,
+                    budget: budget_tokens,
+                    defaulted: budget_defaulted,
+                }
+                .to_string(),
+            );
+        }
+
         // 6. Build result.
-        let count = final_grains.len();
         Ok(CalResultPayload::Assembled {
             grains: final_grains,
             sources: meta,
             total_tokens,
             budget_limit: Some(budget_tokens),
             progressive: false,
-            total_available: Some(count),
+            // PRE-budget (#208). This used to report the trimmed count, which
+            // made a truncated assembly arithmetically indistinguishable from
+            // a complete one — `grains.len() == total_available` held either
+            // way. The per-source `grain_count` still reports what survived,
+            // so the drop is computable rather than announced only in prose.
+            total_available: Some(available_pre_budget),
         })
     }
 

--- a/crates/areev-cal/src/errors.rs
+++ b/crates/areev-cal/src/errors.rs
@@ -1488,6 +1488,35 @@ pub enum CalWarning {
         payload: &'static str,
         why: &'static str,
     },
+
+    /// CAL-W017 — An `ASSEMBLE` token budget dropped grains a source had
+    /// already retrieved.
+    ///
+    /// `ASSEMBLE` applies a budget whether or not the caller wrote one
+    /// (`DEFAULT_BUDGET_TOKENS`, 4000), and when it binds it discards the
+    /// tail of each source in silence. The payload actively hid it:
+    /// `total_available` reported the *post*-budget count, so a truncated
+    /// answer was indistinguishable from a full one. The same cut on
+    /// `RECALL` has announced itself as `CAL-W015` since 1.5.1 — a host
+    /// composing a prompt from an assembly has to be able to tell that its
+    /// rules, its policies or its recent turns were trimmed, or it will
+    /// publish a number produced from a truncated prompt and never know.
+    ///
+    /// `defaulted` distinguishes the two cases the caller cares about most:
+    /// a budget they wrote (raise it) from one they never asked for (write
+    /// one, or narrow the source).
+    AssembleBudgetDropped {
+        /// Source labels the budget cut, in FROM-clause order.
+        labels: Vec<String>,
+        /// Grains discarded across those sources.
+        dropped: usize,
+        /// Grains the sources retrieved before the budget was applied.
+        available: usize,
+        /// The budget that bound, in tokens.
+        budget: u32,
+        /// True when no `BUDGET` clause was written and the default applied.
+        defaulted: bool,
+    },
 }
 
 impl CalWarning {
@@ -1509,6 +1538,7 @@ impl CalWarning {
             Self::WithOptionInert { .. } => "CAL-W014",
             Self::ScanBounded { .. } => "CAL-W015",
             Self::PipelineStageInert { .. } => "CAL-W016",
+            Self::AssembleBudgetDropped { .. } => "CAL-W017",
         }
     }
 
@@ -1529,7 +1559,8 @@ impl CalWarning {
             | Self::ContradictionScanBounded { .. }
             | Self::WithOptionInert { .. }
             | Self::ScanBounded { .. }
-            | Self::PipelineStageInert { .. } => None,
+            | Self::PipelineStageInert { .. }
+            | Self::AssembleBudgetDropped { .. } => None,
         }
     }
 }
@@ -1636,6 +1667,29 @@ impl std::fmt::Display for CalWarning {
                 write!(
                     f,
                     "CAL-W016: {stage} has no effect on a {payload} result — {why}. The stage was skipped; the result is the same as without it."
+                )
+            }
+            Self::AssembleBudgetDropped {
+                labels,
+                dropped,
+                available,
+                budget,
+                defaulted,
+            } => {
+                let clause = if *defaulted {
+                    "the default BUDGET"
+                } else {
+                    "BUDGET"
+                };
+                let advice = if *defaulted {
+                    " No BUDGET clause was written, so the 4000-token default applied — write one (ceiling 16000 tokens), or narrow the source."
+                } else {
+                    " Raise the budget (ceiling 16000 tokens), or narrow the source."
+                };
+                write!(
+                    f,
+                    "CAL-W017: {clause} {budget} tokens dropped {dropped} of {available} grains from source(s) [{}] — this assembly is a window, not the whole match.{advice}",
+                    labels.join(", ")
                 )
             }
         }

--- a/crates/areev-cal/tests/assemble_budget_visibility.rs
+++ b/crates/areev-cal/tests/assemble_budget_visibility.rs
@@ -1,0 +1,152 @@
+//! #208 — an `ASSEMBLE` budget that drops grains has to say so.
+//!
+//! The failure this pins is not a wrong answer but an *undetectable* one. The
+//! budget applies whether or not the caller wrote one (4000 tokens by
+//! default), and when it bound it discarded the tail of each source in
+//! silence while `total_available` reported the post-budget count — so
+//! `grains.len() == total_available` held for a truncated assembly exactly as
+//! it did for a complete one. A host composing a prompt has no other signal
+//! that its rules, its policies or its recent turns were trimmed.
+
+use areev_cal::executor::CalResultPayload;
+use areev_cal::{AreevFacade, CalExecutor, CalExecutorConfig};
+use areev_core::types::{Fact, Grain};
+use areev_store::Areev;
+use tempfile::TempDir;
+
+/// Enough grains, each long enough, that the 4000-token default cannot hold
+/// them. The bug hid behind fixtures too small to bind.
+fn seeded(dir: &TempDir) -> Areev {
+    let mut m = Areev::open(dir.path().join("budget.db").to_str().unwrap()).unwrap();
+    for i in 0..200 {
+        let subject = format!("s{i}");
+        let object = format!(
+            "this is a reasonably long object value number {i}, long enough that \
+             two hundred of them cannot fit inside the four-thousand-token default"
+        );
+        let mut f = Fact::new(&subject, "note", &object).confidence(0.9);
+        f.common.namespace = Some("b".to_string());
+        m.add(&f).unwrap();
+    }
+    m
+}
+
+fn assembled(
+    ex: &CalExecutor,
+    facade: &AreevFacade,
+    src: &str,
+) -> (usize, Option<usize>, Vec<String>) {
+    let res = ex.execute(src, facade).unwrap();
+    let warnings = res.warnings.clone();
+    match res.result {
+        CalResultPayload::Assembled {
+            grains,
+            total_available,
+            ..
+        } => (grains.len(), total_available, warnings),
+        other => panic!("expected Assembled, got {other:?}"),
+    }
+}
+
+#[test]
+fn an_unbudgeted_assemble_reports_what_its_default_dropped() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded(&d), Some("b".to_string()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let (kept, total_available, warnings) = assembled(
+        &ex,
+        &facade,
+        r#"ASSEMBLE "e" FROM e: (RECALL facts WHERE namespace = "b" LIMIT 400)"#,
+    );
+
+    assert!(
+        kept < 200,
+        "fixture must be large enough for the default budget to bind (kept {kept})"
+    );
+    // The number that used to hide the cut: it reported `kept`, so the drop
+    // was not computable from the payload at all.
+    assert_eq!(
+        total_available,
+        Some(200),
+        "total_available must be the PRE-budget count, or a truncated assembly \
+         is arithmetically indistinguishable from a complete one"
+    );
+
+    let w = warnings
+        .iter()
+        .find(|w| w.starts_with("CAL-W017"))
+        .unwrap_or_else(|| panic!("no CAL-W017 among {warnings:?}"));
+    assert!(w.contains(&format!("dropped {} of 200 grains", 200 - kept)), "{w}");
+    // The label matters: "130 grains went" is not actionable on a four-source
+    // assembly without knowing which section lost them.
+    assert!(w.contains("[e]"), "{w}");
+    // …and so does *why* the budget was 4000, since the caller never wrote it.
+    assert!(w.contains("No BUDGET clause was written"), "{w}");
+}
+
+#[test]
+fn an_explicit_budget_that_binds_names_itself_not_the_default() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded(&d), Some("b".to_string()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let (_, _, warnings) = assembled(
+        &ex,
+        &facade,
+        r#"ASSEMBLE "e" FROM e: (RECALL facts WHERE namespace = "b" LIMIT 400) BUDGET 4000 tokens"#,
+    );
+    let w = warnings.iter().find(|w| w.starts_with("CAL-W017")).unwrap();
+    assert!(w.contains("BUDGET 4000 tokens dropped"), "{w}");
+    assert!(
+        !w.contains("No BUDGET clause was written"),
+        "a budget the caller wrote must not be reported as the default: {w}"
+    );
+}
+
+#[test]
+fn a_budget_that_fits_stays_silent() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded(&d), Some("b".to_string()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let (kept, total_available, warnings) = assembled(
+        &ex,
+        &facade,
+        r#"ASSEMBLE "e" FROM e: (RECALL facts WHERE namespace = "b" LIMIT 400) BUDGET 16000 tokens"#,
+    );
+
+    assert_eq!(kept, 200, "the ceiling holds the whole set");
+    assert_eq!(total_available, Some(200));
+    assert!(
+        !warnings.iter().any(|w| w.starts_with("CAL-W017")),
+        "a budget that dropped nothing must not warn — silence has to keep \
+         meaning 'nothing was cut': {warnings:?}"
+    );
+}
+
+/// The plain `RECALL` under the same predicate is the control: if it also
+/// came back short the assembly's cut would not be the budget's doing.
+#[test]
+fn the_same_selection_without_assemble_is_whole() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded(&d), Some("b".to_string()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let res = ex
+        .execute(
+            r#"RECALL facts WHERE namespace = "b" LIMIT 400"#,
+            &facade,
+        )
+        .unwrap();
+    match res.result {
+        CalResultPayload::Grains {
+            grains,
+            total_available,
+        } => {
+            assert_eq!(grains.len(), 200);
+            assert_eq!(total_available, Some(200));
+        }
+        other => panic!("expected Grains, got {other:?}"),
+    }
+}

--- a/crates/areev-server/src/console.html
+++ b/crates/areev-server/src/console.html
@@ -5965,6 +5965,36 @@ function renderQuerySummary() {
   const h = el('div', 'h', head + ' ');
   h.appendChild(el('em', '', describeQuery(Q.text)));
   box.appendChild(h);
+  /* Warnings, above everything else the summary says.
+
+     CAL's contract is that silence means the query did what you asked
+     (docs/cal-reference.md §5), and every other surface honours it — the
+     bindings and the MCP tool return `warnings`, the CLI prints them to
+     stderr. The console was the one place that received them from
+     /api/cal and dropped them on the floor, which is worst here: this is
+     the surface a person reads an answer from, and a warning is precisely
+     the news that the answer is a window rather than the whole match.
+
+     Shown in plain language by default — the code prefix is developer
+     chrome, but "149 of 229 memories were left out" is not. */
+  const warns = (res.warnings || []).filter(Boolean);
+  if (warns.length) {
+    const dev = document.documentElement.classList.contains('dev');
+    const b = el('div', 'banner');
+    b.style.margin = '10px 0 2px';
+    const body = el('div', 'grow');
+    warns.forEach((w, i) => {
+      /* `CAL-W017: text` → keep the code only in developer mode. */
+      const m = /^([A-Z]{3}-W\d{3}):\s*(.*)$/s.exec(w);
+      const line = el('div', i ? 'tiny' : '');
+      if (m && !dev) line.textContent = m[2];
+      else line.textContent = w;
+      if (i) line.style.marginTop = '4px';
+      body.appendChild(line);
+    });
+    b.appendChild(body);
+    box.appendChild(b);
+  }
   const sup = gs.filter(g => g.superseded_by || rgFields(g).superseded_by).length;
   if (sup) box.appendChild(el('div', 'tiny', sup + (sup === 1 ? ' has' : ' have')
     + ' been superseded since it was written — the older wording is kept so the change stays auditable'));

--- a/docs/cal-reference.md
+++ b/docs/cal-reference.md
@@ -235,6 +235,35 @@ used to be silently dropped — `… FORMAT markdown BUDGET 900` ran at the
 labels (`a: 0.5, b: 0.3`) or an ordering chain (`a > b > c`, mapped to evenly
 spaced weights).
 
+**`BUDGET` always applies, written or not.** An `ASSEMBLE` with no `BUDGET`
+clause runs at the **4000-token default**; the ceiling is **16000 tokens**
+(`CAL-E033` above it). Neither number used to appear here, so "no `BUDGET`
+clause" read as "no budget" — and when the default bound, grains were dropped
+in silence while `total_available` reported the *post*-budget count, making a
+truncated assembly arithmetically indistinguishable from a complete one.
+
+Since 1.7.4 a budget that drops grains says so:
+
+```
+ASSEMBLE "e" FROM e: (RECALL tools WHERE namespace = "appworld.*" LIMIT 400)
+→ 70 grains, total_available: 200
+  CAL-W017: the default BUDGET 4000 tokens dropped 130 of 200 grains from
+  source(s) [e] — this assembly is a window, not the whole match.
+```
+
+`total_available` is now the **pre**-budget count, so the drop is computable
+rather than announced only in prose; each source'"'"'s `grain_count` still reports
+what survived. The default was kept rather than removed: an unbudgeted
+assembly that returned everything could overflow the context window it is
+being composed for, which is the worse failure. Silence was the defect, not
+the number.
+
+This matters most where it is least visible. A host composing a prompt from an
+assembly has no other way to detect that its rules, its policies or its recent
+turns were trimmed — it will publish a number produced from a truncated prompt
+and never know. `RECALL` has announced the same kind of cut as `CAL-W015` since
+1.5.1.
+
 **Render order is FROM-clause order, and nothing else changes it.** Sections
 appear in the order their labels are written. `PRIORITY` weights how the token
 budget is *shared*; it does not reorder. A pipeline `ORDER BY` on an assembly

--- a/docs/cal-reference.md
+++ b/docs/cal-reference.md
@@ -252,7 +252,7 @@ ASSEMBLE "e" FROM e: (RECALL tools WHERE namespace = "appworld.*" LIMIT 400)
 ```
 
 `total_available` is now the **pre**-budget count, so the drop is computable
-rather than announced only in prose; each source'"'"'s `grain_count` still reports
+rather than announced only in prose; each source's `grain_count` still reports
 what survived. The default was kept rather than removed: an unbudgeted
 assembly that returned everything could overflow the context window it is
 being composed for, which is the worse failure. Silence was the defect, not
@@ -684,7 +684,7 @@ RECALL tools WHERE input.app = "phone"
 RECALL facts WHERE object.error.code = "rate_limited"
 ```
 
-Hosts put structured payloads in grain fields constantly — a tool'"'"'s `input`,
+Hosts put structured payloads in grain fields constantly — a tool's `input`,
 an eval summary, an error envelope, an API response — and before 1.7.4 CAL
 could not filter on any of them, so a host fetched the whole set and unpacked
 it in application code. A value stored *as a JSON string* navigates
@@ -699,7 +699,7 @@ grains whose payload says otherwise nor the ones with no such key, and
 `input.app != "phone"` does not widen to everything. Like every other
 type-specific key it is an executor post-filter over the widened scan, so
 `CAL-W015` still reports a scan that filled. `ORDER BY` on a path is not
-supported. The renderer'"'"'s equivalent is the `get` filter (§6).
+supported. The renderer's equivalent is the `get` filter (§6).
 
 #### World-time validity: `valid_from` / `valid_to`
 
@@ -833,7 +833,7 @@ RECALL facts WHERE relation = "knows" | OBJECTS
 #### Frequency: `GROUP BY <field>` then `COUNT`
 
 `GROUP BY` on its own **reorders** rows so same-key grains are contiguous.
-Follow it with `COUNT` and you get one row per group carrying that group'"'"'s
+Follow it with `COUNT` and you get one row per group carrying that group's
 size, ordered **most frequent first** (ties by key ascending, so the answer is
 reproducible across backends and runs):
 
@@ -1084,7 +1084,7 @@ and titles, ticket ids, error codes and thread keys all live inside it:
 ```
 
 `get` is the one that reaches into structure. `record_tool_call` round-trips a
-tool'"'"'s `input` as parsed JSON, so a Python or Node host gets the shape for
+tool's `input` as parsed JSON, so a Python or Node host gets the shape for
 free — it was specifically the CAL path that could not see inside. (The `json`
 filter does not help despite its name: it *serialises* a value.) A path that
 does not resolve renders empty, and `get` deliberately does **not** transform:
@@ -1114,7 +1114,7 @@ A `GROUP BY <field> COUNT` result (§4) renders through a `group.` namespace:
 
 | Variable | Value |
 |---|---|
-| `{{group.key}}` | The group'"'"'s key |
+| `{{group.key}}` | The group's key |
 | `{{group.count}}` | How many grains fall in it |
 
 ```

--- a/docs/cal-reference.md
+++ b/docs/cal-reference.md
@@ -947,7 +947,11 @@ Warnings reach you as a `warnings` array of `CAL-Wnnn` strings in the result
 payload from `cal()` in Python and Node and from the MCP `areev_cal` tool, and
 alongside the payload on `POST /api/cal`. The key is present only when there is
 something to report, so a clean query returns the shape it always had. The
-`areev cal` CLI prints them to stderr instead, keeping stdout pure JSON.
+`areev cal` CLI prints them to stderr instead, keeping stdout pure JSON. The
+console shows them above the result on the Query page — in plain language, with
+the `CAL-Wnnn` code itself shown only in Developer mode, because "130 of 200
+memories were left out" is news for whoever is reading the answer while the
+code is developer chrome.
 
 `DESCRIBE`'s `with_options` lists the options that actually change a `RECALL`
 result, so a client can introspect rather than guess.


### PR DESCRIPTION
Closes #208.

## The bug

`ASSEMBLE` applies a token budget whether or not the caller writes one — `DEFAULT_BUDGET_TOKENS` is 4000 — and when it bound it discarded the tail of each source **in silence**. The payload actively hid it: `total_available` reported the *post*-budget count, so a truncated assembly was arithmetically indistinguishable from a complete one — `grains.len() == total_available` held either way.

Reproduced on a seeded memory (200 grains, `LIMIT 400`, no `BUDGET` clause):

```
ASSEMBLE "e" FROM e: (RECALL facts WHERE namespace = "b" LIMIT 400)
→ 70 grains, warnings: None, total_available: 70      # 130 grains gone, silently

… BUDGET 16000 tokens  → 200 grains                   # the ceiling
RECALL (same predicate) → 200 grains, total_available: 200
```

This is the same cut `RECALL` has announced as `CAL-W015` since 1.5.1, made without saying so. A host composing a prompt from an assembly had no way to detect that its rules, its policies or its recent turns were trimmed — it would publish a number produced from a truncated prompt and never know. That is what happened in `areev-bench`: wrapping a selection in an `ASSEMBLE` returned 79 of 229 error grains, and the small parity fixture was too small to notice.

## The fix

**1. `CAL-W017` when the budget drops grains**, naming the sources and the counts, and distinguishing a budget the caller wrote from the default that applied because none was — the two lead to different fixes:

```
CAL-W017: the default BUDGET 4000 tokens dropped 130 of 200 grains from
source(s) [e] — this assembly is a window, not the whole match. No BUDGET
clause was written, so the 4000-token default applied — write one
(ceiling 16000 tokens), or narrow the source.
```

The labels matter: "130 grains went" is not actionable on a four-source assembly without knowing which section lost them.

**2. `total_available` is the pre-budget count.** Each source's `grain_count` still reports what survived, so the drop is computable rather than announced only in prose. The console already renders `total_available > shown` as "N match in total", so it starts telling the truth for assemblies with no change there.

**3. Docs state the numbers.** `docs/cal-reference.md` now gives the 4000 default and the 16000 ceiling where `BUDGET` is documented — neither appeared there, so "no `BUDGET` clause" read as "no budget".

## On the ticket's open question

The issue asks whether an unbudgeted `ASSEMBLE` should default to *no* trimming. **I kept the default**, deliberately:

- An unbudgeted assembly that returned everything could overflow the context window it is being composed for — the worse failure, and silent in its own way.
- Progressive disclosure degrading a section is the point of having a budget at all.
- It would change behaviour for every existing caller, where the warning fixes the actual defect without moving anyone's results.

Silence was the defect, not the number.

## Detail

The post-dedup 2000-grain cap already warns for itself, so its tail is folded into the omitted set for `ELEMENT_OMIT` without double-reporting under W017.

## Tests

`crates/areev-cal/tests/assemble_budget_visibility.rs`, four cases:

- an unbudgeted assemble reports what its default dropped — `total_available` is 200 not 70, `CAL-W017` present, naming `[e]` and the default;
- an explicit `BUDGET 4000` names itself, **not** the default;
- **a budget that fits stays silent** — so silence keeps meaning "nothing was cut";
- the same selection without `ASSEMBLE` is whole (the control: if plain `RECALL` also came back short, the assembly's cut would not be the budget's doing).

The fixture seeds **200 grains past the default** on purpose — a fixture too small to bind is exactly why this shipped.

`cargo test --workspace`: **134 suites green**. `cargo clippy --workspace --all-targets`: clean.

## Known gap, not introduced here

The console's Query page does not display CAL warnings — any of them, W001 through W017. The warning does reach `POST /api/cal`'s payload; it is the UI that drops it. That is a pre-existing gap across all seventeen warnings rather than something this PR adds, and closing it is a console change (with the screenshot re-shoot that implies), so I left it out. Worth its own issue if wanted.

## Docs

`docs/cal-reference.md` §3.1 (the `BUDGET` default, the ceiling, and the warning), `ERROR_CODES.md` (`CAL-W017`, append-only), `crates/areev-cal/CLAUDE.md`, `CHANGELOG.md`.

https://claude.ai/code/session_01JEcv3k8mMwZ5YAa26jdLc2