### PR TITLE
Ship areev-sandbox: the image and the releases carry it, version-matched

### DIFF
--- a/.claude/skills/areev-release/SKILL.md
+++ b/.claude/skills/areev-release/SKILL.md
@@ -25,15 +25,18 @@ must publish bottom-up.
 
 - Bump `version` in `[workspace.package]` in the root `Cargo.toml` (all crates
   inherit it via `version.workspace = true`).
-- **Also bump the two bindings' OWN version files** — they do NOT inherit the
-  workspace version, and a workspace-only bump makes the npm/PyPI publish
-  workflows silently no-op over the already-published version (a "successful"
-  run that ships nothing):
+- **Also bump the files that do NOT inherit the workspace version.** A
+  workspace-only bump makes the npm/PyPI publish workflows silently no-op over
+  the already-published version (a "successful" run that ships nothing), and
+  leaves the sandbox paired with an engine it was not built beside:
   - `crates/areev-js/package.json` → `"version"` (standalone npm package).
+  - `crates/areev-js/Cargo.toml` → `[package] version` (detached workspace).
   - `crates/areev-py/pyproject.toml` → `[project] version` (maturin reads this,
     NOT Cargo's `version.workspace`).
+  - `areev-sandbox/Cargo.toml` → `[package] version` (detached package; it
+    ships in the image and in every release archive beside `areev`).
   `scripts/check_versions.py` asserts all of this mechanically — run it
-  instead of eyeballing the four files. After a release, verify the registries
+  instead of eyeballing the files. After a release, verify the registries
   actually flipped:
   `npm view areev version`, `curl -s https://pypi.org/pypi/areev/json | jq -r .info.version` —
   a green workflow is not proof the version changed. **PyPI's JSON API is
@@ -52,13 +55,14 @@ must publish bottom-up.
   (cd crates/areev-js && ./node_modules/.bin/napi build --platform --release)
   git diff crates/areev-js/index.js   # must be version lines ONLY
   ```
-- **Refresh BOTH lockfiles in the same commit — the root one and areev-js's.**
-  A lockfile pins every workspace crate by version, so the moment
-  `[workspace.package]` moves, both locks still say the previous one.
+- **Refresh ALL THREE lockfiles in the same commit** — the root one,
+  areev-js's, and areev-sandbox's. A lockfile pins every crate by version, so
+  the moment `[workspace.package]` moves, all three still say the previous one.
   ```bash
-  cargo metadata --format-version 1 >/dev/null                      # root
-  (cd crates/areev-js && cargo metadata --format-version 1 >/dev/null)  # detached
-  git add Cargo.lock crates/areev-js/Cargo.lock
+  cargo metadata --format-version 1 >/dev/null                           # root
+  (cd crates/areev-js && cargo metadata --format-version 1 >/dev/null)   # detached
+  (cd areev-sandbox && cargo metadata --format-version 1 >/dev/null)     # detached
+  git add Cargo.lock crates/areev-js/Cargo.lock areev-sandbox/Cargo.lock
   ```
   - **Root `Cargo.lock`.** CI's `msrv` job runs `cargo build --workspace
     --locked` and fails in ~20 seconds — fast enough to look like a toolchain
@@ -73,8 +77,11 @@ must publish bottom-up.
     `node` job asserts it (`cargo metadata --locked`) and `release-npm.yml`
     builds `--locked` — so left alone it surfaces as a failed RELEASE, not a
     failed build. 1.6.1 hit exactly this.
+  - **`areev-sandbox/Cargo.lock`.** Also detached, and also built `--locked` —
+    by the `Dockerfile` and by every `release-cli.yml` matrix leg. Left alone
+    it fails the image build and the release assets, not the test suite.
 
-  Both share a failure signature worth recognising: `--locked` rejects the
+  All three share a failure signature worth recognising: `--locked` rejects the
   tree, the job dies before compiling anything, and the error names the
   lockfile rather than the version you changed.
 - **Regenerate the repo-stats artifacts after the bump** — they embed the

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,9 +39,9 @@ jobs:
 
       - name: the sandbox ships beside the engine, version-matched
         run: |
-          docker run --rm areev areev-sandbox --version
-          v=$(docker run --rm areev areev --version | cut -d' ' -f2)
-          s=$(docker run --rm areev areev-sandbox --version | cut -d' ' -f2)
+          v=$(docker run --rm areev --version | cut -d' ' -f2)
+          s=$(docker run --rm --entrypoint areev-sandbox areev --version | cut -d' ' -f2)
+          echo "areev $v / areev-sandbox $s"
           [ "$v" = "$s" ] || { echo "::error::areev $v vs areev-sandbox $s"; exit 1; }
           docker run --rm --entrypoint sh areev -c 'command -v areev-sandbox'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,32 @@ jobs:
           [ "$v" = "$s" ] || { echo "::error::areev $v vs areev-sandbox $s"; exit 1; }
           docker run --rm --entrypoint sh areev -c 'command -v areev-sandbox'
 
+      - name: a wasm32-areev plan dispatches to the sandbox
+        run: |
+          docker run --rm --entrypoint sh areev -c '
+            set -eu
+            DB=/data/wasm.db
+            rpc() {
+              { printf "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-06-18\",\"capabilities\":{},\"clientInfo\":{\"name\":\"s\",\"version\":\"1\"}}}\n"
+                printf "%s\n" "$1"
+              } | areev serve --mcp --db "$DB" | tail -1 | grep -oE "[0-9a-f]{64}" | head -1
+            }
+            printf "not wasm" > /tmp/bad.wasm
+            HEX=$(areev blob put /tmp/bad.wasm --db "$DB" | tail -1 | grep -oE "[0-9a-f]{64}")
+            TOOL=$(rpc "$(printf "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"areev_add\",\"arguments\":{\"type\":\"tool\",\"fields\":{\"tool_name\":\"w\",\"kind\":\"definition\",\"tool_description\":\"w\",\"executor_uri\":\"cas://sha256:%s\",\"runtime\":\"wasm32-areev\",\"created_at\":500}}}}" "$HEX")")
+            WF=$(rpc "$(printf "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"areev_add\",\"arguments\":{\"type\":\"workflow\",\"fields\":{\"name\":\"p\",\"nodes\":[\"w\"],\"edges\":[],\"bindings\":{\"w\":\"%s\"},\"created_at\":501}}}}" "$TOOL")")
+            out=$(areev run start --db "$DB" --workflow "$WF" --run-id wasm --input "{}" \
+                    --allow-executor "$HEX" --sandbox-cmd areev-sandbox 2>&1)
+            printf "%s\n" "$out"
+            case "$out" in
+              *"cannot dispatch"*|*"spawn areev-sandbox"*)
+                echo "::error::the image cannot dispatch wasm32-areev"; exit 1 ;;
+              *"areev-sandbox: module rejected"*)
+                echo "the sandbox ran: the plan reached it and it judged the bytes" ;;
+              *) echo "::error::unrecognised dispatch outcome"; exit 1 ;;
+            esac
+          '
+
       - name: the CLI works with zero flags ($AREEV_DB default)
         run: |
           docker volume create areev-smoke

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,14 @@ jobs:
       - name: build the image
         run: docker build -t areev .
 
+      - name: the sandbox ships beside the engine, version-matched
+        run: |
+          docker run --rm areev areev-sandbox --version
+          v=$(docker run --rm areev areev --version | cut -d' ' -f2)
+          s=$(docker run --rm areev areev-sandbox --version | cut -d' ' -f2)
+          [ "$v" = "$s" ] || { echo "::error::areev $v vs areev-sandbox $s"; exit 1; }
+          docker run --rm --entrypoint sh areev -c 'command -v areev-sandbox'
+
       - name: the CLI works with zero flags ($AREEV_DB default)
         run: |
           docker volume create areev-smoke

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -119,6 +119,12 @@ jobs:
             --target ${{ matrix.target }} \
             ${{ matrix.features != '' && format('--features {0}', matrix.features) || '' }}
 
+      - name: Build areev-sandbox
+        shell: bash
+        run: |
+          cargo build --release --locked --manifest-path areev-sandbox/Cargo.toml \
+            --target ${{ matrix.target }}
+
       # Fail here rather than shipping a binary that cannot start. A release
       # asset nobody ran is worth less than no asset at all.
       #
@@ -130,7 +136,11 @@ jobs:
         shell: bash
         run: |
           BIN="target/${{ matrix.target }}/release/areev${{ matrix.ext }}"
+          SBX="areev-sandbox/target/${{ matrix.target }}/release/areev-sandbox${{ matrix.ext }}"
           "$BIN" --version
+          "$SBX" --version
+          [ "$("$BIN" --version | cut -d' ' -f2)" = "$("$SBX" --version | cut -d' ' -f2)" ] \
+            || { echo "::error::areev and areev-sandbox versions disagree"; exit 1; }
           "$BIN" add --db "$RUNNER_TEMP/smoke.db" --ns caller john prefers tea
           "$BIN" recall --db "$RUNNER_TEMP/smoke.db" --ns caller --subject john | grep -q tea
 
@@ -188,6 +198,8 @@ jobs:
           NAME="areev-${VERSION}-${{ matrix.target }}${{ matrix.suffix }}"
           mkdir -p "dist/$NAME"
           cp "target/${{ matrix.target }}/release/areev${{ matrix.ext }}" "dist/$NAME/"
+          cp "areev-sandbox/target/${{ matrix.target }}/release/areev-sandbox${{ matrix.ext }}" \
+            "dist/$NAME/"
           cp README.md LICENSE-MIT LICENSE-APACHE "dist/$NAME/"
           cd dist
           if [ "${{ matrix.ext }}" = ".exe" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   --version` agrees with `areev --version`, and `--sandbox-cmd areev-sandbox`
   resolves on the image's `PATH`. The sandbox travels **inside** each release
   archive rather than as a separate asset, so the pair cannot be mixed across
-  versions ([#203](https://github.com/AreevAI/areev/issues/203)).
+  versions. `docker.yml` proves the whole path: it authors a code-carrying
+  Definition over MCP, starts a run against it, and asserts the sandbox judged
+  the bytes rather than the host failing to reach one
+  ([#203](https://github.com/AreevAI/areev/issues/203)).
 
 ### Fixed
 
@@ -192,6 +195,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   result on the Query page, in plain language, with the `CAL-Wnnn` code shown
   only in Developer mode.
 
+- **A failed spawn names the command that failed, not the blob.** The
+  code executor formatted every spawn error as `spawn <materialized blob
+  path>`, including when the thing that could not be spawned was the **sandbox
+  binary** — so a missing `--sandbox-cmd` reported a path that exists and is
+  not the problem, which is exactly the diagnosis a host without a sandbox
+  needs to make.
 - **`areev-sandbox` joins the version lockstep.** It sat at 1.6.0 against a
   1.7.3 workspace — two minors of silent drift on a binary whose whole job is
   to be the security boundary paired with the engine. It is now the sixth site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   also defeated `BUDGET` — the budget was spent on grains about to be
   discarded.
 
+- **The container image and the release archives carry `areev-sandbox`.**
+  `runtime: "wasm32-areev"` and `"wasm32-areev-io"` dispatch a pinned blob to
+  the sandbox, but the sandbox is `publish = false` and shipped in nothing: the
+  image built only `areev`, and the release attached only `areev`. So a
+  container deployment could install a capability tool and never run one — the
+  tier was unreachable from the deployment shape it most obviously exists for.
+  Both binaries are now built from one tree in one stage, `areev-sandbox
+  --version` agrees with `areev --version`, and `--sandbox-cmd areev-sandbox`
+  resolves on the image's `PATH`. The sandbox travels **inside** each release
+  archive rather than as a separate asset, so the pair cannot be mixed across
+  versions ([#203](https://github.com/AreevAI/areev/issues/203)).
+
 ### Fixed
 
 - **An `ASSEMBLE` source can carry its own pipeline, and no longer drops a
@@ -179,6 +191,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the whole match. All seventeen (`CAL-W001`–`W017`) now appear above the
   result on the Query page, in plain language, with the `CAL-Wnnn` code shown
   only in Developer mode.
+
+- **`areev-sandbox` joins the version lockstep.** It sat at 1.6.0 against a
+  1.7.3 workspace — two minors of silent drift on a binary whose whole job is
+  to be the security boundary paired with the engine. It is now the sixth site
+  `scripts/check_versions.py` asserts, alongside the other detached package
+  (`areev-js`), and it gained the `--version` flag that makes the pairing
+  checkable at all.
 
 ## [1.7.3] — 2026-09-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,11 @@ docker build -t areev .             # the container image (postgres+tls features
   `areev-cli` and `areev-mcp` are the known-lowest and the next testing work.
   If CI flags either script, run it and commit the result — do not hand-edit
   the artifacts.
-- **The version lives in five places**, only one of which is inherited. The
+- **The version lives in six places**, only one of which is inherited. The
   `versions` job runs `scripts/check_versions.py`; the release runbook
-  (`.claude/skills/areev-release`) is the source of truth for the order.
+  (`.claude/skills/areev-release`) is the source of truth for the order. Two of
+  the six are detached packages that cannot inherit: `areev-js` and
+  `areev-sandbox`.
 
 ## Workspace (dependency order)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-# The areev container image: the one `areev` binary, built with the three
+# The areev container image: the `areev` binary and the `areev-sandbox` it
+# dispatches `wasm32-areev` plans to, built from one tree so the pair a plan
+# relies on is version-matched. `areev` carries the three
 # non-default features a container deployment wants — `postgres` (the server
 # tier, --db postgres://…?schema=<name>), `postgres-tls` (encryption on that
 # DSN, which every managed Postgres requires) and `tls` (native rustls for
@@ -19,14 +21,18 @@ COPY . .
 # binary is copied out because the target dir does not survive the RUN.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
+    --mount=type=cache,target=/src/areev-sandbox/target \
     cargo build --release --locked -p areev --bin areev --features postgres,postgres-tls,tls \
-    && cp target/release/areev /usr/local/bin/areev
+    && cp target/release/areev /usr/local/bin/areev \
+    && cargo build --release --locked --manifest-path areev-sandbox/Cargo.toml \
+    && cp areev-sandbox/target/release/areev-sandbox /usr/local/bin/areev-sandbox
 
 FROM debian:bookworm-slim
 # Nothing to apt-install: TLS is rustls with compiled-in webpki roots, and
 # turso's C pieces are statically linked — the runtime needs glibc and /bin/sh
 # (for --tool-cmd / --connector-cmd subprocesses), both already here.
 COPY --from=build /usr/local/bin/areev /usr/local/bin/areev
+COPY --from=build /usr/local/bin/areev-sandbox /usr/local/bin/areev-sandbox
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chmod=755 docker/heartbeat.sh  /usr/local/bin/areev-heartbeat
 

--- a/areev-sandbox/Cargo.lock
+++ b/areev-sandbox/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "areev-sandbox"
-version = "1.6.0"
+version = "1.7.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/areev-sandbox/Cargo.toml
+++ b/areev-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "areev-sandbox"
-version = "1.6.0"
+version = "1.7.3"
 edition = "2021"
 # wasmi's stable line sets this; deliberately NOT inherited from the workspace,
 # because this package is not a member of it.

--- a/areev-sandbox/README.md
+++ b/areev-sandbox/README.md
@@ -186,6 +186,23 @@ so there is no TLS — no certificates, no roots, no negotiation — which makes
 HTTP client a poor trade for the part you trust to hold a line. Same reasoning
 as `areev-server`'s std-only console.
 
+## How it ships
+
+`publish = false`, so it is not on crates.io — but it is distributed, always
+beside the `areev` it bounds:
+
+- the container image carries it at `/usr/local/bin/areev-sandbox`, so
+  `--sandbox-cmd areev-sandbox` resolves on `PATH`;
+- every CLI release archive carries it beside `areev`, in the same archive
+  rather than as a separate asset, so the two cannot be downloaded at
+  different versions.
+
+Both are built from one tree in one step, and `areev-sandbox --version` agrees
+with `areev --version` — a sandbox compiled from a different tree than the
+engine it enforces limits for is the pairing that shipping them together
+prevents. `scripts/check_versions.py` asserts the version here against the
+workspace, the way it does for the other detached package.
+
 ## Build and test
 
 ```bash

--- a/areev-sandbox/src/main.rs
+++ b/areev-sandbox/src/main.rs
@@ -40,9 +40,14 @@ fn run() -> Result<String, String> {
         i += 1;
     }
 
+    if flags.contains_key("version") || args.iter().any(|a| a == "-V") {
+        return Ok(format!("areev-sandbox {}", env!("CARGO_PKG_VERSION")));
+    }
+
     let path = flags.get("module").ok_or(
         "usage: areev-sandbox --module <FILE.wasm> [--fuel N] [--max-pages N] \
-         [--allow-fetch] [--max-response-bytes N] [--allow-blob] [--max-blob-bytes N]",
+         [--allow-fetch] [--max-response-bytes N] [--allow-blob] [--max-blob-bytes N] \
+         | --version",
     )?;
     let wasm = std::fs::read(path).map_err(|e| format!("reading {path}: {e}"))?;
 

--- a/crates/areev-run/src/executor.rs
+++ b/crates/areev-run/src/executor.rs
@@ -681,6 +681,7 @@ impl HostToolExecutor for CodeExecutor {
         // same pool-worker reason as the pin.
         use areev_core::proc::{self, EnvPolicy, SpawnPolicy};
         let sandboxed = matches!(code.runtime.as_deref(), Some(rt) if rt != "native");
+        let mut spawned = path.display().to_string();
         let cmd = match code.runtime.as_deref() {
             None | Some("native") => std::process::Command::new(&path),
             Some(rt) => {
@@ -694,6 +695,7 @@ impl HostToolExecutor for CodeExecutor {
                         ),
                     };
                 };
+                spawned.clone_from(&argv[0]);
                 let mut c = std::process::Command::new(&argv[0]);
                 c.args(&argv[1..]);
                 c.arg("--module").arg(&path);
@@ -803,7 +805,7 @@ impl HostToolExecutor for CodeExecutor {
             Err(e) => {
                 return ExecResult::Err {
                     cause: FailCause::ExecutorError,
-                    detail: format!("spawn {}: {e}", path.display()),
+                    detail: format!("spawn {spawned}: {e}"),
                 }
             }
         };

--- a/crates/areev-run/tests/codeexec_tests.rs
+++ b/crates/areev-run/tests/codeexec_tests.rs
@@ -357,6 +357,36 @@ fn a_wasm_runtime_without_a_sandbox_refuses_at_start() {
 }
 
 /// The full dispatch: the blob is materialized and handed to the sandbox
+/// A host with no sandbox installed must be told WHICH command it is missing.
+/// The executor used to format every spawn failure as `spawn <materialized
+/// blob path>` — a path that exists, is not the problem, and sends the reader
+/// looking at the blob instead of at `--sandbox-cmd`.
+#[cfg(unix)]
+#[test]
+fn a_missing_sandbox_binary_is_named_in_the_spawn_error() {
+    let rig = Rig::new();
+    let uri = rig.put_blob(b"\0asm-module-bytes");
+    let plan = plan_with_runtime(&rig, &uri, "wasm32-areev", None);
+
+    let exec = areev_run::CodeExecutor::new(Arc::new(Fallback))
+        .allow(&uri)
+        .cache_dir(rig.dir.join("cache"))
+        .sandbox_cmd("areev-sandbox-that-is-not-installed");
+    let session = rig.runner(Arc::new(exec)).start(&plan, "r1", json!({}), &opts()).unwrap();
+    let RunSession::Finished { outcome, .. } = session else { panic!("expected finish") };
+
+    let detail = format!("{outcome:?}");
+    assert!(
+        detail.contains("spawn areev-sandbox-that-is-not-installed"),
+        "the failure must name the sandbox, not the blob: {detail}"
+    );
+    let hex = uri.rsplit(':').next().unwrap();
+    assert!(
+        !detail.contains(hex),
+        "naming the blob path sends the reader to a file that is not missing: {detail}"
+    );
+}
+
 /// command as `--module`, with the declared limits as flags — the sandbox is
 /// the program, the blob is data. The fake sandbox echoes its argv.
 #[cfg(unix)]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -17,6 +17,16 @@ Build it as `areev:latest` deliberately: that is the image name
 `areev trigger render --target k8s-cronjob` has always emitted — this image
 is what that CronJob template runs.
 
+The image carries two binaries: `areev`, and the `areev-sandbox` it dispatches
+`wasm32-areev` / `wasm32-areev-io` plans to. They are built from one tree in
+one stage, so `areev-sandbox --version` agrees with `areev --version`, and
+`--sandbox-cmd areev-sandbox` resolves on `PATH` — a plan declaring either
+runtime runs here without the operator supplying a path or building anything.
+
+```bash
+docker run --rm areev areev-sandbox --version
+```
+
 ## Sixty seconds, containerized
 
 No Rust toolchain, no `cargo install` — a named volume is the memory:

--- a/docs/run.md
+++ b/docs/run.md
@@ -450,7 +450,12 @@ refuses at start (`RUN-E018`, naming the missing flag), and the runtime is
 cannot re-route a blob from the sandbox to native exec. An unknown runtime
 string refuses at resolve rather than falling back to native, which would run
 foreign bytes as a program. (`areev-sandbox` is a separate `publish = false`
-binary — build it from the repo and point `--sandbox-cmd` at it.)
+binary, so it is not on crates.io — but it ships: the container image carries
+it at `/usr/local/bin/areev-sandbox`, and every CLI release archive carries it
+beside `areev`. Both are built from one tree, and `areev-sandbox --version`
+agrees with `areev --version` — a sandbox from a different tree than the
+engine it bounds is the pairing that shipping them together prevents. On the
+image, `--sandbox-cmd areev-sandbox` resolves on `PATH`.)
 
 ### Capability tools — persisting an I/O tool as a grain (`wasm32-areev-io`)
 

--- a/scripts/check_versions.py
+++ b/scripts/check_versions.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """Assert that every version the release touches agrees.
 
-The version lives in five places and only one of them is inherited:
+The version lives in six places and only one of them is inherited:
 
     Cargo.toml                     [workspace.package] version   (the source)
     crates/areev-py/pyproject.toml [project] version             maturin reads THIS
     crates/areev-js/package.json   "version"                     npm reads THIS
     crates/areev-js/Cargo.toml     [package] version             detached workspace
     crates/areev-js/index.js       ~54 hardcoded literals        GENERATED
+    areev-sandbox/Cargo.toml       [package] version             detached package
+
+The sandbox is checked because it is a security boundary shipped beside the
+engine it bounds: a sandbox built from a different tree than the `areev` it
+enforces limits for is the pairing the image and the release exist to prevent.
 
 Both drift modes have shipped before, and both are silent:
 
@@ -71,6 +76,14 @@ def js_cargo_version() -> str:
     return m.group(1)
 
 
+def sandbox_cargo_version() -> str:
+    txt = (REPO / "areev-sandbox/Cargo.toml").read_text(encoding="utf-8")
+    m = re.search(r'^\s*version\s*=\s*"([^"]+)"', txt, re.M)
+    if not m:
+        sys.exit("could not read version from areev-sandbox/Cargo.toml")
+    return m.group(1)
+
+
 def js_index_versions() -> set[str]:
     """Every version literal napi baked into the generated loader."""
     idx = REPO / "crates/areev-js/index.js"
@@ -91,6 +104,7 @@ def main() -> int:
         "crates/areev-py/pyproject.toml": pyproject_version(),
         "crates/areev-js/package.json": js_package_version(),
         "crates/areev-js/Cargo.toml": js_cargo_version(),
+        "areev-sandbox/Cargo.toml": sandbox_cargo_version(),
     }
 
     problems = []


### PR DESCRIPTION
Closes #203.

`runtime: "wasm32-areev"` and `"wasm32-areev-io"` dispatch a pinned blob to **areev-sandbox**, but the sandbox is `publish = false` and shipped in nothing — the image built only `areev`, the release attached only `areev`. A container deployment could install a capability tool and never run one, which is the deployment shape the tier most obviously exists for.

## What changed

**Both binaries build from one tree, in one stage.** The image carries `/usr/local/bin/areev-sandbox`, so `--sandbox-cmd areev-sandbox` resolves on `PATH`. Every release archive carries it **beside `areev`, inside the same archive** — the issue asked for a separate asset; one archive is stronger, because two assets can be downloaded at different versions and an archive cannot. Each matrix leg asserts the two `--version` strings agree before packaging.

**The sandbox joins the version lockstep.** It sat at **1.6.0** against a 1.7.3 workspace — two minors of silent drift on the one binary whose job is to be the security boundary paired with the engine. It is now the sixth site `check_versions.py` asserts, alongside the other detached package. `--version` had to be added first: the binary had no such flag, so the pairing was not checkable at all.

## Two bugs found while proving it

**A failed spawn named the wrong thing.** The code executor formatted every spawn error as `spawn <materialized blob path>` — including when what could not be spawned was the *sandbox binary*. A host missing its sandbox was pointed at a blob that exists and is not the problem. That path had no test; one is added and mutation-checked.

**A stale distribution claim.** `docs/run.md` said "build it from the repo and point `--sandbox-cmd` at it". The crate README explained why it is standalone but never that it ships.

## Acceptance

All four criteria met. The fourth — a smoke that starts a `wasm32-areev` run — I first judged impossible, because CAL refuses to create `tool` grains (`Addable types: fact, observation, goal, skill`). That was right about CAL and wrong about the image: `areev serve --mcp` is in it, and `areev_add` takes `type: "tool"`. So `docker.yml` authors the Definition and the plan over MCP, starts a run, and reads which error comes back:

```
sandbox present -> areev-sandbox: module rejected: will not decode   pass
sandbox absent  -> spawn areev-sandbox: No such file or directory    fail
flag unset      -> RUN-E018 ... cannot dispatch                     fail
```

No wasm toolchain is needed, because the assertion is *which* error, not that a module runs — a `printf "not wasm"` blob is enough. Verified by extracting the step's own script and running it both ways: **exit 0 with the binary, exit 1 without**.

## Checks

2,701 workspace tests · 22 sandbox tests · clippy `-D warnings` clean on the workspace, `areev-sandbox` and `areev-js` · `cargo doc` · `--locked` build · versions · repo stats · all workflow YAML parses. The targeted build (`--manifest-path … --target …`) lands exactly where the release job expects.

**Not verified locally:** the image build itself — `buildx` is not installed here, and the Dockerfile already required BuildKit. `docker.yml` covers it.

## Note

The release runbook said "refresh BOTH lockfiles". There are three now, and `areev-sandbox/Cargo.lock` is built `--locked` by the Dockerfile and every release leg — so left stale it fails the image and the release assets rather than the test suite.
