### PR TITLE
cal: summarise by frequency, extract from text, navigate a payload

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1856,6 +1856,64 @@ the first read-write open; a `--read-only` open of a schema that predates it
 refuses by name (`STO-E005`) rather than keying lookups on a column that is
 not there. Reference: `crates/areev-store/CLAUDE.md` ("Schema").
 
+### CAL grows by closed sets, because conformance is what makes it portable
+
+**Decision (2026-09-08, issues #209/#210/#211):** CAL gains the ability to
+summarise by frequency, to extract part of a value, and to navigate into a
+structured payload — and it gains all three by **extending closed sets**, never
+by opening one. The spec record is
+[`docs/oms-1.7-amendments-cal-expressiveness.md`](docs/oms-1.7-amendments-cal-expressiveness.md).
+
+Each addition was a read a host could only perform by over-fetching and
+finishing the job in application code — which also defeats `BUDGET`, because
+the budget is spent on the rows the host is about to discard. "Which tool fails
+most" is the ordinary summarisation read of any agent memory; titles and error
+codes live inside the free text a memory stores; and `record_tool_call` already
+round-trips a tool's `input` as parsed JSON, so Python and Node hosts received a
+structure the *query language* alone could not see inside.
+
+What is refused, and stays refused, is the general version of each:
+
+- **Host-registered functions.** A saved template calling one would render
+  differently — or fail — depending on who opened the memory, because the
+  registry travels *with the file*. That portability is the property that makes
+  saved queries worth having; a function library trades it away.
+- **A general expression language in templates.** It needs its own sandbox and
+  its own spec, and it makes "what will this saved query show me?" a
+  program-analysis question rather than a reading comprehension one. Saved-query
+  bodies get an extra read-only verification pass precisely because the surface
+  is narrow, and those bodies are handed to unattended agents.
+- **Parse → mutate → re-serialise.** The tempting shape in #211 ("read
+  `error.code`, drop that key, re-emit the rest") is a program. Its real use is
+  reshaping on the way out, which is better served by writing the right shape
+  in — two fields rather than one payload — because that also makes the value
+  **filterable**, which no amount of render machinery does.
+
+So the additions are enumerable and introspectable: `DESCRIBE CAPABILITIES`
+reports the filter set and the variable namespaces, and a client can ask rather
+than guess. Two properties fall out and are load-bearing:
+
+**Authoring-time validation, render-time totality.** A pattern that does not
+compile, a `split` index that is not a number, a path past its depth bound —
+refused when the template is *defined*. At render time every filter is total: a
+filter that finds nothing yields empty, never an error, because one unparseable
+grain must not fail the render of the other 199. The two rules are complements,
+not a compromise: unreadable queries never get stored, so the render path never
+needs to fail.
+
+**Patterns run on a non-backtracking engine.** A template renders on every turn
+over host- and model-supplied text; a backtracking regex there is a
+denial-of-service primitive. Areev uses `regex`, a finite-automaton engine —
+which is *why* the dialect has no backreferences and no lookaround, those being
+exactly the constructs that force backtracking. That is a capability the safety
+argument depends on, not a limitation to apologise for.
+
+One thing this batch deliberately did not need: new syntax for the common case.
+`GROUP BY <field>` followed by `COUNT` already parsed — it just answered the
+plain total, discarding the grouping, which is `COUNT` with extra words. Giving
+that combination the meaning it should always have had costs no caller anything
+and asks nothing of the spec beyond a semantic note.
+
 ### Portability and provenance over lock-in
 
 Grains are content-addressed, immutable, and hash-linked; the format reserves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,89 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **CAL can summarise by frequency, extract from text, and navigate a JSON
+  payload** (#209, #210, #211) — three reads that could only be done by
+  over-fetching and finishing the job in host code, which also defeated
+  `BUDGET` (the budget was spent on the rows about to be discarded). The
+  spec-level decisions are recorded in
+  [`docs/oms-1.7-amendments-cal-expressiveness.md`](docs/oms-1.7-amendments-cal-expressiveness.md).
+
+  **Per-group counts** (#209). `GROUP BY <field>` followed by `COUNT` now
+  projects one row per group carrying its size, **most frequent first** (ties
+  by key ascending, so the answer is reproducible across backends and runs):
+
+  ```sql
+  RECALL tools WHERE is_error = true LIMIT 400 GROUP BY tool_name COUNT
+  ```
+
+  That combination previously returned the plain total — identical to `COUNT`
+  alone, silently discarding the grouping — so **no new syntax was needed**
+  and no meaningful answer is taken away. Frequency is how a memory says what
+  *matters*: "which tool fails most", "which topic does this user raise most",
+  "which policy is cited most". Render it with the new `group.*` template
+  variables (`{{group.count}}x {{group.key}}`), or make an `ASSEMBLE` source
+  of it so a frequency roll-up is a *section of a prompt*.
+
+  **Extracting filters** (#210): `first_line`, `split("<sep>", n)`,
+  `strip_prefix`, `strip_suffix`, `between("<open>", "<close>")`, and
+  `match("<pattern>"[, n])`. Memories store text people wrote, and titles,
+  ticket ids, error codes and thread keys all live inside it:
+
+  ```
+  {{grain.object | between("[", "]")}}     → Q3 close handoff
+  ```
+
+  **A JSON path accessor** (#211), in both a render and a filter:
+
+  ```
+  {{grain.object | get("error.code")}}     → rate_limited
+  ```
+  ```sql
+  RECALL tools WHERE input.app = "phone"
+  RECALL facts WHERE object.error.code = "rate_limited"
+  ```
+
+  `record_tool_call` round-trips a tool'"'"'s `input` as parsed JSON, so Python
+  and Node hosts already received the structure — it was specifically the CAL
+  path that could not see inside. A field name may now be a dotted path of up
+  to 8 segments (it accepted one dot before, which did not reach the shape a
+  stored error envelope actually has), and a value stored *as a JSON string*
+  navigates identically to a parsed one. **A path that does not resolve is
+  UNKNOWN**, so navigation inherits the fails-closed rule rather than adding
+  one: `input.app != "phone"` does not widen to everything.
+
+  The filter set stays **closed** — `DESCRIBE CAPABILITIES` reports it, and
+  OMS conformance means two implementations must render a grain identically.
+  Bad arguments are refused when the template is *defined* (`CAL-E049`), not
+  when it renders, so "what will this saved query show me?" stays answerable
+  by reading it; rendering itself stays total, because one unparseable grain
+  must not fail the render of the other 199. `match` uses a non-backtracking
+  engine — no backreferences, no lookaround — because a template runs over
+  untrusted grain content on every turn, where a backtracking regex is a
+  denial-of-service primitive. Patterns are length-capped and compiled through
+  a bounded cache; extractor input is clipped at 64 KiB; paths are
+  depth-capped.
+
+  Deliberately **not** added: host-registered functions (a template calling
+  one would render differently depending on who opened the file, breaking the
+  property that makes saved queries worth having — the registry travels *with*
+  the memory), a general expression language in templates, and any
+  transformation that parses, mutates and re-serialises. For new corpora the
+  paved road is still to store the shape you want to read: two fields rather
+  than one payload, which makes the value filterable as well as renderable.
+
+### Fixed
+
+- **An `ASSEMBLE` source can carry its own pipeline, and no longer drops a
+  nested assembly'"'"'s grains.** Sources had no pipeline at all, so a source
+  could not be ranked, bounded or summarised in place. Separately,
+  `assemble.rs` carried a **second copy** of `extract_grains` that had drifted
+  from the executor'"'"'s: it saw only the `Grains` payload, so a nested
+  `Assembled` result silently contributed nothing to the enclosing assembly.
+  There is now one extractor.
+
 ### Fixed
 
 - **A `WHERE` predicate on a field the grain does not carry no longer matches

--- a/crates/areev-cal/CLAUDE.md
+++ b/crates/areev-cal/CLAUDE.md
@@ -47,6 +47,40 @@ composite gates, where an absent field means "this member has not fired" — a
 definite FALSE, not UNKNOWN. `gate_satisfied` therefore materializes every
 `referenced_members` name rather than projecting only the fired ones.
 
+**Summarise / extract / navigate (#209/#210/#211, 1.7.4).** Three additions,
+one spec decision, recorded in
+[`docs/oms-1.7-amendments-cal-expressiveness.md`](../../docs/oms-1.7-amendments-cal-expressiveness.md):
+
+- `GROUP BY <field>` then `COUNT` projects one row per group
+  (`CalResultPayload::GroupCounts`, most frequent first, ties by key asc). The
+  rows are `CalGrainResult`s with `grain_type "group"`, fields `{key, count}`
+  and an **empty hash** — a group is computed, not stored, and anything keying
+  on a content address must skip it. **No new syntax**: that combination used
+  to answer the plain total, which is `COUNT` with extra words. Rendered via
+  the `group.` template namespace (`GROUP_VARIABLES`, closed at `key`/`count`,
+  bound only on a group row).
+- `KNOWN_FILTERS` grows by seven: six extractors and `get` (a dotted JSON
+  path). The list stays **closed** — `DESCRIBE CAPABILITIES` reports it. Bad
+  arguments are refused in `parse_single_filter` (define time, `CAL-E049`), not
+  at render time, so rendering stays total and a saved template stays readable.
+  `match` compiles through `cached_pattern` (bounded LRU, `regex` — a
+  finite-automaton engine, so no backtracking and therefore no backreferences
+  or lookaround). Bounds: `MAX_EXTRACT_INPUT`, `MAX_PATTERN_LEN`,
+  `MAX_GET_PATH_DEPTH`.
+- `WHERE` accepts a dotted field path up to `MAX_FIELD_PATH_SEGMENTS` (8),
+  resolved in `resolve_grain_field`. A field holding JSON **as a string**
+  navigates identically to a parsed one. An unresolvable path is `None` →
+  UNKNOWN → no match, so navigation inherits the fails-closed rule above
+  rather than adding one. Keep the three depth constants (parser, executor,
+  templates) equal: a path that parses must be one the executor walks and a
+  template can express.
+
+An `ASSEMBLE` **source** now carries its own `pipeline` (`NamedSource`), run in
+`execute_source` before dedup and budgeting — that is what lets a frequency
+roll-up be a prompt section. `extract_grains` lives in `executor.rs` and is
+`pub(crate)`; `assemble.rs` used to keep a second copy that had drifted (it saw
+only `Grains`, so a nested `Assembled` contributed nothing). One extractor.
+
 **World-time validity is queryable (#206, 1.7.4).** `valid_from`/`valid_to`/
 `system_valid_from`/`system_valid_to` are `GrainCommon` fields on every type,
 already serialized and expanded back into `fields` — they were simply missing

--- a/crates/areev-cal/src/assemble.rs
+++ b/crates/areev-cal/src/assemble.rs
@@ -46,7 +46,11 @@ use std::time::Instant;
 
 use super::ast::{AssembleStmt, AssembleWithOption, CalQuery, NamedSource, PrioritySpec};
 use super::errors::CalError;
-use super::executor::{CalExecutor, CalGrainResult, CalResultPayload};
+// `extract_grains` is the executor's, not a local copy. There used to be two,
+// and they had drifted: this module's saw only `Grains`, so an `Assembled`
+// payload from a nested source silently contributed nothing — and #209's
+// group rows would have done the same.
+use super::executor::{extract_grains, CalExecutor, CalGrainResult, CalResultPayload};
 use super::facade::CalStoreFacade;
 
 // ---------------------------------------------------------------------------
@@ -407,7 +411,11 @@ impl<'a> AssembleEngine<'a> {
             let_values: query.let_values.clone(),
             version: query.version,
             statement: *source.query.clone(),
-            pipeline: Vec::new(),
+            // The source's OWN pipeline (#209), written inside its parens.
+            // The enclosing query's pipeline runs on the assembled result and
+            // is a different thing — this one ranks, bounds or summarises the
+            // section, which is what lets a frequency roll-up BE a section.
+            pipeline: source.pipeline.clone(),
             with_options,
             format: None,
             let_bindings: Vec::new(),
@@ -421,6 +429,19 @@ impl<'a> AssembleEngine<'a> {
             &surrogate,
             warnings,
         )?;
+
+        // The source's own pipeline runs here, on this source's grains, before
+        // dedup and budgeting see them. `GROUP BY <field> COUNT` in a source
+        // therefore contributes ONE row per group — a frequency roll-up as a
+        // prompt section, rather than a read the host performs separately and
+        // splices in.
+        let payload = if source.pipeline.is_empty() {
+            payload
+        } else {
+            self.executor
+                .apply_pipeline(payload, &source.pipeline, warnings)?
+                .0
+        };
 
         Ok(extract_grains(payload))
     }
@@ -715,17 +736,6 @@ pub fn estimate_grain_tokens(grain: &CalGrainResult) -> u32 {
         created_at_sec: crate::render::created_at_sec_from_fields(&grain.fields),
     };
     crate::render::estimate_tokens(&view, crate::render::MetadataDetail::None) as u32
-}
-
-// ---------------------------------------------------------------------------
-// Helper: extract grains from a CalResultPayload
-// ---------------------------------------------------------------------------
-
-fn extract_grains(payload: CalResultPayload) -> Vec<CalGrainResult> {
-    match payload {
-        CalResultPayload::Grains { grains, .. } => grains,
-        _ => Vec::new(),
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/areev-cal/src/ast.rs
+++ b/crates/areev-cal/src/ast.rs
@@ -417,6 +417,17 @@ pub struct NamedSource {
     /// these override the parent query's with_options for this source.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub with_options: Vec<WithOption>,
+    /// Pipeline stages written INSIDE the source's parens, applied to that
+    /// source's grains before dedup and budgeting.
+    ///
+    /// A source is a query, and a query's answer may need ranking, bounding
+    /// or summarising — `ORDER BY`, `LIMIT`, and above all `GROUP BY <field>
+    /// COUNT` (#209), so "the five errors this agent hits most" can be a
+    /// *section of a prompt* rather than a separate read the host tallies and
+    /// splices in itself. The enclosing query's own pipeline still runs on
+    /// the assembled result and is a different thing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pipeline: Vec<PipelineStage>,
     #[serde(skip)]
     pub span: Option<Span>,
 }

--- a/crates/areev-cal/src/executor.rs
+++ b/crates/areev-cal/src/executor.rs
@@ -201,6 +201,31 @@ pub enum CalResultPayload {
     Exists { exists: bool, hash: String },
     /// Result of a `| COUNT` pipeline stage.
     Count { count: usize },
+    /// Result of `GROUP BY <field>` followed by `COUNT` — one row per group,
+    /// **most frequent first** (#209).
+    ///
+    /// "The five errors this agent hits most" is the ordinary summarisation
+    /// read of any agent memory — which tool fails most, which topic a user
+    /// raises most, which policy is cited most — and it used to be host code,
+    /// because `GROUP BY` only *reordered* rows. Worse, `GROUP BY x COUNT`
+    /// answered the plain total, identical to `COUNT` alone: a well-formed
+    /// number that ignored the grouping.
+    ///
+    /// `groups` are `CalGrainResult`s rather than a bespoke row type on
+    /// purpose. Every downstream consumer — the renderers, `extract_grains`,
+    /// an `ASSEMBLE` source — then works unchanged, and a template reaches
+    /// them through `{{group.key}}` / `{{group.count}}`. Each carries
+    /// `grain_type: "group"` and fields `{key, count}`; the hash is empty
+    /// because a group is computed, not stored, and must never be mistaken
+    /// for a grain.
+    GroupCounts {
+        /// The field the rows were grouped by.
+        field: String,
+        /// One synthetic row per group.
+        groups: Vec<CalGrainResult>,
+        /// Number of groups.
+        total_available: Option<usize>,
+    },
     /// Result of `GRANT` (CAL 1.3 §8.15).
     Granted { principal: String, object: String, hash: String },
     /// Result of `REVOKE`.
@@ -3685,6 +3710,15 @@ impl CalExecutor {
                     "max_let_bindings": caps.max_let_bindings,
                     "max_budget_tokens": caps.max_budget_tokens,
                     "tier1_enabled": self.config.tier1_enabled,
+                    // The template filter set (#210/#211). It is a CLOSED
+                    // list, and a client that can read it does not have to
+                    // guess whether this host supports the filter its saved
+                    // template needs — which is the whole reason the set is
+                    // closed rather than open.
+                    "template_filters": super::templates::KNOWN_FILTERS,
+                    // The `group.` namespace (#209) — reported alongside, for
+                    // the same reason.
+                    "template_variable_namespaces": ["grain", "assembly", "budget", "source", "group"],
                     "oms_version": "1.2"
                 })
             }
@@ -4953,7 +4987,10 @@ impl CalExecutor {
         Ok(())
     }
 
-    fn apply_pipeline(
+    /// `pub(crate)` so `AssembleEngine` can run a SOURCE's own pipeline
+    /// (#209) — the enclosing query's pipeline runs on the assembled result,
+    /// which is a different thing.
+    pub(crate) fn apply_pipeline(
         &self,
         payload: CalResultPayload,
         stages: &[PipelineStage],
@@ -4985,10 +5022,29 @@ impl CalExecutor {
                     }
                 }
 
-                // COUNT
+                // COUNT — per group when a GROUP BY came first (#209),
+                // otherwise the plain total.
+                //
+                // `GROUP BY x COUNT` used to answer the same scalar as
+                // `COUNT` alone, silently discarding the grouping. Nothing
+                // could have wanted that number: it is `COUNT` with extra
+                // words. So projecting one row per group here takes no
+                // meaningful answer away from anyone, and needs no new
+                // syntax — which matters, because new CAL syntax is an OMS
+                // conformance decision.
                 (CalResultPayload::Grains { grains, .. }, PipelineStage::Count { .. }) => {
-                    CalResultPayload::Count {
-                        count: grains.len(),
+                    match grouped_by.as_deref() {
+                        Some(field) => {
+                            let groups = count_by_field(&grains, field);
+                            CalResultPayload::GroupCounts {
+                                field: field.to_string(),
+                                total_available: Some(groups.len()),
+                                groups,
+                            }
+                        }
+                        None => CalResultPayload::Count {
+                            count: grains.len(),
+                        },
                     }
                 }
 
@@ -5523,6 +5579,7 @@ fn payload_kind_name(payload: &CalResultPayload) -> &'static str {
     match payload {
         CalResultPayload::Assembled { .. } => "assembled",
         CalResultPayload::Count { .. } => "count",
+        CalResultPayload::GroupCounts { .. } => "group counts",
         CalResultPayload::Formatted { .. } => "formatted",
         CalResultPayload::Exists { .. } => "exists",
         CalResultPayload::History { .. } => "history",
@@ -5546,6 +5603,10 @@ fn inert_stage_reason(payload: &CalResultPayload) -> &'static str {
              that source's sub-query"
         }
         CalResultPayload::Count { .. } => "a count is a scalar; stage it before | COUNT",
+        CalResultPayload::GroupCounts { .. } => {
+            "a grouped count is already one row per group, ordered most \
+             frequent first; stage it before GROUP BY … COUNT"
+        }
         CalResultPayload::Formatted { .. } => {
             "FORMAT has already rendered the grains to text; stage it before FORMAT"
         }
@@ -5585,6 +5646,7 @@ fn count_payload_results(payload: &CalResultPayload) -> usize {
         CalResultPayload::Grains { grains, .. } => grains.len(),
         CalResultPayload::Exists { .. } => 1,
         CalResultPayload::Count { .. } => 1,
+        CalResultPayload::GroupCounts { groups, .. } => groups.len(),
         CalResultPayload::History { versions } => versions.len(),
         CalResultPayload::Describe { .. } => 1,
         CalResultPayload::Explain { .. } => 1,
@@ -5625,10 +5687,15 @@ fn count_payload_results(payload: &CalResultPayload) -> usize {
 }
 
 /// Extract a Vec<CalGrainResult> from a payload (for set operations).
-fn extract_grains(payload: CalResultPayload) -> Vec<CalGrainResult> {
+pub(crate) fn extract_grains(payload: CalResultPayload) -> Vec<CalGrainResult> {
     match payload {
         CalResultPayload::Grains { grains, .. } => grains,
         CalResultPayload::Assembled { grains, .. } => grains,
+        // #209 — an ASSEMBLE source may be a grouped count, so "the five
+        // errors this agent hits most" can be a *section of a prompt* rather
+        // than a separate read the host tallies itself. This is the
+        // `execute_source` discard the issue names.
+        CalResultPayload::GroupCounts { groups, .. } => groups,
         _ => Vec::new(),
     }
 }
@@ -5968,6 +6035,10 @@ fn apply_format_clause(
     // and flattening it here is what previously made them unreachable.
     let (grains, assembled) = match &payload {
         CalResultPayload::Grains { grains, .. } => (grains, None),
+        // Group rows render like any other row (#209) — they ARE
+        // `CalGrainResult`s, so `FORMAT markdown` on a grouped count is the
+        // same code path as `FORMAT markdown` on a recall.
+        CalResultPayload::GroupCounts { groups, .. } => (groups, None),
         CalResultPayload::Assembled {
             grains,
             sources,
@@ -6548,6 +6619,40 @@ fn group_grains_by_field(grains: Vec<CalGrainResult>, field: &str) -> Vec<CalGra
 
 /// Collect already-grouped grains into `(key, members)` pairs by detecting
 /// contiguous runs of the same field value.
+/// Project one row per group, carrying that group's size — the #209
+/// projection.
+///
+/// **Most frequent first**, ties broken by key ascending. Frequency is the
+/// point ("which tool fails most"), and a deterministic tiebreak is what
+/// makes the answer reproducible across backends and across runs — a
+/// conformance property, not a nicety.
+///
+/// Reuses `collect_groups`, so it sees the same groups a grouped render does:
+/// one grouping, one set of keys.
+fn count_by_field(grains: &[CalGrainResult], field: &str) -> Vec<CalGrainResult> {
+    let mut rows: Vec<(String, usize)> = collect_groups(grains, field)
+        .into_iter()
+        .map(|(key, members)| (key, members.len()))
+        .collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    rows.into_iter()
+        .map(|(key, count)| CalGrainResult {
+            // Empty: a group is computed, not stored. Anything that keys on a
+            // content address (dedup above all) must skip it rather than
+            // treat a synthetic row as a grain.
+            hash: String::new(),
+            grain_type: "group".to_string(),
+            score: 0.0,
+            fields: serde_json::json!({ "key": key, "count": count }),
+            score_breakdown: None,
+            explanation: None,
+            relative_time: None,
+            is_deterministic: true,
+            contested_by: None,
+        })
+        .collect()
+}
+
 fn collect_groups<'a>(
     grains: &'a [CalGrainResult],
     field: &str,
@@ -6872,6 +6977,25 @@ fn validate_residual_leaf(
     if field.contains(':') {
         return Ok(());
     }
+    // A dotted path navigates INTO a structured field (#211): `input.app` is
+    // the field `input` and a path within its JSON. Validate the base — the
+    // path itself cannot be validated, because the shape lives in the
+    // payload, not in the schema. Depth is bounded here rather than at the
+    // scan, so an absurd path is refused before it costs anything.
+    let (field, path_depth) = match field.split_once('.') {
+        Some((base, rest)) => (base, 1 + rest.split('.').count()),
+        None => (field, 1),
+    };
+    if path_depth > MAX_FIELD_PATH_DEPTH {
+        return Err(CalError::FieldNotOnGrainType {
+            field: field.to_string(),
+            grain_type: grain_type.as_str().to_string(),
+            span,
+            suggestion: Some(format!(
+                "a field path may be at most {MAX_FIELD_PATH_DEPTH} segments deep"
+            )),
+        });
+    }
     if ENGINE_ONLY_FIELDS.contains(&field) {
         return Err(CalError::EngineFieldNotFilterable {
             field: field.to_string(),
@@ -6948,7 +7072,64 @@ fn resolve_grain_field(grain: &CalGrainResult, field: &str) -> Option<serde_json
         }
         _ => {}
     }
+    // A dotted path navigates into a structured field (#211). `input.app`
+    // reads the Tool grain's parsed `input` payload — which the engine
+    // already round-trips as JSON, so a Python or Node host got the structure
+    // for free while CAL alone could not see inside.
+    //
+    // A path that does not resolve yields None, which since #207 means
+    // UNKNOWN: `WHERE input.app = "phone"` matches neither the grains whose
+    // payload says otherwise nor the ones that have no such key. That is the
+    // fails-closed reading, and it falls out of the two changes composing
+    // rather than needing a rule of its own.
+    if let Some((base, path)) = field.split_once('.') {
+        let root = json_field(&grain.fields, base)?;
+        // Two shapes reach here and both must work. A Tool's `input` is
+        // already a parsed object — `record_tool_call` round-trips it as JSON,
+        // which is exactly why a Python or Node host could see inside it while
+        // CAL could not. A `fails_with` signature is a JSON *document stored
+        // as a string*. Navigating one and not the other would make the
+        // accessor depend on how the writer happened to type the field.
+        let parsed;
+        let root = match root {
+            serde_json::Value::String(text) => {
+                parsed = serde_json::from_str::<serde_json::Value>(text).ok()?;
+                &parsed
+            }
+            other => other,
+        };
+        return navigate_json_path(root, path).cloned();
+    }
     json_field(&grain.fields, field).cloned()
+}
+
+/// Maximum segments in a `WHERE` field path (`input.a.b` is three).
+const MAX_FIELD_PATH_DEPTH: usize = 8;
+
+/// Walk a dotted path into a JSON value. A numeric segment indexes an array,
+/// so `items.0.name` needs no separate syntax.
+///
+/// The `WHERE`-side twin of the template `get` filter — same path grammar
+/// (dotted, no wildcards, no predicates, no arithmetic) and the same bound,
+/// because a caller who can navigate a payload in a render and not in a
+/// filter has to over-fetch anyway, which is the cost the accessor exists to
+/// remove.
+fn navigate_json_path<'a>(
+    root: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let mut cur = root;
+    for (depth, seg) in path.split('.').enumerate() {
+        if depth >= MAX_FIELD_PATH_DEPTH {
+            return None;
+        }
+        cur = match cur {
+            serde_json::Value::Object(m) => m.get(seg)?,
+            serde_json::Value::Array(a) => a.get(seg.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(cur)
 }
 
 /// Does this grain carry `field` at all?
@@ -7155,23 +7336,21 @@ fn grain_condition_truth(grain: &CalGrainResult, condition: &Condition) -> Optio
         Condition::IsNull { field, .. } => Some(!grain_carries_field(grain, field)),
         Condition::IsNotNull { field, .. } => Some(grain_carries_field(grain, field)),
         Condition::Contains { field, value, .. } => {
-            if !grain_carries_field(grain, field) {
-                return None;
-            }
+            // Through the ONE resolver, so a dotted path (#211) and the
+            // envelope properties behave the same here as under `=`.
+            let v = resolve_grain_field(grain, field)?;
             Some(
-                json_field(&grain.fields, field)
-                    .and_then(|v| v.as_str())
+                v.as_str()
                     .map(|s| s.contains(value.as_str()))
                     .unwrap_or(false),
             )
         }
         Condition::StartsWith { field, value, .. } => {
-            if !grain_carries_field(grain, field) {
-                return None;
-            }
+            // Through the ONE resolver, so a dotted path (#211) and the
+            // envelope properties behave the same here as under `=`.
+            let v = resolve_grain_field(grain, field)?;
             Some(
-                json_field(&grain.fields, field)
-                    .and_then(|v| v.as_str())
+                v.as_str()
                     .map(|s| s.starts_with(value.as_str()))
                     .unwrap_or(false),
             )
@@ -7179,12 +7358,9 @@ fn grain_condition_truth(grain: &CalGrainResult, condition: &Condition) -> Optio
         Condition::IsCategory {
             field, category, ..
         } => {
-            if !grain_carries_field(grain, field) {
-                return None;
-            }
+            let v = resolve_grain_field(grain, field)?;
             Some(
-                json_field(&grain.fields, field)
-                    .and_then(|v| v.as_str())
+                v.as_str()
                     .map(|s| s.eq_ignore_ascii_case(category))
                     .unwrap_or(false),
             )
@@ -11112,6 +11288,7 @@ mod tests {
                 pinned: false,
                 query: Box::new(CalStatement::Recall(recall_facts)),
                 with_options: vec![],
+                pipeline: vec![],
                 span: None,
             }]),
             budget: None,
@@ -11193,6 +11370,7 @@ mod tests {
                 pinned: false,
                 query: Box::new(CalStatement::Recall(recall_facts)),
                 with_options: vec![],
+                pipeline: vec![],
                 span: None,
             }]),
             budget: None,
@@ -11273,6 +11451,7 @@ mod tests {
                 pinned: false,
                 query: Box::new(CalStatement::Recall(recall_facts)),
                 with_options: vec![],
+                pipeline: vec![],
                 span: None,
             }]),
             budget: None,

--- a/crates/areev-cal/src/parser.rs
+++ b/crates/areev-cal/src/parser.rs
@@ -97,6 +97,14 @@ const MAX_IN_SET_SIZE: usize = 100;
 /// Maximum pipeline stages in a single query.
 const MAX_PIPELINE_STAGES: usize = 5;
 
+/// Maximum segments in a dotted field path (`input.error.code` is three).
+///
+/// Matches the executor's `MAX_FIELD_PATH_DEPTH` and the template `get`
+/// filter's `MAX_GET_PATH_DEPTH`: a path that parses must be a path the
+/// executor will walk, and a path a template can render must be one a filter
+/// can express.
+const MAX_FIELD_PATH_SEGMENTS: usize = 8;
+
 /// Maximum operands in a UNION / INTERSECT / EXCEPT chain.
 const MAX_SET_OPERANDS: usize = 4;
 
@@ -1505,12 +1513,19 @@ impl Parser {
     ///
     /// Scoped to the assemble-source path only — `parse_paren_statement` is
     /// shared with the set-op operand path and must NOT change.
-    fn parse_assemble_source_query(&mut self) -> CalResult<(CalStatement, Vec<WithOption>)> {
+    fn parse_assemble_source_query(
+        &mut self,
+    ) -> CalResult<(CalStatement, Vec<WithOption>, Vec<PipelineStage>)> {
         if self.at_exact(&Token::LParen) {
             self.expect_exact(&Token::LParen)?;
             self.enter_nesting()?;
             // parse_statement already consumes any UNION/INTERSECT/EXCEPT set-op tail.
             let stmt = self.parse_statement()?;
+            // Pipeline stages INSIDE the parens belong to this source (#209),
+            // not to the assembly: `(RECALL tools … GROUP BY tool_name COUNT)`
+            // is a frequency summary rendered as one section. The enclosing
+            // query's own pipeline still runs on the assembled result.
+            let pipeline = self.parse_pipeline()?;
             self.leave_nesting();
             // Optional inside-paren WITH (not WITH VARS).
             let inside_with = if self.at_exact(&Token::With) && !self.peek_next_is_vars() {
@@ -1519,11 +1534,13 @@ impl Parser {
                 vec![]
             };
             self.expect_exact(&Token::RParen)?;
-            Ok((stmt, inside_with))
+            Ok((stmt, inside_with, pipeline))
         } else {
-            // Bare RECALL with no parens — no inside-paren WITH possible.
+            // Bare RECALL with no parens — no inside-paren WITH possible, and
+            // no pipeline either: without the parens there is nothing to say
+            // whether a trailing stage binds to the source or to the assembly.
             let stmt = self.parse_recall_stmt()?;
-            Ok((CalStatement::Recall(stmt), vec![]))
+            Ok((CalStatement::Recall(stmt), vec![], vec![]))
         }
     }
 
@@ -2355,16 +2372,38 @@ impl Parser {
 
     /// Parse a field name — either an `Ident` token or a dotted path.
     ///
-    /// Returns the field as a string (e.g. `"subject"`, `"metadata.source"`).
+    /// Returns the field as a string (e.g. `"subject"`, `"metadata.source"`,
+    /// `"input.error.code"`).
+    ///
+    /// The path may be up to [`MAX_FIELD_PATH_SEGMENTS`] segments (#211): a
+    /// structured payload nests, and one dot only reached the first level of
+    /// it — `object.error.code`, the shape a stored error envelope actually
+    /// has, did not parse. The bound is a bound, not a shape: no wildcards,
+    /// no predicates, no arithmetic. The executor resolves the path against
+    /// the field's JSON, and a segment that does not resolve is UNKNOWN, so
+    /// navigation inherits the fails-closed rule rather than adding one.
     fn parse_field_name(&mut self) -> CalResult<String> {
-        let first = self.parse_identifier()?;
-        if self.at_exact(&Token::Dot) {
+        let mut path = self.parse_identifier()?;
+        let mut segments = 1usize;
+        while self.at_exact(&Token::Dot) {
+            if segments >= MAX_FIELD_PATH_SEGMENTS {
+                let found = self.peek();
+                return Err(CalError::UnexpectedToken {
+                    expected: format!(
+                        "at most {MAX_FIELD_PATH_SEGMENTS} segments in a field path                          (got {path:?})"
+                    ),
+                    found: ".".into(),
+                    span: found.map(|t| t.span),
+                    suggestion: None,
+                });
+            }
             self.advance();
-            let second = self.parse_identifier()?;
-            Ok(format!("{}.{}", first, second))
-        } else {
-            Ok(first)
+            let next = self.parse_identifier()?;
+            path.push('.');
+            path.push_str(&next);
+            segments += 1;
         }
+        Ok(path)
     }
 
     // -- PIPELINE ---------------------------------------------------------
@@ -3885,6 +3924,9 @@ impl Parser {
                         })),
                         literal: Some(text),
                         pinned,
+                        // A literal is host text, not a query — nothing to
+                        // rank, bound or summarise.
+                        pipeline: Vec::new(),
                         with_options: Vec::new(),
                         span: Some(sspan),
                     });
@@ -3895,7 +3937,7 @@ impl Parser {
                 }
                 // Parse the sub-query (in parentheses or bare RECALL),
                 // accepting an optional WITH clause INSIDE the parens.
-                let (query, inside_with) = self.parse_assemble_source_query()?;
+                let (query, inside_with, pipeline) = self.parse_assemble_source_query()?;
                 // Parse optional outside-paren WITH options (back-compat).
                 let mut with_options = inside_with;
                 let outside_with = if self.at_exact(&Token::With) && !self.peek_next_is_vars() {
@@ -3910,6 +3952,7 @@ impl Parser {
                     literal: None,
                     pinned,
                     with_options,
+                    pipeline,
                     span: Some(sspan),
                 });
                 if !self.eat_exact(&Token::Comma) {

--- a/crates/areev-cal/src/templates.rs
+++ b/crates/areev-cal/src/templates.rs
@@ -80,6 +80,11 @@ const ALLOWED_FIELDS: &[&str] = &[
     "summary",
     "source_hash",
     "source_hashes",
+    // Group projection rows (#209) — `GROUP BY <field> COUNT`. Reachable as
+    // `{{group.key}}`/`{{group.count}}`; listed here because the resolver
+    // reads them out of the row's fields like any other.
+    "key",
+    "count",
     // Event
     "actor",
     "action",
@@ -180,6 +185,10 @@ const SPEC_ASSEMBLY_VARIABLES: &[&str] = &["name", "intent", "source_count", "gr
 const SPEC_BUDGET_VARIABLES: &[&str] =
     &["total", "used", "remaining", "unit", "utilization"];
 
+/// Group-level variables (the `group.` namespace, #209) — bound on the rows
+/// `GROUP BY <field> COUNT` projects, and nowhere else.
+const GROUP_VARIABLES: &[&str] = &["key", "count"];
+
 /// CAL §10.5 source-level variables (the `source.` namespace).
 const SPEC_SOURCE_VARIABLES: &[&str] = &[
     "label",
@@ -225,6 +234,11 @@ const ALL_VALID_VARIABLES: &[&str] = &[
     "summary",
     "source_hash",
     "source_hashes",
+    // Group projection rows (#209) — `GROUP BY <field> COUNT`. Reachable as
+    // `{{group.key}}`/`{{group.count}}`; listed here because the resolver
+    // reads them out of the row's fields like any other.
+    "key",
+    "count",
     // Event
     "actor",
     "action",
@@ -297,7 +311,24 @@ const ALL_VALID_VARIABLES: &[&str] = &[
 ];
 
 /// Known filter names.
-const KNOWN_FILTERS: &[&str] = &[
+///
+/// **Closed on purpose.** OMS conformance means two implementations render a
+/// grain identically, which an open function library cannot promise — so the
+/// set is enumerable and `DESCRIBE CAPABILITIES` reports it. The first ten
+/// *format* a value; the rest **take** part of one (#210/#211), which is what
+/// a memory storing text people wrote actually needs: titles, ticket ids,
+/// error codes and thread keys all live inside free text or a JSON payload,
+/// and every host that wanted one used to over-fetch and slice it in
+/// application code — spending the token budget on text it was about to throw
+/// away.
+///
+/// What is deliberately NOT here: anything that transforms and re-serialises
+/// (parse → mutate → emit). That is a program, it needs its own sandbox and
+/// its own spec, and its main use — reshaping on the way out — is better
+/// served by storing the right shape in. See `docs/oms-1.7-amendments-cal-
+/// expressiveness.md`.
+pub(crate) const KNOWN_FILTERS: &[&str] = &[
+    // Formatters.
     "truncate",
     "date",
     "relative",
@@ -308,7 +339,62 @@ const KNOWN_FILTERS: &[&str] = &[
     "json",
     "default",
     "join",
+    // Extractors (#210) — text in, part of that text out.
+    "first_line",
+    "split",
+    "strip_prefix",
+    "strip_suffix",
+    "between",
+    "match",
+    // Navigation (#211) — one scalar out of a structured payload.
+    "get",
 ];
+
+/// Longest input any extracting filter will look at, in bytes.
+///
+/// Templates already bound themselves (`MAX_TEMPLATE_SIZE`,
+/// `MAX_EACH_ITERATIONS`) because a template renders on every turn over
+/// host- and model-supplied text; an extractor needs the equivalent. A grain
+/// body longer than this is truncated before matching rather than refused —
+/// template resolution is total, and a render that errors on one long grain
+/// is worse than one that clips it.
+const MAX_EXTRACT_INPUT: usize = 64 * 1024;
+
+/// Maximum depth a `get("a.b.c")` path may walk.
+const MAX_GET_PATH_DEPTH: usize = 8;
+
+/// Compiled-pattern cache for the `match` filter.
+///
+/// `regex` is a finite-automaton engine with no backtracking, so a pattern
+/// over untrusted grain content cannot be a ReDoS primitive the way a
+/// backtracking engine would be — that property, plus this cache, is why a
+/// pattern filter is safe to render on every turn. The cache is bounded: an
+/// unbounded one is itself a memory leak driven by query text.
+static PATTERN_CACHE: std::sync::LazyLock<
+    parking_lot::Mutex<lru::LruCache<String, Option<std::sync::Arc<regex::Regex>>>>,
+> = std::sync::LazyLock::new(|| {
+    parking_lot::Mutex::new(lru::LruCache::new(
+        std::num::NonZeroUsize::new(128).expect("128 > 0"),
+    ))
+});
+
+/// Compile (or fetch) a pattern. `None` for a pattern that does not compile —
+/// the filter then yields empty, because template resolution is total.
+fn cached_pattern(pat: &str) -> Option<std::sync::Arc<regex::Regex>> {
+    let mut cache = PATTERN_CACHE.lock();
+    if let Some(hit) = cache.get(pat) {
+        return hit.clone();
+    }
+    let compiled = regex::RegexBuilder::new(pat)
+        // Bound the compiled program too: a pattern can be pathological in
+        // size even when it cannot be pathological in time.
+        .size_limit(1 << 20)
+        .build()
+        .ok()
+        .map(std::sync::Arc::new);
+    cache.put(pat.to_string(), compiled.clone());
+    compiled
+}
 
 // ---------------------------------------------------------------------------
 // Template AST types
@@ -370,8 +456,17 @@ pub enum TemplateNode {
 pub struct Filter {
     /// Filter name (e.g. "truncate", "date", "relative").
     pub name: String,
-    /// Optional argument (e.g. "80" for truncate, "%Y-%m-%d" for date).
+    /// The first argument, unquoted (e.g. "80" for truncate, "%Y-%m-%d" for
+    /// date). What every single-argument filter reads.
     pub arg: Option<String>,
+    /// Every argument, unquoted, in order — for the filters that take more
+    /// than one (`split(",", 2)`, `between("[", "]")`, `match("re", 1)`).
+    ///
+    /// Kept beside `arg` rather than replacing it because unquoting a
+    /// multi-argument list cannot be done by stripping outer quotes:
+    /// `between("[", "]")` would come back as `[", "]`. Splitting happens
+    /// once, at parse time, quote-aware.
+    pub args: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -1103,23 +1198,26 @@ fn parse_single_filter(segment: &str, tag_start: usize, tag_end: usize) -> CalRe
 
     // Split on first whitespace or opening paren to get name and optional argument.
     // Supports both `truncate 5` (space-separated) and `truncate(5)` (parenthesized).
-    let (name, arg) = if let Some(paren_idx) = segment.find('(') {
-        // Parenthesized syntax: name(arg)
+    let (name, arg, args) = if let Some(paren_idx) = segment.find('(') {
+        // Parenthesized syntax: name(arg) — and name(a, b) for the filters
+        // that take two.
         let name = segment[..paren_idx].trim();
         let rest = &segment[paren_idx + 1..];
         let close = rest.rfind(')').unwrap_or(rest.len());
         let raw_arg = rest[..close].trim();
+        let args = split_filter_args(raw_arg);
         let arg = unquote(raw_arg).unwrap_or_else(|| raw_arg.to_string());
-        (name, Some(arg))
+        (name, Some(arg), args)
     } else {
         match segment.find(|c: char| c.is_whitespace()) {
             Some(idx) => {
                 let name = &segment[..idx];
                 let raw_arg = segment[idx..].trim();
+                let args = split_filter_args(raw_arg);
                 let arg = unquote(raw_arg).unwrap_or_else(|| raw_arg.to_string());
-                (name, Some(arg))
+                (name, Some(arg), args)
             }
-            None => (segment, None),
+            None => (segment, None, Vec::new()),
         }
     };
 
@@ -1162,13 +1260,156 @@ fn parse_single_filter(segment: &str, tag_start: usize, tag_end: usize) -> CalRe
                 }
             }
         }
+        // A pattern that does not compile is an authoring mistake, not data,
+        // so it is refused HERE — when the template is defined — rather than
+        // rendering empty on every grain forever. That also makes the render
+        // path total by construction: by the time a pattern reaches
+        // `cached_pattern` it is known to compile.
+        //
+        // This is the auditability half of the bargain: "what will this saved
+        // query show me?" stays answerable by reading it, because an
+        // unreadable pattern never gets stored.
+        "match" => {
+            let parts = &args;
+            let Some(pat) = parts.first().filter(|p| !p.is_empty()) else {
+                return Err(CalError::TemplateSyntaxError {
+                    detail: "match requires a pattern, e.g. match(\"[A-Z]+-[0-9]+\")".into(),
+                    span: Some(make_span(tag_start, tag_end)),
+                });
+            };
+            if pat.len() > MAX_PATTERN_LEN {
+                return Err(CalError::TemplateSyntaxError {
+                    detail: format!(
+                        "match pattern too long ({} chars, max {MAX_PATTERN_LEN})",
+                        pat.len()
+                    ),
+                    span: Some(make_span(tag_start, tag_end)),
+                });
+            }
+            if cached_pattern(pat).is_none() {
+                return Err(CalError::TemplateSyntaxError {
+                    detail: format!(
+                        "match pattern {pat:?} does not compile. Note this is the Rust \
+                         regex dialect: no backreferences and no lookaround (they are what \
+                         make a pattern engine backtrack, and a template runs over \
+                         untrusted grain text on every turn), and `]` inside a class must \
+                         be escaped — write \\[([^\\]]+)\\] rather than [[]([^]]+)[]]"
+                    ),
+                    span: Some(make_span(tag_start, tag_end)),
+                });
+            }
+            if let Some(g) = parts.get(1) {
+                if g.parse::<usize>().is_err() {
+                    return Err(CalError::TemplateSyntaxError {
+                        detail: format!("match capture group {g:?} is not a number"),
+                        span: Some(make_span(tag_start, tag_end)),
+                    });
+                }
+            }
+        }
+        "split" => {
+            let parts = &args;
+            if parts.first().map(String::as_str).unwrap_or("").is_empty() {
+                return Err(CalError::TemplateSyntaxError {
+                    detail: "split requires a separator, e.g. split(\"]\", 0)".into(),
+                    span: Some(make_span(tag_start, tag_end)),
+                });
+            }
+            if let Some(n) = parts.get(1) {
+                if n.parse::<usize>().is_err() {
+                    return Err(CalError::TemplateSyntaxError {
+                        detail: format!("split index {n:?} is not a number"),
+                        span: Some(make_span(tag_start, tag_end)),
+                    });
+                }
+            }
+        }
+        "between" => {
+            let parts = &args;
+            if parts.len() != 2 || parts.iter().any(String::is_empty) {
+                return Err(CalError::TemplateSyntaxError {
+                    detail: "between requires two delimiters, e.g. between(\"[\", \"]\")"
+                        .into(),
+                    span: Some(make_span(tag_start, tag_end)),
+                });
+            }
+        }
+        "get" => {
+            let path = args.first().map(String::as_str).unwrap_or("");
+            if path.is_empty() {
+                return Err(CalError::TemplateSyntaxError {
+                    detail: "get requires a dotted path, e.g. get(\"error.code\")".into(),
+                    span: Some(make_span(tag_start, tag_end)),
+                });
+            }
+            let depth = path.split('.').count();
+            if depth > MAX_GET_PATH_DEPTH {
+                return Err(CalError::TemplateSyntaxError {
+                    detail: format!(
+                        "get path {path:?} is {depth} segments deep (max {MAX_GET_PATH_DEPTH})"
+                    ),
+                    span: Some(make_span(tag_start, tag_end)),
+                });
+            }
+        }
         _ => {}
     }
 
     Ok(Filter {
         name: name.to_string(),
         arg,
+        args,
     })
+}
+
+/// Longest pattern the `match` filter will compile.
+const MAX_PATTERN_LEN: usize = 512;
+
+/// Split a filter's raw argument text on top-level commas, respecting quotes,
+/// and unquote each part.
+///
+/// `"[", "]"` is two arguments, `"a, b"` is one — which is the whole reason
+/// this cannot be `raw.split(',')`, and why it cannot run over the already-
+/// unquoted `arg` either.
+fn split_filter_args(raw: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut current = String::new();
+    let mut in_quote = false;
+    let mut quote_char = '"';
+    let mut escaped = false;
+    for ch in raw.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_quote => {
+                current.push(ch);
+                escaped = true;
+            }
+            '"' | '\'' => {
+                if in_quote && ch == quote_char {
+                    in_quote = false;
+                } else if !in_quote {
+                    in_quote = true;
+                    quote_char = ch;
+                }
+                current.push(ch);
+            }
+            ',' if !in_quote => {
+                out.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.trim().is_empty() || !out.is_empty() {
+        out.push(current.trim().to_string());
+    }
+    out.into_iter()
+        .map(|a| unquote(&a).unwrap_or_default())
+        .collect()
 }
 
 /// Split an expression on `|` characters, respecting quoted strings.
@@ -1308,6 +1549,11 @@ fn validate_variable_name(name: &str, _grain_type_ctx: Option<&str>) -> CalResul
     }
     if let Some(field) = name.strip_prefix("source.") {
         if SPEC_SOURCE_VARIABLES.contains(&field) {
+            return Ok(());
+        }
+    }
+    if let Some(field) = name.strip_prefix("group.") {
+        if GROUP_VARIABLES.contains(&field) {
             return Ok(());
         }
     }
@@ -1556,6 +1802,21 @@ fn resolve_variable(
         };
     }
 
+    // The `group.` namespace (#209): the current row when it is a group
+    // projection from `GROUP BY <field> COUNT`. `{{group.count}}x
+    // {{group.key}}` is the whole "most frequent first" render.
+    //
+    // Bound only on a group row — on an ordinary grain it resolves Null
+    // rather than silently reading a field that happens to be called `key`.
+    if let Some(field) = name.strip_prefix("group.") {
+        return match grain {
+            Some(g) if g.grain_type == "group" && GROUP_VARIABLES.contains(&field) => {
+                resolve_from_fields(&g.fields, field)
+            }
+            _ => ResolvedValue::Null,
+        };
+    }
+
     // 1. Metadata variables (_prefix).
     match name {
         "_index" => return ResolvedValue::Integer(index.unwrap_or(0) as i64),
@@ -1738,10 +1999,165 @@ pub fn apply_filter(
             }
             _ => Ok(ResolvedValue::Str(value.to_display())),
         },
+        // ── Extractors (#210). Each TAKES part of a value rather than
+        // formatting the whole of it. All of them are total: a filter that
+        // finds nothing yields empty, never an error, because template
+        // resolution is total and one unparseable grain must not fail the
+        // render of the other 199.
+        "first_line" => {
+            let s = extract_input(value);
+            Ok(ResolvedValue::Str(
+                s.split(['\n', '\r']).next().unwrap_or("").to_string(),
+            ))
+        }
+        "split" => {
+            let s = extract_input(value);
+            let sep = filter.args.first().map(String::as_str).unwrap_or("");
+            let n: usize = filter
+                .args
+                .get(1)
+                .and_then(|a| a.parse().ok())
+                .unwrap_or(0);
+            if sep.is_empty() {
+                return Ok(ResolvedValue::Str(String::new()));
+            }
+            Ok(ResolvedValue::Str(
+                s.split(sep).nth(n).unwrap_or("").trim().to_string(),
+            ))
+        }
+        "strip_prefix" => {
+            let s = extract_input(value);
+            let p = filter.args.first().map(String::as_str).unwrap_or("");
+            Ok(ResolvedValue::Str(
+                s.strip_prefix(p).unwrap_or(&s).to_string(),
+            ))
+        }
+        "strip_suffix" => {
+            let s = extract_input(value);
+            let p = filter.args.first().map(String::as_str).unwrap_or("");
+            Ok(ResolvedValue::Str(
+                s.strip_suffix(p).unwrap_or(&s).to_string(),
+            ))
+        }
+        // The motivating case, and the one that needs no pattern language:
+        // `[Q3 close handoff] the ops team flagged…` → `Q3 close handoff`.
+        "between" => {
+            let s = extract_input(value);
+            let open = filter.args.first().map(String::as_str).unwrap_or("");
+            let close = filter.args.get(1).map(String::as_str).unwrap_or("");
+            if open.is_empty() || close.is_empty() {
+                return Ok(ResolvedValue::Str(String::new()));
+            }
+            let found = s.find(open).and_then(|i| {
+                let after = i + open.len();
+                s[after..].find(close).map(|j| s[after..after + j].to_string())
+            });
+            Ok(ResolvedValue::Str(found.unwrap_or_default()))
+        }
+        // `match("pattern")` yields the whole match; `match("pattern", n)`
+        // yields capture group n. A pattern that does not compile, does not
+        // match, or names a group that did not participate yields empty.
+        "match" => {
+            let s = extract_input(value);
+            let pat = filter.args.first().map(String::as_str).unwrap_or("");
+            let group: usize = filter
+                .args
+                .get(1)
+                .and_then(|a| a.parse().ok())
+                .unwrap_or(0);
+            if pat.is_empty() {
+                return Ok(ResolvedValue::Str(String::new()));
+            }
+            let out = cached_pattern(pat)
+                .and_then(|re| re.captures(&s))
+                .and_then(|c| c.get(group).map(|m| m.as_str().to_string()))
+                .unwrap_or_default();
+            Ok(ResolvedValue::Str(out))
+        }
+        // ── Navigation (#211). One scalar out of a structured payload.
+        //
+        // Note the asymmetry this closes: `record_tool_call` round-trips
+        // `input` as parsed JSON, so a Python or Node host gets the structure
+        // for free — it was specifically the CAL path that could not see
+        // inside. A dotted path only: no wildcards, no predicates, no
+        // arithmetic, and explicitly no "remove a key and re-serialise the
+        // rest", which is a transformation. If a caller needs that, the write
+        // should have stored two fields — which also makes the value
+        // *filterable*, as no amount of template machinery does.
+        "get" => {
+            let Some(path) = filter.args.first().map(String::as_str).filter(|p| !p.is_empty())
+            else {
+                return Ok(ResolvedValue::Null);
+            };
+            // Both shapes arrive here as text: a structured field (a Tool
+            // `input`, an eval summary) resolves to its JSON serialization,
+            // and a JSON document stored *as* a string (a `fails_with`
+            // signature in `object`) is already one. Parsing is what makes
+            // the existing `json` filter's name misleading — that one
+            // *serialises*, which is why it never helped here.
+            let Ok(root) = serde_json::from_str::<serde_json::Value>(&extract_input(value)) else {
+                return Ok(ResolvedValue::Null);
+            };
+            Ok(json_to_resolved(navigate_json(&root, path)))
+        }
         unknown => Err(CalError::TemplateUnknownFilter {
             name: unknown.to_string(),
             span: None,
         }),
+    }
+}
+
+/// The string an extracting filter looks at, bounded.
+fn extract_input(value: &ResolvedValue) -> String {
+    let s = value.to_display();
+    if s.len() <= MAX_EXTRACT_INPUT {
+        return s;
+    }
+    // Clip on a char boundary — grain bodies are UTF-8 and slicing mid-code-
+    // point would panic.
+    let mut end = MAX_EXTRACT_INPUT;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+/// Walk a dotted path into a JSON value. Depth-bounded; a missing segment
+/// yields `None` (rendered empty), never an error.
+///
+/// A numeric segment indexes an array, so `items.0.name` works without a
+/// separate syntax for it.
+fn navigate_json<'a>(root: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut cur = root;
+    for (depth, seg) in path.split('.').enumerate() {
+        if depth >= MAX_GET_PATH_DEPTH {
+            return None;
+        }
+        cur = match cur {
+            serde_json::Value::Object(m) => m.get(seg)?,
+            serde_json::Value::Array(a) => a.get(seg.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(cur)
+}
+
+/// A navigated JSON value as a template value. A container comes back
+/// serialised — the path reached a subtree rather than a scalar, and showing
+/// it is more useful than showing nothing.
+fn json_to_resolved(v: Option<&serde_json::Value>) -> ResolvedValue {
+    match v {
+        None | Some(serde_json::Value::Null) => ResolvedValue::Null,
+        Some(serde_json::Value::String(s)) => ResolvedValue::Str(s.clone()),
+        Some(serde_json::Value::Bool(b)) => ResolvedValue::Bool(*b),
+        Some(serde_json::Value::Number(n)) => match n.as_i64() {
+            Some(i) => ResolvedValue::Integer(i),
+            None => n
+                .as_f64()
+                .map(ResolvedValue::Number)
+                .unwrap_or(ResolvedValue::Null),
+        },
+        Some(other) => ResolvedValue::Str(other.to_string()),
     }
 }
 
@@ -3363,6 +3779,7 @@ mod tests {
         let filter = Filter {
             name: "truncate".into(),
             arg: Some("13".into()),
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "Hello, world!...");
@@ -3375,6 +3792,7 @@ mod tests {
         let filter = Filter {
             name: "truncate".into(),
             arg: Some("80".into()),
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "short");
@@ -3392,6 +3810,7 @@ mod tests {
         let filter = Filter {
             name: "relative".into(),
             arg: None,
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "1m ago");
@@ -3404,6 +3823,7 @@ mod tests {
         let filter = Filter {
             name: "humanize".into(),
             arg: None,
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "likes");
@@ -3416,6 +3836,7 @@ mod tests {
         let filter = Filter {
             name: "percent".into(),
             arg: None,
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "94%");
@@ -3431,6 +3852,7 @@ mod tests {
             &Filter {
                 name: "uppercase".into(),
                 arg: None,
+                args: Vec::new(),
             },
             &ctx,
         )
@@ -3442,6 +3864,7 @@ mod tests {
             &Filter {
                 name: "lowercase".into(),
                 arg: None,
+                args: Vec::new(),
             },
             &ctx,
         )
@@ -3459,6 +3882,7 @@ mod tests {
             &Filter {
                 name: "default".into(),
                 arg: Some("fallback".into()),
+                args: Vec::new(),
             },
             &ctx,
         )
@@ -3471,6 +3895,7 @@ mod tests {
             &Filter {
                 name: "default".into(),
                 arg: Some("fallback".into()),
+                args: Vec::new(),
             },
             &ctx,
         )
@@ -3485,6 +3910,7 @@ mod tests {
         let filter = Filter {
             name: "join".into(),
             arg: Some(", ".into()),
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "a, b, c");
@@ -3500,6 +3926,7 @@ mod tests {
         let filter = Filter {
             name: "date".into(),
             arg: Some("%Y-%m-%d".into()),
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "2023-11-14");
@@ -3512,6 +3939,7 @@ mod tests {
         let filter = Filter {
             name: "date".into(),
             arg: None,
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "<invalid date>");
@@ -3524,6 +3952,7 @@ mod tests {
         let filter = Filter {
             name: "json".into(),
             arg: None,
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         assert_eq!(result.to_display(), "\"hello\"");
@@ -4154,6 +4583,7 @@ mod tests {
         let filter = Filter {
             name: "truncate".into(),
             arg: Some("3".into()),
+            args: Vec::new(),
         };
         let result = apply_filter(&val, &filter, &ctx).unwrap();
         let display = result.to_display();

--- a/crates/areev-cal/tests/cal_expressiveness.rs
+++ b/crates/areev-cal/tests/cal_expressiveness.rs
@@ -1,0 +1,443 @@
+//! #209 / #210 / #211 — the three reads that could not be written in CAL:
+//! summarise by frequency, extract part of a value, and navigate into a
+//! structured payload.
+//!
+//! The spec decisions behind them are recorded in
+//! `docs/oms-1.7-amendments-cal-expressiveness.md`.
+
+use areev_cal::executor::CalResultPayload;
+use areev_cal::{AreevFacade, CalExecutor, CalExecutorConfig};
+use areev_core::types::{Fact, Grain};
+use areev_store::Areev;
+use tempfile::TempDir;
+
+fn mem(d: &TempDir) -> Areev {
+    Areev::open(d.path().join("x.db").to_str().unwrap()).unwrap()
+}
+
+fn add(m: &mut Areev, ns: &str, s: &str, r: &str, o: &str) {
+    let mut f = Fact::new(s, r, o).confidence(0.9);
+    f.common.namespace = Some(ns.to_string());
+    m.add(&f).unwrap();
+}
+
+fn text(ex: &CalExecutor, facade: &AreevFacade, src: &str) -> String {
+    match ex.execute(src, facade).unwrap().result {
+        CalResultPayload::Formatted { text, .. } => text,
+        other => panic!("expected Formatted, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #209 — per-group counts
+// ---------------------------------------------------------------------------
+
+/// The fixture is deliberately uneven *and* has a tie, because the ordering is
+/// part of the contract: frequency is the answer, and a deterministic
+/// tiebreak is what makes it reproducible across backends and runs.
+fn seeded_failures(d: &TempDir) -> Areev {
+    let mut m = mem(d);
+    for (tool, n) in [("search_notes", 3), ("search_contacts", 2), ("send_email", 2), ("ping", 1)] {
+        for i in 0..n {
+            add(&mut m, "e", tool, "failed_with", &format!("status 401 attempt {i}"));
+        }
+    }
+    m
+}
+
+#[test]
+fn group_by_then_count_projects_one_row_per_group_most_frequent_first() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_failures(&d), Some("e".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let res = ex
+        .execute(
+            r#"RECALL facts WHERE namespace = "e" LIMIT 400 GROUP BY subject COUNT"#,
+            &facade,
+        )
+        .unwrap();
+    let CalResultPayload::GroupCounts { field, groups, total_available } = res.result else {
+        panic!("expected GroupCounts");
+    };
+    assert_eq!(field, "subject");
+    assert_eq!(total_available, Some(4));
+
+    let rows: Vec<(String, i64)> = groups
+        .iter()
+        .map(|g| {
+            (
+                g.fields["key"].as_str().unwrap().to_string(),
+                g.fields["count"].as_i64().unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            ("search_notes".into(), 3),
+            // The tie breaks by key ascending, not by insertion or scan order.
+            ("search_contacts".into(), 2),
+            ("send_email".into(), 2),
+            ("ping".into(), 1),
+        ]
+    );
+    // A group is computed, not stored: anything keying on a content address
+    // (dedup above all) must be able to tell it from a grain.
+    assert!(groups.iter().all(|g| g.hash.is_empty() && g.grain_type == "group"));
+}
+
+/// The behaviour this replaces answered the plain total — identical to
+/// `COUNT` alone, so nothing could have wanted it. `COUNT` without a
+/// `GROUP BY` must still answer exactly that.
+#[test]
+fn count_without_group_by_is_still_the_plain_total() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_failures(&d), Some("e".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    match ex
+        .execute(r#"RECALL facts WHERE namespace = "e" LIMIT 400 COUNT"#, &facade)
+        .unwrap()
+        .result
+    {
+        CalResultPayload::Count { count } => assert_eq!(count, 8),
+        other => panic!("expected Count, got {other:?}"),
+    }
+}
+
+#[test]
+fn group_variables_render_most_frequent_first() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_failures(&d), Some("e".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    ex.execute(
+        r#"DEFINE TEMPLATE topfail ELEMENT {- ({{group.count}}x) {{group.key}}
+}"#,
+        &facade,
+    )
+    .unwrap();
+    let out = text(
+        &ex,
+        &facade,
+        r#"RECALL facts WHERE namespace = "e" LIMIT 400 GROUP BY subject COUNT FORMAT TEMPLATE topfail"#,
+    );
+    assert!(out.starts_with("- (3x) search_notes"), "{out}");
+    assert!(out.contains("- (1x) ping"), "{out}");
+}
+
+/// `group.*` is bound on a group row and nowhere else — on an ordinary grain
+/// it must not read a field that happens to be called `key`.
+#[test]
+fn group_variables_are_null_on_an_ordinary_grain() {
+    let d = TempDir::new().unwrap();
+    let mut m = mem(&d);
+    add(&mut m, "g", "a", "note", "b");
+    let facade = AreevFacade::with_session(m, Some("g".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    ex.execute(
+        r#"DEFINE TEMPLATE gk ELEMENT {[{{group.key}}]}"#,
+        &facade,
+    )
+    .unwrap();
+    assert_eq!(
+        text(&ex, &facade, r#"RECALL facts WHERE namespace = "g" FORMAT TEMPLATE gk"#),
+        "[]"
+    );
+}
+
+/// The `execute_source` discard the issue names: an assembly could not carry
+/// a grouped summary, so "the errors this agent hits most" had to be a
+/// separate read the host tallied and spliced in itself.
+#[test]
+fn an_assemble_source_can_be_a_grouped_count() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_failures(&d), Some("e".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let res = ex
+        .execute(
+            r#"ASSEMBLE "brief" FROM top: (RECALL facts WHERE namespace = "e" LIMIT 400 GROUP BY subject COUNT)"#,
+            &facade,
+        )
+        .unwrap();
+    match res.result {
+        CalResultPayload::Assembled { grains, .. } => {
+            assert_eq!(grains.len(), 4, "the four groups reached the assembly");
+            assert_eq!(grains[0].fields["key"], "search_notes");
+        }
+        other => panic!("expected Assembled, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #210 — extracting part of a value
+// ---------------------------------------------------------------------------
+
+fn seeded_text(d: &TempDir) -> Areev {
+    let mut m = mem(d);
+    add(
+        &mut m,
+        "s",
+        "sess1",
+        "note",
+        "[Q3 close handoff] the ops team flagged three invoices\nsecond line",
+    );
+    m
+}
+
+#[test]
+fn extractors_pull_a_title_out_of_free_text() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_text(&d), Some("s".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    // Four routes to the same answer — the motivating case from #210.
+    for (name, body, want) in [
+        ("t1", r#"{{{grain.object | between("[", "]")}}}"#, "Q3 close handoff"),
+        (
+            "t2",
+            r#"{{{grain.object | split("]", 0) | strip_prefix("[")}}}"#,
+            "Q3 close handoff",
+        ),
+        (
+            "t3",
+            r#"{{{grain.object | match("\[([^\]]+)\]", 1)}}}"#,
+            "Q3 close handoff",
+        ),
+        (
+            "t4",
+            r#"{{{grain.object | first_line | strip_suffix(" invoices")}}}"#,
+            "[Q3 close handoff] the ops team flagged three",
+        ),
+    ] {
+        ex.execute(&format!("DEFINE TEMPLATE {name} ELEMENT {body}"), &facade)
+            .unwrap();
+        assert_eq!(
+            text(
+                &ex,
+                &facade,
+                &format!(r#"RECALL facts WHERE namespace = "s" FORMAT TEMPLATE {name}"#)
+            ),
+            want,
+            "filter chain {name}"
+        );
+    }
+}
+
+/// Totality: a filter that finds nothing yields empty. One grain that does not
+/// match the shape must not fail the render of every other grain.
+#[test]
+fn an_extractor_that_finds_nothing_renders_empty_not_an_error() {
+    let d = TempDir::new().unwrap();
+    let mut m = mem(&d);
+    add(&mut m, "s", "plain", "note", "no brackets here at all");
+    let facade = AreevFacade::with_session(m, Some("s".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    ex.execute(
+        r#"DEFINE TEMPLATE e1 ELEMENT {[{{grain.object | between("[", "]")}}]}"#,
+        &facade,
+    )
+    .unwrap();
+    assert_eq!(
+        text(&ex, &facade, r#"RECALL facts WHERE namespace = "s" FORMAT TEMPLATE e1"#),
+        "[]"
+    );
+}
+
+/// …but a bad *argument* is an authoring mistake, and is refused when the
+/// template is defined rather than rendering empty on every grain forever.
+/// This is the auditability half: an unreadable saved query never gets stored.
+#[test]
+fn bad_filter_arguments_are_refused_at_define_time() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(mem(&d), Some("s".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    for (name, body) in [
+        // Backreferences force backtracking, so the engine does not have them.
+        ("b1", r#"{{{grain.object | match("(a)\1")}}}"#),
+        // The POSIX `]`-first-in-class quirk is not this dialect.
+        ("b2", r#"{{{grain.object | match("[[]([^]]+)[]]")}}}"#),
+        ("b3", r#"{{{grain.object | split("]", notanumber)}}}"#),
+        ("b4", r#"{{{grain.object | between("[")}}}"#),
+        ("b5", r#"{{{grain.object | get("a.b.c.d.e.f.g.h.i")}}}"#),
+    ] {
+        let err = ex
+            .execute(&format!("DEFINE TEMPLATE {name} ELEMENT {body}"), &facade)
+            .unwrap_err();
+        assert_eq!(err.code(), "CAL-E049", "{name} should refuse at define time");
+    }
+
+    // An unknown filter is still refused — the set stays closed.
+    let err = ex
+        .execute(
+            r#"DEFINE TEMPLATE b6 ELEMENT {{{grain.object | eval("1+1")}}}"#,
+            &facade,
+        )
+        .unwrap_err();
+    assert!(format!("{err}").contains("CAL-E043"), "{err}");
+}
+
+// ---------------------------------------------------------------------------
+// #211 — navigating a structured payload
+// ---------------------------------------------------------------------------
+
+fn seeded_json(d: &TempDir) -> Areev {
+    let mut m = mem(d);
+    add(
+        &mut m,
+        "j",
+        "search_api",
+        "fails_with",
+        r#"{"error":{"code":"rate_limited"},"retry_after":30,"tags":["a","b"]}"#,
+    );
+    add(&mut m, "j", "other_api", "fails_with", r#"{"error":{"code":"timeout"}}"#);
+    m
+}
+
+#[test]
+fn get_reads_a_scalar_out_of_a_json_field() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_json(&d), Some("j".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    ex.execute(
+        r#"DEFINE TEMPLATE sig ELEMENT {{{grain.subject}}={{grain.object | get("error.code")}}/{{grain.object | get("tags.0")}};}"#,
+        &facade,
+    )
+    .unwrap();
+    let out = text(
+        &ex,
+        &facade,
+        r#"RECALL facts WHERE namespace = "j" ORDER BY subject ASC FORMAT TEMPLATE sig"#,
+    );
+    assert!(out.contains("search_api=rate_limited/a;"), "{out}");
+    // A path that is absent on THIS grain renders empty, not an error.
+    assert!(out.contains("other_api=timeout/;"), "{out}");
+}
+
+#[test]
+fn a_missing_path_or_a_non_json_value_renders_empty() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_json(&d), Some("j".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    ex.execute(
+        r#"DEFINE TEMPLATE m ELEMENT {[{{grain.object | get("nope.nothing")}}][{{grain.subject | get("a")}}]}"#,
+        &facade,
+    )
+    .unwrap();
+    let out = text(
+        &ex,
+        &facade,
+        r#"RECALL facts WHERE namespace = "j" AND subject = "other_api" FORMAT TEMPLATE m"#,
+    );
+    assert_eq!(out, "[][]");
+}
+
+#[test]
+fn where_filters_on_a_json_path() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_json(&d), Some("j".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let count = |src: &str| match ex.execute(src, &facade).unwrap().result {
+        CalResultPayload::Grains { grains, .. } => grains.len(),
+        other => panic!("expected Grains, got {other:?}"),
+    };
+
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "j" AND object.error.code = "rate_limited""#),
+        1
+    );
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "j" AND object.error.code = "nope""#),
+        0
+    );
+    // Numbers compare as numbers, not as text.
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "j" AND object.retry_after > 10"#),
+        1
+    );
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "j" AND object.retry_after > 100"#),
+        0
+    );
+    // IS NULL / IS NOT NULL see the path, not just the base field.
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "j" AND object.retry_after IS NOT NULL"#),
+        1
+    );
+}
+
+/// The composition that matters: a path that does not resolve is UNKNOWN
+/// (#207), so navigation inherits the fails-closed rule rather than adding
+/// one of its own. Both grains here carry `object`; only one carries the path.
+#[test]
+fn an_unresolvable_path_fails_closed_under_negation() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_json(&d), Some("j".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let count = |src: &str| match ex.execute(src, &facade).unwrap().result {
+        CalResultPayload::Grains { grains, .. } => grains.len(),
+        other => panic!("expected Grains, got {other:?}"),
+    };
+
+    assert_eq!(count(r#"RECALL facts WHERE namespace = "j""#), 2);
+    // `other_api` has no `retry_after`. It must match neither the equality
+    // nor its negation — otherwise `!=` is a filter that widens.
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "j" AND object.retry_after != 999"#),
+        1
+    );
+    assert_eq!(
+        count(r#"RECALL facts WHERE namespace = "j" AND NOT object.retry_after = 999"#),
+        1
+    );
+}
+
+#[test]
+fn a_field_path_past_the_bound_is_refused_before_the_scan() {
+    let d = TempDir::new().unwrap();
+    let facade = AreevFacade::with_session(seeded_json(&d), Some("j".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let err = ex
+        .execute(
+            r#"RECALL facts WHERE namespace = "j" AND object.a.b.c.d.e.f.g.h.i = "x""#,
+            &facade,
+        )
+        .unwrap_err();
+    assert_eq!(err.code(), "CAL-E002");
+    assert!(format!("{err}").contains("8 segments"), "{err}");
+}
+
+/// A structured field and a JSON document stored as a string must navigate
+/// identically, or the accessor depends on how the writer typed the field.
+#[test]
+fn a_parsed_object_and_a_json_string_navigate_the_same() {
+    let d = TempDir::new().unwrap();
+    let mut m = mem(&d);
+    // `object` here is a JSON *string*; `input` on the tool grain below is a
+    // parsed object the engine round-trips as JSON — which is exactly why a
+    // Python or Node host could already see inside it while CAL could not.
+    add(&mut m, "k", "as_string", "sig", r#"{"app":"phone"}"#);
+    let mut tool = areev_core::types::Tool::new("phone.search_contacts")
+        .input(serde_json::json!({"app": "phone"}));
+    tool.common.namespace = Some("k".to_string());
+    m.add(&tool).unwrap();
+    let facade = AreevFacade::with_session(m, Some("k".into()), None);
+    let ex = CalExecutor::new(CalExecutorConfig::default());
+
+    let count = |src: &str| match ex.execute(src, &facade).unwrap().result {
+        CalResultPayload::Grains { grains, .. } => grains.len(),
+        other => panic!("expected Grains, got {other:?}"),
+    };
+    assert_eq!(count(r#"RECALL facts WHERE namespace = "k" AND object.app = "phone""#), 1);
+    assert_eq!(count(r#"RECALL tools WHERE namespace = "k" AND input.app = "phone""#), 1);
+}

--- a/docs/cal-reference.md
+++ b/docs/cal-reference.md
@@ -644,6 +644,34 @@ order. Now:
   operators *about* absence and stay definite; `AND`/`OR` use SQL's truth
   tables, so nothing that already matched stops matching.
 
+#### Reaching into a structured field
+
+A field name may be a **dotted path** of up to 8 segments: the first segment
+names the grain field, the rest navigate its JSON. A numeric segment indexes
+an array, so `items.0.name` needs no separate syntax.
+
+```sql
+RECALL tools WHERE input.app = "phone"
+RECALL facts WHERE object.error.code = "rate_limited"
+```
+
+Hosts put structured payloads in grain fields constantly — a tool'"'"'s `input`,
+an eval summary, an error envelope, an API response — and before 1.7.4 CAL
+could not filter on any of them, so a host fetched the whole set and unpacked
+it in application code. A value stored *as a JSON string* navigates
+identically to a parsed one, so the accessor does not depend on how the writer
+happened to type the field.
+
+The base field is validated against the grain type as usual (`CAL-E060`); the
+path is not, because the shape lives in the payload rather than in the schema.
+**A path that does not resolve is UNKNOWN**, so it inherits the fails-closed
+rule above rather than adding one: `input.app = "phone"` matches neither the
+grains whose payload says otherwise nor the ones with no such key, and
+`input.app != "phone"` does not widen to everything. Like every other
+type-specific key it is an executor post-filter over the widened scan, so
+`CAL-W015` still reports a scan that filled. `ORDER BY` on a path is not
+supported. The renderer'"'"'s equivalent is the `get` filter (§6).
+
 #### World-time validity: `valid_from` / `valid_to`
 
 Every grain type carries the OMS §6.1 world-time axis, and since 1.7.4 all four
@@ -765,12 +793,43 @@ Pipeline stages post-process a statement's result set, chained with `|` (up to
 | `\| SUBJECTS` / `\| OBJECTS` | Extract the `subject`/`object` of each Fact |
 | `\| HASHES` | Extract the content hash of each grain |
 | `\| GROUP BY field` | Group results |
+| `\| GROUP BY field \| COUNT` | One row per group with its size, **most frequent first** |
 
 ```sql
 RECALL facts WHERE subject = "john" | SELECT relation, object | LIMIT 5
 RECALL facts WHERE namespace = "caller" | COUNT
 RECALL facts WHERE relation = "knows" | OBJECTS
 ```
+
+#### Frequency: `GROUP BY <field>` then `COUNT`
+
+`GROUP BY` on its own **reorders** rows so same-key grains are contiguous.
+Follow it with `COUNT` and you get one row per group carrying that group'"'"'s
+size, ordered **most frequent first** (ties by key ascending, so the answer is
+reproducible across backends and runs):
+
+```sql
+RECALL tools WHERE is_error = true LIMIT 400 GROUP BY tool_name COUNT
+```
+
+```json
+{"type": "group_counts", "field": "tool_name", "groups": [
+  {"grain_type": "group", "fields": {"key": "simple_note.search_notes", "count": 8}},
+  {"grain_type": "group", "fields": {"key": "phone.search_contacts",    "count": 6}}
+]}
+```
+
+Before 1.7.4 that statement returned the plain total — identical to `COUNT`
+alone, silently discarding the grouping. Frequency is how a memory says what
+*matters* ("which tool fails most", "which topic does this user raise most",
+"which policy is cited most"), and every one of those reads used to be host
+code, which also spent the token budget on the rows being discarded.
+
+A group row is grain-shaped so every renderer works on it unchanged, and its
+**hash is empty** — a group is computed, not stored. Render one with the
+`group.*` template variables (§6), or make an `ASSEMBLE` source out of it so
+"the five errors this agent hits most" is a section of a prompt rather than a
+read the host tallies itself.
 
 `WHERE session_id = "…"` is **pushed into the thread index**
 (`idx_thread(ns, session, seq)`) rather than applied as a post-filter, so
@@ -971,6 +1030,70 @@ open function library cannot promise.
 | `json` | **Serialise** the value as JSON — it does not parse one |
 | `default "<text>"` | Substitute when the value is absent or empty |
 | `join("<sep>")` | Join an array |
+
+Since 1.7.4 the set also contains filters that **take** part of a value rather
+than formatting the whole of one — because memories store text people wrote,
+and titles, ticket ids, error codes and thread keys all live inside it:
+
+| Filter | Effect |
+|---|---|
+| `first_line` | Text up to the first line break |
+| `split("<sep>", n)` | The nth field (0-indexed) after splitting |
+| `strip_prefix("<s>")` / `strip_suffix("<s>")` | Remove a fixed affix if present |
+| `between("<open>", "<close>")` | The text between the first `open` and the next `close` |
+| `match("<pattern>"[, n])` | The whole match, or capture group `n` |
+| `get("<a.b.c>")` | One value out of a JSON payload, by dotted path |
+
+```
+{{grain.object | between("[", "]")}}      → Q3 close handoff
+{{grain.object | get("error.code")}}      → rate_limited
+{{grain.content | first_line | truncate(60)}}
+```
+
+`get` is the one that reaches into structure. `record_tool_call` round-trips a
+tool'"'"'s `input` as parsed JSON, so a Python or Node host gets the shape for
+free — it was specifically the CAL path that could not see inside. (The `json`
+filter does not help despite its name: it *serialises* a value.) A path that
+does not resolve renders empty, and `get` deliberately does **not** transform:
+no wildcards, no predicates, and no "remove a key and re-serialise the rest".
+If you need that, store two fields — which also makes the value *filterable*,
+as no amount of template machinery does.
+
+**Bad arguments are refused when the template is defined, not when it
+renders.** A pattern that does not compile, a `split` index that is not a
+number, a `between` missing a delimiter, a `get` path deeper than 8 segments —
+all `CAL-E049` at `DEFINE TEMPLATE` time. So "what will this saved query show
+me?" stays answerable by reading it, and rendering stays total: at render time
+a filter that finds nothing yields empty, never an error, because one
+unparseable grain must not fail the render of the other 199.
+
+**`match` uses the Rust regex dialect — no backreferences, no lookaround.**
+Those are exactly the constructs that force an engine to backtrack, and a
+template runs over untrusted grain content on every turn, where a backtracking
+regex is a denial-of-service primitive. Patterns are capped at 512 characters
+and compiled through a bounded cache; extractor input is clipped at 64 KiB.
+Note that `]` inside a character class must be escaped: write
+`\[([^\]]+)\]`, not `[[]([^]]+)[]]`.
+
+#### Group variables
+
+A `GROUP BY <field> COUNT` result (§4) renders through a `group.` namespace:
+
+| Variable | Value |
+|---|---|
+| `{{group.key}}` | The group'"'"'s key |
+| `{{group.count}}` | How many grains fall in it |
+
+```
+DEFINE TEMPLATE top_failures ELEMENT {- ({{group.count}}x) {{group.key}}}
+```
+```
+- (8x) simple_note.search_notes
+- (6x) phone.search_contacts
+```
+
+Both resolve null on an ordinary grain, rather than reading a field that
+happens to be called `key`.
 
 **Timestamps are epoch milliseconds.** Every timestamp a template can name —
 `created_at`, `valid_from`, `valid_to`, `deadline`, `expires_at`,

--- a/docs/oms-1.6-amendments.md
+++ b/docs/oms-1.6-amendments.md
@@ -2,7 +2,9 @@
 
 > Companion: [`oms-1.6-amendments-triggers.md`](oms-1.6-amendments-triggers.md)
 > covers the trigger batch (new grain type, the §27.6 removal, the execution
-> contract).
+> contract); [`oms-1.7-amendments-cal-expressiveness.md`](oms-1.7-amendments-cal-expressiveness.md)
+> covers the CAL expressiveness batch (per-group counts, the `group.`
+> namespace, the extracting filters, dotted field paths).
 
 **Status:** amendment proposal, written 2026-08-11. One revision covering
 every spec-level change the GDPR compliance work needs, so conformance moves

--- a/docs/oms-1.7-amendments-cal-expressiveness.md
+++ b/docs/oms-1.7-amendments-cal-expressiveness.md
@@ -1,0 +1,222 @@
+# OMS 1.7 amendments — CAL expressiveness
+
+> Companion to [`oms-1.6-amendments.md`](oms-1.6-amendments.md) (the
+> compliance batch) and
+> [`oms-1.6-amendments-triggers.md`](oms-1.6-amendments-triggers.md).
+
+**Status:** amendment proposal, written 2026-09-08. One revision covering the
+three reads that could not be expressed in CAL, so conformance moves once
+rather than three times.
+
+CAL syntax and its §10.5 template-variable set are OMS conformance contracts:
+Areev's own invariants say no new CAL syntax without a spec-level decision.
+This document is that decision, written down.
+
+| # | Amendment | Issue | Conformance impact |
+|---|---|---|---|
+| B1 | `GROUP BY <field>` followed by `COUNT` projects one row per group | [#209](https://github.com/AreevAI/areev/issues/209) | Result payload; **no new syntax** |
+| B2 | The `group.` template namespace (`key`, `count`) | #209 | §10.5 variable set |
+| B3 | Six extracting filters and one navigating filter | [#210](https://github.com/AreevAI/areev/issues/210), [#211](https://github.com/AreevAI/areev/issues/211) | §10.7 filter set |
+| B4 | Dotted field paths in `WHERE`, up to 8 segments | #211 | Grammar (relaxes an existing rule) |
+
+All four ship in 1.7.4 ahead of ratification, because each closes a read a
+host must otherwise perform by over-fetching — which also defeats `BUDGET`,
+since the budget is spent on the rows the host is about to discard. They are
+written here as the record of what an implementation must do to interoperate.
+
+---
+
+## The standing constraint, and why these fit inside it
+
+CAL's value is that it is **not** a programming language. Saved-query bodies
+get an extra read-only verification pass precisely because the surface is
+narrow, and those bodies are handed to unattended agents. Four properties are
+load-bearing, and every amendment below is shaped by them:
+
+1. **Conformance surface.** Two implementations must render a grain
+   identically. That is why §10.5's variables and the filter list are *closed*
+   sets, and why every addition here extends a closed set rather than opening
+   one.
+2. **Cost and safety.** A template renders on every turn over host-supplied
+   and model-supplied text. Anything added needs a bound.
+3. **Auditability.** "What will this saved query show me?" must stay
+   answerable by reading it. Arbitrary expressions make that a
+   program-analysis question.
+4. **The render is sometimes the wrong place.** If a value has to be taken
+   apart at read time, the write often chose the wrong shape.
+
+**What is therefore refused, and stays refused:** host-registered functions (a
+template calling one would render differently depending on who opened the
+file, which breaks the property that makes saved queries worth having — the
+registry travels *with* the memory); a general expression language in
+templates; and any transformation that parses, mutates and re-serialises. That
+last one is the tempting case in #211 — "read `error.code`, remove that key,
+re-emit the rest" — and it is declined. It is a program. Its main use,
+reshaping on the way out, is better served by writing the right shape in,
+which also makes the value **filterable**, as no amount of template machinery
+does.
+
+---
+
+## B1 — `GROUP BY <field> COUNT` projects one row per group
+
+```sql
+RECALL tools WHERE is_error = true LIMIT 400 GROUP BY tool_name COUNT
+```
+
+**Semantics.** One row per group, carrying the group's key and size, ordered
+**most frequent first** with ties broken by key ascending. The payload is
+`group_counts`, and each row is a grain-shaped record with `grain_type
+"group"`, fields `{key, count}`, and an **empty content address** — a group is
+computed, not stored, and must never be mistaken for a grain (anything keying
+on a hash, dedup above all, has to skip it).
+
+**No new syntax, and that is the point.** `GROUP BY` and `COUNT` both already
+exist. What the combination *did* was return the plain total — identical to
+`COUNT` alone, silently discarding the grouping. Nothing could have wanted
+that number: it is `COUNT` with extra words. So an implementation adopting
+this amendment takes no meaningful answer away from any caller.
+
+**Why it belongs in the language.** Frequency is how a memory says what
+*matters*. "Which tool fails most", "which topic does this user raise most",
+"which policy is cited most" are the ordinary summarisation reads, and every
+one of them was host code. The ordering is part of the contract, not a
+convenience: a deterministic tiebreak is what makes the answer reproducible
+across backends and across runs.
+
+**An `ASSEMBLE` source may be a grouped count.** So "the five errors this
+agent hits most" can be a *section of a prompt* rather than a separate read
+the host tallies and splices in itself.
+
+## B2 — the `group.` template namespace
+
+§10.5 gains a fourth namespace beside `grain.`, `assembly.`, `budget.` and
+`source.`:
+
+| Variable | Value |
+|---|---|
+| `{{group.key}}` | The group's key |
+| `{{group.count}}` | How many grains fall in it |
+
+```
+DEFINE TEMPLATE top_failures ELEMENT {- ({{group.count}}x) {{group.key}}}
+```
+```
+- (8x) simple_note.search_notes
+- (6x) phone.search_contacts
+```
+
+**Bound only on a group row.** On an ordinary grain both resolve null, rather
+than reading a field that happens to be called `key`. The set is closed at two
+names; an implementation MUST NOT resolve any other `group.` variable.
+
+No `GROUP` / `GROUP_BREAK` sections are added. `ELEMENT` over group rows
+renders the list, and the existing sections keep their meaning — a second
+sectioning axis would need its own inheritance and budget-tier rules for a
+case `ELEMENT` already covers.
+
+## B3 — the filter set grows by seven, and stays closed
+
+§10.7's filter list gains six **extractors** (which *take* part of a value,
+where the existing ten *format* the whole of one) and one **navigator**:
+
+| Filter | Effect |
+|---|---|
+| `first_line` | Text up to the first line break |
+| `split("<sep>", n)` | The nth field (0-indexed) after splitting |
+| `strip_prefix("<s>")` / `strip_suffix("<s>")` | Remove a fixed affix if present |
+| `between("<open>", "<close>")` | The text between the first `open` and the next `close` |
+| `match("<pattern>"[, n])` | The whole match, or capture group `n` |
+| `get("<a.b.c>")` | One value out of a JSON payload, by dotted path |
+
+```
+{{grain.object | between("[", "]")}}           → Q3 close handoff
+{{grain.object | get("error.code")}}           → rate_limited
+```
+
+**Why extractors at all.** Memories store text people wrote. Titles, ticket
+ids, error codes, subject lines and thread keys all live inside free text, and
+every host that wanted one over-fetched to slice it in application code.
+`get` closes a narrower and sharper gap: `record_tool_call` round-trips a
+tool's `input` as parsed JSON, so a Python or Node host receives the structure
+for free — it was specifically the **CAL** path that could not see inside.
+(The existing `json` filter does not help despite its name: it *serialises* a
+value, it does not parse one.)
+
+**Requirements on an implementation.**
+
+- **Totality.** Every one of these is total at render time: a filter that
+  finds nothing yields empty, never an error. One unparseable grain must not
+  fail the render of the other 199.
+- **Validation is at authoring time, not render time.** A pattern that does
+  not compile, a `split` index that is not a number, a `between` missing a
+  delimiter, or a `get` path deeper than the bound MUST be refused when the
+  template is defined. This is the auditability requirement: an unreadable
+  saved query never gets stored, and by the time a pattern reaches the render
+  path it is known to compile.
+- **Patterns MUST use a non-backtracking engine.** A template renders on every
+  turn over untrusted grain content; a backtracking regex there is a
+  denial-of-service primitive. Areev uses Rust's `regex` (a finite-automaton
+  engine), which is why the dialect has **no backreferences and no
+  lookaround** — those are precisely the constructs that force backtracking.
+  An implementation MAY choose another linear-time engine; it MUST NOT choose
+  a backtracking one.
+- **Bounds.** Extractor input is clipped (Areev: 64 KiB), patterns are length-
+  capped (512 chars) and compiled through a bounded cache, and `get` paths are
+  depth-capped (8 segments). These sit beside the existing §10.8 limits
+  (`MAX_TEMPLATE_SIZE` 4096, `MAX_EACH_ITERATIONS` 200).
+
+**`get` deliberately does not transform.** No wildcards, no predicates, no
+arithmetic, and no "remove a key and re-serialise the rest". See the standing
+constraint above.
+
+## B4 — dotted field paths in `WHERE`
+
+```sql
+RECALL tools WHERE input.app = "phone"
+RECALL facts WHERE object.error.code = "rate_limited"
+```
+
+**Semantics.** A field name may be a dotted path of up to **8 segments**. The
+first segment names the grain field; the rest navigate its JSON. A numeric
+segment indexes an array (`items.0.name`), so no separate syntax is needed for
+it. The base field is validated against the grain type as usual (`CAL-E060`);
+the *path* cannot be validated, because the shape lives in the payload rather
+than in the schema.
+
+**A value stored as a JSON string navigates identically to a parsed one.** A
+Tool's `input` is already an object; a failure signature is often a JSON
+document stored *as a string*. Navigating one and not the other would make the
+accessor depend on how the writer happened to type the field.
+
+**A path that does not resolve is UNKNOWN, not false** — it inherits the
+fails-closed rule (`ARCHITECTURE.md` §10, "WHERE fails closed", amended
+2026-09-08 for [#207](https://github.com/AreevAI/areev/issues/207)) rather
+than adding one. So `WHERE input.app = "phone"` matches neither the grains
+whose payload says otherwise nor the grains that have no such key, and
+`input.app != "phone"` does not widen to everything.
+
+**This relaxes an existing rule rather than adding one.** `parse_field_name`
+already accepted one dot (`metadata.source`); a structured payload nests, and
+one level did not reach `object.error.code` — the shape a stored error
+envelope actually has. Indexing is unaffected: like every other type-specific
+key, a path is an executor post-filter over the widened scan, so `CAL-W015`
+still reports a scan that filled.
+
+**No `ORDER BY` on a path.** Sorting by a payload value would need the same
+post-filter widening plus a total order over heterogeneous JSON; it is not
+part of this amendment.
+
+---
+
+## What this batch does not do
+
+- **No `| WHERE` stage, no new pipeline stages.** B1 reuses two that exist.
+- **No first-of-group.** #210's motivating case wants "one row per session,
+  titled from its first event" — B1 gives per-group counts, not a per-group
+  representative row. That is a separate amendment if it is wanted.
+- **No write-side change.** The paved road for a new corpus is still to store
+  the shape you want to read: two fields rather than one payload, because that
+  makes the value filterable as well as renderable. B3 and B4 exist for the
+  corpora already written, which cannot be reshaped — a grain's fields are
+  part of its content address, so changing them changes every hash.


### PR DESCRIPTION
Closes #209. Closes #210. Closes #211.

> Reopens #214, which GitHub auto-closed when its base branch (#212) was deleted on merge. Same commit, rebased onto `main`; #212's review discussion is over there.

Three reads a host could only perform by over-fetching and finishing the job in application code — which also defeats `BUDGET`, since the budget is spent on the rows about to be discarded.

**The spec decision is written down**: [`docs/oms-1.7-amendments-cal-expressiveness.md`](https://github.com/AreevAI/areev/blob/feat/cal-summarise-extract-navigate/docs/oms-1.7-amendments-cal-expressiveness.md), following the `oms-1.6-amendments.md` convention. The standing *refusals* are an `ARCHITECTURE.md` §10 decision, because they are the durable part.

---

## #209 — frequency

```sql
RECALL tools WHERE is_error = true LIMIT 400 GROUP BY tool_name COUNT
```
```
- (8x) simple_note.search_notes
- (6x) phone.search_contacts
```

One row per group with its size, **most frequent first**, ties by key ascending so the answer is reproducible across backends and runs.

**No new syntax was needed, and that is the interesting part.** `GROUP BY x COUNT` already parsed — it returned the plain total, identical to `COUNT` alone, silently discarding the grouping. Nothing could have wanted that number: it is `COUNT` with extra words. So giving the combination the meaning it should always have had takes no meaningful answer away from any caller, and asks nothing of the spec beyond a semantic note.

Group rows are `CalGrainResult`s (`grain_type "group"`, fields `{key, count}`, **empty hash** — a group is computed, not stored, so anything keying on a content address skips it). Every renderer, the assembler and `extract_grains` therefore work on them unchanged. Rendered through a new `group.` namespace, closed at `key`/`count` and bound **only** on a group row — on an ordinary grain both resolve null rather than reading a field that happens to be called `key`.

## #210 — extraction

Six filters that *take* rather than format: `first_line`, `split("<sep>", n)`, `strip_prefix`, `strip_suffix`, `between("<open>", "<close>")`, `match("<pattern>"[, n])`.

```
{{grain.object | between("[", "]")}}     → Q3 close handoff
```

## #211 — navigation

```
{{grain.object | get("error.code")}}     → rate_limited
```
```sql
RECALL tools WHERE input.app = "phone"
RECALL facts WHERE object.error.code = "rate_limited"
```

Both halves, (a) and (b). `record_tool_call` round-trips a tool's `input` as parsed JSON, so Python and Node hosts already received the structure — it was specifically the CAL path that could not see inside.

A field name may now be a dotted path of up to **8 segments**. `parse_field_name` accepted one dot already (`metadata.source`), which does not reach `object.error.code` — the shape a stored error envelope actually has. A value stored **as a JSON string** navigates identically to a parsed one, so the accessor does not depend on how the writer happened to type the field.

**An unresolvable path is UNKNOWN**, so navigation inherits #207's fails-closed rule rather than adding one: `input.app != "phone"` does not widen to everything. That falls out of the two changes composing, and is pinned by a test.

---

## How the ticket's four concerns are answered

The #210 author was explicit that this is the gap to approach most carefully. Taking each:

**1. Conformance surface.** Every addition **extends a closed set**; none opens one. `DESCRIBE CAPABILITIES` now reports `template_filters` and `template_variable_namespaces`, so a client asks rather than guesses.

**2. Cost and safety (ReDoS).** `match` compiles through a bounded LRU cache on `regex` — a finite-automaton engine with **no backtracking**, already an `areev-cal` dependency, so no new dep and no ReDoS primitive. That is *why* the dialect has no backreferences and no lookaround: those are exactly the constructs that force backtracking. Bounds: extractor input clipped at 64 KiB, patterns capped at 512 chars, paths depth-capped at 8 — beside the existing §10.8 limits.

**3. Auditability.** Bad arguments are refused when the template is **defined** (`CAL-E049`), not when it renders — a pattern that does not compile, a `split` index that is not a number, a `between` missing a delimiter, a `get` path past the bound. So "what will this saved query show me?" stays answerable by reading it, *and* the render path stays total by construction: a filter that finds nothing yields empty, because one unparseable grain must not fail the render of the other 199. The two rules are complements, not a compromise.

**4. The render is sometimes the wrong place.** Agreed, and recorded: the paved road for a **new** corpus is still to store the shape you want to read — two fields rather than one payload, because that makes the value *filterable* as well as renderable. These exist for corpora already written, which cannot be reshaped (fields are part of the content address).

### Refused, and recorded as refused

- **Host-registered functions** — the registry travels *with the file*, so a template calling one would render differently, or fail, depending on who opened the memory. That portability is what makes saved queries worth having.
- **A general expression language in templates.**
- **Parse → mutate → re-serialise** — the tempting shape in #211 ("read `error.code`, drop that key, re-emit the rest"). It is a program.

`get` therefore has no wildcards, no predicates, no arithmetic.

---

## Two bugs fixed on the way

**An `ASSEMBLE` source had no pipeline at all**, so a source could not be ranked, bounded or summarised in place — and #209's acceptance ("inside an `ASSEMBLE` source as well as at statement level") was unreachable. Sources now carry their own `pipeline`, run before dedup and budgeting.

**`assemble.rs` kept a second copy of `extract_grains`** that had drifted from the executor's: it matched only `Grains`, so a nested `Assembled` payload silently contributed **nothing** to the enclosing assembly. This is the `execute_source` discard #209 names, and it was worse than the ticket knew. There is one extractor now.

## Tests

`crates/areev-cal/tests/cal_expressiveness.rs`, 14 cases:

- per-group projection incl. **a deliberate tie**, since the ordering is contract;
- `COUNT` without `GROUP BY` still answers the plain total;
- `group.*` renders, and is **null on an ordinary grain**;
- an `ASSEMBLE` source can be a grouped count;
- four filter chains reaching the same title, from the #210 example;
- an extractor that finds nothing renders empty (totality);
- five bad arguments refused at define time — including a backreference and the POSIX `[]]` quirk — and an unknown filter still refused (the set stays closed);
- `get` on a scalar, an array index, a missing path, and a non-JSON value;
- `WHERE` on a path: equality, a number compared as a number, `IS NOT NULL`;
- an unresolvable path fails closed under both `!=` and `NOT`;
- a path past the bound refused before the scan;
- a parsed object and a JSON string navigate the same.

`cargo test --workspace`: **134 suites green**. `cargo clippy --workspace --all-targets`: clean. `docs_examples` (the executable-`sql`-fence gate): green.

## Docs

New: `docs/oms-1.7-amendments-cal-expressiveness.md`. Updated: `docs/cal-reference.md` §3.4 (dotted paths), §4 (`GROUP BY … COUNT`), §6 (the extractor table, the group variables, the regex-dialect note), `ARCHITECTURE.md` §10, `crates/areev-cal/CLAUDE.md`, `CHANGELOG.md`, and a cross-link from `oms-1.6-amendments.md`. No new error codes (`CAL-E040`–`E050` already covers templates), so `ERROR_CODES.md` is unchanged.

## Not done here

- **First-of-group.** #210's example also wants "one row per session, titled from its *first* event". This PR gives per-group *counts*, not a per-group representative row — noted in the amendment as a separate decision if wanted.
- **`ORDER BY` on a path.** Needs a total order over heterogeneous JSON; out of scope.

https://claude.ai/code/session_01JEcv3k8mMwZ5YAa26jdLc2