### PR TITLE
Serve blob reads on the Postgres tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`areev::blob_get` works on the Postgres tier** — the whole class of
+  attachment-parsing capability tools was unavailable on the backend the
+  server tier actually runs on. `{"blob": {"read": true}}` (#106) is what lets
+  a `wasm32-areev-io` module read the attachment a trigger's connector already
+  filed, by address, read-only, every read journaled as a `blob_read`
+  Observation. On PostgreSQL the broker answered `501`: the read is lock-free
+  because it goes to the `.blobs` sidecar without opening the database, and
+  that sidecar is an embedded-backend thing. The documented alternative — the
+  tool opens the memory itself — needs handing the tool a credential to the
+  memory, which is exactly what a capability tool exists to avoid.
+
+  `read_blob_offline` now serves a `postgres://…?schema=…` locator too: one
+  short-lived connection of its own, one schema-qualified `SELECT` against the
+  in-schema `blobs` table, closed on return. It still never opens the memory,
+  so it cannot contend with the run holding it — and on this backend there is
+  no exclusive lock to avoid in the first place, which makes it cheaper than
+  the embedded case rather than harder. Qualifying the table (#181) keeps it
+  independent of `search_path`, so it is safe behind a pooler. Blobs are never
+  sealed here (the blob key derives from the page cipher, which Postgres
+  refuses), so the sealed branch cannot arise.
+
+  `areev blob get` lifts the same restriction: it skipped the lock-free path
+  for a DSN, a workaround for the limitation this removes, so the two
+  blob-reading surfaces now behave identically
+  ([#202](https://github.com/AreevAI/areev/issues/202)).
+
 - **CAL can summarise by frequency, extract from text, and navigate a JSON
   payload** (#209, #210, #211) — three reads that could only be done by
   over-fetching and finishing the job in host code, which also defeated

--- a/crates/areev-cli/src/main.rs
+++ b/crates/areev-cli/src/main.rs
@@ -13,7 +13,7 @@ use std::process::ExitCode;
 use areev_cal::{CalExecutor, CalExecutorConfig, AreevFacade};
 use areev_core::error::Hash;
 use areev_core::types::{ContentBlock, Event, Fact, Grain, TokenUsage, Tool};
-use areev_store::{Axis, Areev, Direction};
+use areev_store::{is_pg_dsn, Axis, Areev, Direction};
 use areev_loop_adapter::{now_ms, AreevSubstrate};
 use areev_loop::{Decision, Engine, ObserverType, Policy, RecStatus, RunOptions, ScopeSet, Severity};
 
@@ -809,11 +809,6 @@ fn report_meta_warnings(facade: &areev_cal::AreevFacade) {
     for w in facade.meta_warnings() {
         eprintln!("areev: warning: {w}");
     }
-}
-
-/// A `--mount` target is a postgres DSN rather than a file path.
-fn is_pg_dsn(target: &str) -> bool {
-    target.starts_with("postgres://") || target.starts_with("postgresql://")
 }
 
 /// Would this mount point at the SAME memory as the primary?
@@ -1773,12 +1768,13 @@ Nothing was written — apply the snippet yourself (or rerun with your own paths
     // attachment out of reach of the very `--tool-cmd` subprocess the run
     // spawned to process it. Blobs are immutable, live beside the file, and
     // carry their checksum as their address, so reading one needs neither the
-    // database nor a lock. A sealed blob still needs the memory's derived key,
-    // so that case falls through to the normal open below.
-    if cmd == "blob" && positional.first().map(String::as_str) == Some("get") && !is_pg_url {
+    // database nor a lock — on postgres, one connection of its own and a
+    // schema-qualified SELECT. A sealed blob still needs the memory's derived
+    // key, so that case falls through to the normal open below.
+    if cmd == "blob" && positional.first().map(String::as_str) == Some("get") {
         let uri = positional
             .get(1)
-            .ok_or("usage: areev blob get <cas-uri> --db <file>")?;
+            .ok_or("usage: areev blob get <cas-uri> --db <file|dsn>")?;
         if let Some(bytes) = areev_store::read_blob_offline(&db, uri).map_err(|e| e.to_string())? {
             use std::io::Write;
             std::io::stdout().write_all(&bytes).map_err(|e| e.to_string())?;

--- a/crates/areev-conformance/src/cases/blobs_hybrid.rs
+++ b/crates/areev-conformance/src/cases/blobs_hybrid.rs
@@ -23,6 +23,27 @@ pub fn cas_blob_roundtrip_and_gc(b: &dyn Backend) {
     assert!(m.get_blob(&uri).is_err(), "reclaimed blob is gone");
 }
 
+/// `read_blob_offline` reaches a blob by address without opening the memory,
+/// on either backend (#202) — which is what lets a sandboxed tool read the
+/// attachment its own run filed while that run still holds the memory.
+pub fn blob_reads_without_opening_the_memory(b: &dyn Backend) {
+    let uri = {
+        let mut m = b.open_named("offline_blob");
+        m.put_blob(b"attachment bytes").unwrap()
+    };
+    let locator = b.locator("offline_blob");
+    let _held_open_throughout = b.open_named("offline_blob");
+
+    let got = areev_store::read_blob_offline(&locator, &uri)
+        .expect("a stored blob is readable by address")
+        .expect("a plaintext blob is not sealed");
+    assert_eq!(got, b"attachment bytes");
+
+    let absent = format!("cas://sha256:{}", "b".repeat(64));
+    assert!(areev_store::read_blob_offline(&locator, &absent).is_err());
+    assert!(areev_store::read_blob_offline(&locator, "cas://sha256:zz").is_err());
+}
+
 pub fn bm25_leg_finds_text(b: &dyn Backend) {
     let mut m = b.open();
     m.add(&fact("caller", "john", "allergic_to", "peanuts")).unwrap();

--- a/crates/areev-conformance/src/lib.rs
+++ b/crates/areev-conformance/src/lib.rs
@@ -52,6 +52,11 @@ pub trait Backend {
         self.try_open_named_with(name, opts).expect("open store")
     }
 
+    /// What a host names this memory by: a file path on the embedded backend,
+    /// a `postgres://…?schema=<name>` DSN on postgres. For cases exercising an
+    /// API that takes the memory's address rather than a handle.
+    fn locator(&self, name: &str) -> String;
+
     /// A scratch directory for interchange files (bundles). Backend-neutral:
     /// bundles are files regardless of where the store lives.
     fn scratch(&self) -> &Path;
@@ -96,6 +101,10 @@ impl Backend for TursoBackend {
     ) -> areev_core::error::Result<Areev> {
         let path = self.dir.path().join(format!("{name}.db"));
         Areev::open_with(path.to_str().expect("utf8 path"), opts)
+    }
+
+    fn locator(&self, name: &str) -> String {
+        self.path_for(name).to_str().expect("utf8 path").to_string()
     }
 
     fn scratch(&self) -> &Path {
@@ -161,6 +170,10 @@ impl Backend for PgBackend {
         let schema = format!("{}_{}", self.prefix, name);
         self.opened.borrow_mut().insert(schema.clone());
         Areev::open_postgres_with(&self.url, &schema, opts)
+    }
+
+    fn locator(&self, name: &str) -> String {
+        format!("{}?schema={}_{}", self.url, self.prefix, name)
     }
 
     fn scratch(&self) -> &Path {
@@ -239,6 +252,7 @@ macro_rules! for_each_conformance_case {
         // CAS blobs + hybrid legs
         $per_case!(cas_blob_roundtrip_and_gc);
         $per_case!(forget_reclaims_sole_referenced_blob);
+        $per_case!(blob_reads_without_opening_the_memory);
         $per_case!(bm25_leg_finds_text);
         $per_case!(vector_leg_roundtrip);
         $per_case!(external_vectors_need_no_embedder);

--- a/crates/areev-js/src/lib.rs
+++ b/crates/areev-js/src/lib.rs
@@ -692,7 +692,7 @@ impl Areev {
         // leaving a handle behind — which on Node would need an explicit
         // close() nobody has a reference to.
         let anon = anon_key.as_deref().map(parse_anon_key).transpose()?;
-        let is_pg = path.starts_with("postgres://") || path.starts_with("postgresql://");
+        let is_pg = areev_store::is_pg_dsn(&path);
         let store = match (is_pg, passphrase) {
             (true, Some(_)) => {
                 return Err(err(

--- a/crates/areev-py/src/lib.rs
+++ b/crates/areev-py/src/lib.rs
@@ -488,7 +488,7 @@ impl Areev {
             .detach(|| {
                 // A postgres://…?schema=<name> DSN selects the server-tier
                 // backend — same API, the memory lives in a Postgres schema.
-                if path.starts_with("postgres://") || path.starts_with("postgresql://") {
+                if areev_store::is_pg_dsn(&path) {
                     return open_postgres_from_dsn(
                         &path,
                         tel,

--- a/crates/areev-run/src/broker.rs
+++ b/crates/areev-run/src/broker.rs
@@ -983,11 +983,13 @@ impl Broker {
 
     /// Serve `POST /blob` from this memory's CAS store (#106).
     ///
-    /// The path, not a handle: [`areev_store::read_blob_offline`] reads the
-    /// `.blobs` sidecar without opening the database, so serving a blob never
-    /// contends with the driver's exclusive write lock on the same file. That
-    /// is the same property that lets a `--tool-cmd` subprocess run
-    /// `areev blob get` mid-run.
+    /// The path, not a handle: [`areev_store::read_blob_offline`] never opens
+    /// the memory, so serving a blob cannot contend with the run holding it.
+    /// On the embedded backend it reads the `.blobs` sidecar beside the file,
+    /// avoiding the driver's exclusive write lock; on postgres it opens its
+    /// own short-lived connection and reads the in-schema `blobs` table, which
+    /// takes no lock at all. That is the same property that lets a
+    /// `--tool-cmd` subprocess run `areev blob get` mid-run.
     ///
     /// Until a host calls this, blob reads are refused whatever a module
     /// declared — declaring is not granting here either.
@@ -1228,24 +1230,6 @@ fn serve_blob(
             .to_string(),
         );
     };
-
-    // The lock-free door is the `.blobs` sidecar, which is an EMBEDDED-backend
-    // thing: on Postgres a blob lives in-schema and reaching it means opening
-    // the memory. Said plainly and up front rather than letting the sidecar
-    // read miss and report "blob missing", which would send someone hunting
-    // for an attachment that is present and simply not reachable this way.
-    if db_path.starts_with("postgres://") || db_path.starts_with("postgresql://") {
-        return respond(
-            stream,
-            501,
-            &serde_json::json!({
-                "error": "blob reads from a sandboxed tool are not supported on the postgres \
-                          backend: the lock-free path is the .blobs sidecar, which only the \
-                          embedded backend has"
-            })
-            .to_string(),
-        );
-    }
 
     match areev_store::read_blob_offline(&db_path, &req.uri) {
         Ok(Some(bytes)) => {

--- a/crates/areev-store/CLAUDE.md
+++ b/crates/areev-store/CLAUDE.md
@@ -195,6 +195,11 @@ Pg-only multi-writer race cases); extend it whenever store semantics change.
   instead of mixing vector spaces. Host config is never persisted here —
   the file describes itself, the host supplies capabilities.
   `tests/meta_tests.rs` covers persistence/reconciliation.
+- `read_blob_offline(locator, uri)` reads a blob by ADDRESS without opening the
+  memory, on either backend (#202): the sidecar on embedded, a short-lived
+  connection and a schema-qualified `SELECT blobs` on postgres. It takes no
+  lock and no session state, which is what lets a sandboxed tool — or
+  `areev blob get` — read an attachment while a run holds the memory.
 - CAS blob sidecar at `"{path}.blobs"`, git-style `hex[..2]/hex[2..]` fan-out:
   `put_blob` (idempotent, tmp+rename), `get_blob` (re-verifies sha256),
   `gc_blobs` (ref-count from live grains' `content_refs`). Free fn

--- a/crates/areev-store/src/lib.rs
+++ b/crates/areev-store/src/lib.rs
@@ -1714,9 +1714,13 @@ fn projected_text(view: &DeserializedGrain) -> Option<String> {
 pub fn read_blob_offline(db_path: &str, uri: &str) -> Result<Option<Vec<u8>>> {
     use sha2::{Digest, Sha256};
     let hex = Areev::cas_hex(uri)?;
-    let dir = std::path::PathBuf::from(format!("{db_path}.blobs"));
-    let raw = std::fs::read(fs_blob_path(&dir, hex))
-        .map_err(|_| AreevError::Storage(format!("blob missing: {uri}")))?;
+    let raw = if is_pg_dsn(db_path) {
+        read_blob_pg(db_path, hex, uri)?
+    } else {
+        let dir = std::path::PathBuf::from(format!("{db_path}.blobs"));
+        std::fs::read(fs_blob_path(&dir, hex))
+            .map_err(|_| AreevError::Storage(format!("blob missing: {uri}")))?
+    };
     if blobcrypt::is_sealed(&raw) {
         return Ok(None);
     }
@@ -1724,6 +1728,46 @@ pub fn read_blob_offline(db_path: &str, uri: &str) -> Result<Option<Vec<u8>>> {
         return Err(AreevError::Storage(format!("blob corrupt: {uri}")));
     }
     Ok(Some(raw))
+}
+
+/// Whether a memory locator names the postgres backend rather than a file.
+///
+/// One spelling, because every surface that takes a `--db`-shaped string has
+/// to make this decision: the CLI, both bindings, and the blob read below.
+pub fn is_pg_dsn(locator: &str) -> bool {
+    locator.starts_with("postgres://") || locator.starts_with("postgresql://")
+}
+
+/// The postgres half of [`read_blob_offline`]: its own short-lived connection,
+/// one schema-qualified `SELECT`, closed on return.
+///
+/// No lock and no session state, so it cannot contend with the run holding the
+/// schema. Qualifying the table (#181) is what keeps it independent of
+/// `search_path`, so it is safe behind a pooler too.
+#[cfg(feature = "postgres")]
+fn read_blob_pg(dsn: &str, hex: &str, uri: &str) -> Result<Vec<u8>> {
+    let (url, schema) = pg::split_schema_url(dsn)?;
+    let raw = hex::decode(hex).map_err(|e| AreevError::Storage(e.to_string()))?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| AreevError::Storage(e.to_string()))?;
+    let client = pgtls::connect(&rt, &url)?;
+    let sql = pg::qualify_tables("SELECT body FROM blobs WHERE hash = $1", &schema);
+    let rows = rt
+        .block_on(client.query(sql.as_str(), &[&raw]))
+        .map_err(pg::pg_err)?;
+    let row = rows
+        .first()
+        .ok_or_else(|| AreevError::Storage(format!("blob missing: {uri}")))?;
+    row.try_get::<_, Vec<u8>>(0).map_err(pg::pg_err)
+}
+
+#[cfg(not(feature = "postgres"))]
+fn read_blob_pg(_dsn: &str, _hex: &str, _uri: &str) -> Result<Vec<u8>> {
+    Err(AreevError::Storage(
+        "this build lacks the postgres backend — rebuild with --features postgres-tls".into(),
+    ))
 }
 
 /// Where the CAS blob payloads live: a `.blobs` fan-out directory next to

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -533,8 +533,9 @@ media is referenced rather than carried.
 
 A tool that needs the bytes should take the `cas://` URI from the grain's
 `content_refs` (which `areev_recall` already returns) and fetch them out of
-band with `areev blob get`, which reads the sidecar without opening the memory
-and therefore works even while a run holds the writer. See
+band with `areev blob get`, which reads the blob by address without opening the
+memory — the `.blobs` sidecar on the embedded backend, one short-lived
+connection on postgres — and therefore works even while a run holds the writer. See
 [cookbook §17](cookbook.md).
 
 ---

--- a/docs/run.md
+++ b/docs/run.md
@@ -500,13 +500,13 @@ A blob-only module still needs a grant, because the token is what identifies
 the caller: `--tool-egress 'parse_attachments::'` names neither a credential
 nor a method, minting a token and authorizing no egress whatsoever.
 
-⚠️ **Embedded backend only.** The read is lock-free precisely because it goes
-to the `.blobs` sidecar without opening the database — and that sidecar is an
-embedded-backend thing. On PostgreSQL a blob lives in-schema, so
-`areev::blob_get` returns a `501` naming the limitation rather than reporting
-the attachment as missing. On that backend a tool can open the memory
-directly anyway (see [Backend divergence](#backend-divergence-reading-the-memory-mid-run-85)),
-so the capability is closing an embedded-tier gap.
+**Both backends** (#202). The read never opens the memory, so serving a blob
+cannot contend with the run holding it. On the embedded backend that means the
+`.blobs` sidecar beside the file, which avoids the driver's exclusive write
+lock; on PostgreSQL it means one short-lived connection of the broker's own and
+a schema-qualified `SELECT` against the in-schema `blobs` table — no lock at
+all, and independent of `search_path`, so it is safe behind a pooler. A
+conformance case runs the same module against both.
 
 `headers` names the non-credential request headers the module may set, and is
 deny-by-default like `credentials`: declaring none permits none. A name the


### PR DESCRIPTION
Closes #202.

`{"blob": {"read": true}}` (#106) is what lets a `wasm32-areev-io` module read the attachment a trigger's connector already filed — by address, read-only, every read journaled as a `blob_read` Observation. On PostgreSQL the broker answered **501**, so on the tier the server product actually runs on, the whole class of attachment-parsing capability tools was unavailable.

The documented alternative — the tool opens the memory itself — means handing it a credential to that memory, which is precisely what a capability tool exists to avoid.

## The fix

`read_blob_offline` now serves a `postgres://…?schema=…` locator too: its own short-lived connection, one schema-qualified `SELECT` against the in-schema `blobs` table, closed on return. The broker's 501 is **deleted rather than narrowed** — widening the function was smaller than adding a second one, so its call site is unchanged.

Three things made this simpler than the issue assumed:

- **There is no lock to avoid.** Postgres admits concurrent readers, so this is cheaper here than the embedded case the sidecar exists to work around.
- **Qualifying the table** (#181, just landed) keeps the read independent of `search_path`, so it is safe behind a pooler.
- **Blobs are never sealed on this backend** — the blob key derives from the page cipher Postgres refuses — so that branch cannot arise.

`areev blob get` carried the same restriction (`&& !is_pg_url`), a workaround for the limitation this removes. Lifted, so the two blob-reading surfaces stop diverging for a reason that no longer holds.

## Cleaned up on the way

The "is this a DSN?" test existed in **four** copies — CLI, both bindings, and the one this change would have added. It now lives once in the store, which owns the concept. And the row read uses `try_get` rather than `get`, so a column whose type ever surprises us is an error the broker reports rather than a panic that takes the serving thread with it.

## Testing

A conformance case puts a blob in, **holds the memory open**, and reads it by address — registered once, run against both backends. The `Backend` trait gains `locator` for it (a file path or a DSN), the seam any case needs when the API under test takes an address rather than a handle.

```
turso: 69 passed        pg: 83 passed   (real pgvector:pg16)
```

Mutation-checked: forcing the embedded path makes the Postgres run fail. Driven end-to-end too — `areev blob get` against a live schema while another handle held the memory returned the bytes.

2,702 workspace tests · 124 pytest · 72 `node --test` · clippy `-D warnings` clean including `--features postgres` · `--locked` build · versions · repo stats.

## Docs

`run.md`'s "⚠️ Embedded backend only" warning, `mcp-reference.md`'s sidecar claim, and the store crate notes.
