### PR TITLE
mcp: areev_run_input takes the runner's Result (main is red)

### DIFF
--- a/crates/areev-mcp/src/lib.rs
+++ b/crates/areev-mcp/src/lib.rs
@@ -839,7 +839,7 @@ impl McpServer {
                 let message = args.get("message").and_then(Value::as_str)
                     .ok_or("areev_run_input requires 'message'")?;
                 let who = self.run_identity();
-                self.runner(&who)
+                self.runner(&who)?
                     .input(run_id, message, &who)
                     .map_err(|e| e.to_string())?;
                 Ok(json!({"queued": run_id, "by": who,


### PR DESCRIPTION
**main does not compile.** #223 made `McpServer::runner` fallible and updated every call site it could see; #224 added one it could not — the `areev_run_input` arm, written against the old signature on a branch that predated the change. Both were green on their own branches, and git merged them without a conflict because they touch different lines of the same file. The second merge landed 41 seconds after the first, and nothing re-ran CI on the result.

The fix is the `?` every neighbouring arm already has. `areev-mcp` sits under the `areev` binary, so the single compile error is what failed clippy, doc, msrv, coverage, tls, and every test and node-binding job on main.

Verified locally on merged main: full workspace suite and clippy `-D warnings` both clean.