### PR TITLE
Bindings: an empty tool_env clears the environment like --tool-env does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **An empty `tool_env` / `toolEnv` in the bindings now means "clear to the
+  minimal set", as the CLI's `--tool-env ""` does** (#197). Both bindings
+  filtered the empty string out before building the policy, so the strictest
+  request — clear the environment, admit nothing beyond what a command needs
+  to start — was answered with the loosest posture, inherit everything. A host
+  wanting the clear-only policy had to name a variable already in the minimal
+  set just to select it. `None` / `null` keep the inherit default, unchanged.
+  Pinned in both bindings' tests, on the run executors and the trigger
+  connector.
+
 ## [1.7.3] — 2026-09-07
 
 ### Added

--- a/crates/areev-js/__test__/smoke.mjs
+++ b/crates/areev-js/__test__/smoke.mjs
@@ -751,6 +751,10 @@ test('toolEnv clears a host tool environment down to what it names', async () =>
 
   assert.equal(await seen('js-env-inherit', null), 'leaked')
   assert.equal(await seen('js-env-cleared', 'AREEV_TEST_OTHER'), '')
+  // Presence is the setting (#197): an EMPTY toolEnv clears to the minimal
+  // set, the strictest posture — exactly as the CLI's `--tool-env ""` does.
+  // It used to be read as "not configured" and inherit everything.
+  assert.equal(await seen('js-env-empty', ''), '')
   await m.close()
 })
 
@@ -798,11 +802,25 @@ test('toolEnv reaches the trigger connector, not just the run executors', async 
   assert.deepEqual(await sawSoFar(), ['leaked'],
     'without toolEnv the connector inherits, as the default promises')
 
+  // Items dedup on `/saw`, so every phase below must make the connector see
+  // something new. The EMPTY list clears to the minimal set (#197 —
+  // presence is the setting, exactly as the CLI's `--tool-env ""`): the
+  // planted variable is gone.
   await wait()
-  const cleared = await poll('AREEV_TEST_OTHER')
-  assert.equal(cleared.items, 1, `the connector still runs: ${JSON.stringify(cleared)}`)
+  const emptied = await poll('')
+  assert.equal(emptied.items, 1, `the connector still runs: ${JSON.stringify(emptied)}`)
   assert.deepEqual((await sawSoFar()).sort(), ['', 'leaked'],
-    'a cleared connector environment must not carry the planted variable')
+    'an empty toolEnv must clear, not inherit')
+
+  // A named list passes exactly the names given: re-admit the planted
+  // variable under a new value and the connector sees that value, nothing
+  // it was not handed.
+  process.env.AREEV_TEST_PLANTED = 'readmitted'
+  await wait()
+  const named = await poll('AREEV_TEST_PLANTED')
+  assert.equal(named.items, 1, JSON.stringify(named))
+  assert.deepEqual((await sawSoFar()).sort(), ['', 'leaked', 'readmitted'],
+    'a named list re-admits only what it names')
   await m.close()
 })
 

--- a/crates/areev-js/src/lib.rs
+++ b/crates/areev-js/src/lib.rs
@@ -3400,7 +3400,11 @@ fn js_runner_with_llm(
 /// holding a secret. One helper so the connector and the run executors cannot
 /// drift apart.
 fn js_tool_env_policy(names: Option<&str>) -> Option<areev_core::proc::EnvPolicy> {
-    let names = names.map(str::trim).filter(|n| !n.is_empty())?;
+    // Presence is the setting (`docs/run.md`): `toolEnv: ""` clears to the
+    // minimal set, the strictest posture, exactly as the CLI's `--tool-env ""`
+    // does. Only `null` keeps the inherit default. Filtering the empty string
+    // out here used to turn the strictest request into the loosest answer.
+    let names = names.map(str::trim)?;
     let (policy, dropped) = areev_run::env_allow_policy(names);
     if !dropped.is_empty() {
         eprintln!("areev: toolEnv dropped {} — registered as holding a secret", dropped.join(", "));
@@ -3414,10 +3418,10 @@ struct JsExecutorPin {
     executor_cache: Option<String>,
     sandbox_cmd: Option<String>,
     executor_timeout_secs: Option<i64>,
-    /// Comma list of variables a host tool may keep. Unset (or empty)
-    /// inherits this process's environment minus the registered secrets; a
-    /// list clears it and passes only those, plus the minimal set a command
-    /// needs to start.
+    /// Comma list of variables a host tool may keep. Unset inherits this
+    /// process's environment minus the registered secrets; a list — the
+    /// empty list included — clears it and passes only those, plus the
+    /// minimal set a command needs to start.
     tool_env: Option<String>,
 }
 

--- a/crates/areev-py/src/lib.rs
+++ b/crates/areev-py/src/lib.rs
@@ -3061,10 +3061,10 @@ struct ExecutorPin {
     executor_cache: Option<String>,
     sandbox_cmd: Option<String>,
     executor_timeout_secs: Option<u64>,
-    /// Comma list of variables a host tool may keep. Unset (or empty)
-    /// inherits this process's environment minus the registered secrets; a
-    /// list clears it and passes only those, plus the minimal set a command
-    /// needs to start.
+    /// Comma list of variables a host tool may keep. Unset inherits this
+    /// process's environment minus the registered secrets; a list — the
+    /// empty list included — clears it and passes only those, plus the
+    /// minimal set a command needs to start.
     tool_env: Option<String>,
 }
 
@@ -3072,7 +3072,11 @@ struct ExecutorPin {
 /// as holding a secret. One helper so the connector and the run executors
 /// cannot drift apart.
 fn tool_env_policy(names: Option<&str>) -> Option<areev_core::proc::EnvPolicy> {
-    let names = names.map(str::trim).filter(|n| !n.is_empty())?;
+    // Presence is the setting (`docs/run.md`): `tool_env=""` clears to the
+    // minimal set, the strictest posture, exactly as the CLI's `--tool-env ""`
+    // does. Only `None` keeps the inherit default. Filtering the empty string
+    // out here used to turn the strictest request into the loosest answer.
+    let names = names.map(str::trim)?;
     let (policy, dropped) = areev_run::env_allow_policy(names);
     if !dropped.is_empty() {
         eprintln!(

--- a/crates/areev-py/tests/test_areev.py
+++ b/crates/areev-py/tests/test_areev.py
@@ -560,6 +560,10 @@ def test_tool_env_clears_a_host_tool_environment(tmp_path, monkeypatch):
 
     assert seen("py-env-inherit") == "leaked"
     assert seen("py-env-cleared", tool_env="AREEV_TEST_OTHER") == ""
+    # Presence is the setting (#197): an EMPTY tool_env clears to the minimal
+    # set, the strictest posture — exactly as the CLI's `--tool-env ""` does.
+    # It used to be read as "not configured" and inherit everything.
+    assert seen("py-env-empty", tool_env="") == ""
 
 
 def test_tool_env_reaches_the_trigger_connector(tmp_path, monkeypatch):
@@ -595,9 +599,20 @@ def test_tool_env_reaches_the_trigger_connector(tmp_path, monkeypatch):
     assert poll()["items"] == 1
     assert saw_so_far() == ["leaked"], "without tool_env the connector inherits"
 
+    # Items dedup on `/saw`, so every phase below must make the connector see
+    # something new. The EMPTY list clears to the minimal set (#197 — presence
+    # is the setting, exactly as the CLI's `--tool-env ""`): the planted
+    # variable is gone.
     time.sleep(1.1)
-    assert poll(tool_env="AREEV_TEST_OTHER")["items"] == 1
-    assert saw_so_far() == ["", "leaked"], "a cleared connector must not carry it"
+    assert poll(tool_env="")["items"] == 1
+    assert saw_so_far() == ["", "leaked"], "an empty tool_env must clear, not inherit"
+
+    # A named list passes exactly the names given: re-admit the planted
+    # variable under a new value and the connector sees that value.
+    monkeypatch.setenv("AREEV_TEST_PLANTED", "readmitted")
+    time.sleep(1.1)
+    assert poll(tool_env="AREEV_TEST_PLANTED")["items"] == 1
+    assert saw_so_far() == ["", "leaked", "readmitted"], "a named list re-admits only what it names"
 
 
 def test_tool_env_refuses_to_re_admit_a_registered_secret(tmp_path, monkeypatch):

--- a/docs/run.md
+++ b/docs/run.md
@@ -191,7 +191,10 @@ posture — and are honored as such. Every other `$AREEV_RUN_*` variable reads a
 empty value as "not configured", which is right for them (`AREEV_RUN_SANDBOX_CMD=""`
 means "no sandbox") and would be exactly backwards here: it would take an
 operator asking for the strictest environment and silently hand them the
-loosest. Only an **absent** flag and variable keep the inherit default.
+loosest. Only an **absent** flag and variable keep the inherit default. The
+bindings follow the same rule: `tool_env=""` (Python) and `toolEnv: ""`
+(Node) clear to the minimal set, on the run executors, a pinned native blob
+and the trigger connector alike; `None` / `null` keep the inherit default.
 
 ### The model boundary (anonymization)
 


### PR DESCRIPTION
The CLI's `--tool-env ""` clears a tool's environment down to the minimal
set. The bindings' `tool_env=""` / `toolEnv: ""` were filtered out as
unset and silently inherited everything — the one downgrade nobody
notices, on the flag that exists to prevent it.

- `tool_env_policy` in both bindings now treats presence as the setting:
  an empty string clears; `None` / `null` keeps the inherit default.
- Applies to the run executors, a pinned native blob, and the trigger
  connector.
- Both smoke suites assert the clear and that a named list re-admits a
  variable afterwards; `docs/run.md` and the changelog say so.

Verified: Node 72/72, Python 88/88, clippy clean.

Closes #197.