### PR TITLE
Reap idle Postgres connections, and evict the pool with them (#229)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1866,6 +1866,46 @@ one pool share nothing; and the whole conformance suite passes through a
 pool of two, under the `RESET ALL` chaos hook, and through PgBouncer in
 transaction mode.
 
+### A pool is reaped, because the thing that multiplies is the pool and not the memory
+
+The pool bounds what one *DSN* costs, and the sentence it licensed — "N
+memories hold at most P connections" — is true only where N memories share a
+DSN. Areev Cloud gives every memory its own Postgres **role**, which is the
+isolation property it sells, and a role is part of the pool key: one pool per
+tenant, `?pool=` bounding each separately rather than their sum. Nothing ever
+released one. The registry had no eviction and the idle list had no TTL, so a
+worker's connection count grew with the number of distinct tenants it had
+*ever touched* since it started, not with how many were in use, and only a
+restart brought it down — a cell of 500 memories across four workers trending
+to 2,000 connections against a server sized in the low hundreds (#229). The
+previous decision's own remedy was unavailable, because it had just withdrawn
+the handle LRU that used to bound this by accident.
+
+The decision: idleness is a state a pool can leave AND return to. A
+connection idle past `?pool_idle_secs=` (default 300 s,
+`$AREEV_PG_POOL_IDLE_SECS` out of band, `0` to keep the old never-reap
+behaviour) is closed, and a pool whose idle list has emptied while no handle
+and no checkout holds it is dropped from the registry, taking its runtime's
+worker threads with it. So an idle memory holds no connection, an idle
+process holds no pool, and the reopen after a reaping costs one dial and says
+nothing — the schema is stamped, so it is not even a bootstrap.
+
+Two details carry the weight. The reaper is ONE plain OS thread per process,
+not a task per pool: a task per pool would rebuild the same accumulation in
+thread form, and a task on a pool's own runtime cannot drop that pool, since
+dropping a `Runtime` from inside itself panics. And eviction's safety is the
+`Arc` count read under the registry lock — every other reference to a pool is
+a clone that can only be made while holding that lock, so a count of one
+proves the registry is the last owner and the pool can go. The alternative
+considered and not taken was a process-wide connection ceiling: it bounds the
+same number, but a cap shared across pools can deadlock a caller that holds
+one memory's transaction open while opening another's, which the per-pool
+semaphore cannot. Proof: `tests/pg_pool.rs` opens eight memories on eight
+DSNs — the shape eight roles would have — and asserts eight connections held
+after every handle is dropped, then zero once the TTL passes, with all eight
+pools gone from the registry; and the whole conformance suite passes with a
+one-second TTL under the chaos hook, re-dialling throughout.
+
 ### The dictionary is keyed by digest, because the index must be bounded and the value is not
 
 Every subject, relation and object string is interned into `terms` (§3): a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Idle Postgres connections are reaped, and a quiet pool is evicted**
+  (#229). `?pool=` bounds one pool, and the pool is keyed by the DSN — so a
+  host that gives every tenant its own Postgres role has one pool per tenant,
+  and nothing ever released one: a long-lived worker's connection count grew
+  with the number of distinct roles it had *ever touched*, not with how many
+  were in use, and only a restart brought it down. Now a connection idle past
+  `?pool_idle_secs=T` (default 300 s, `$AREEV_PG_POOL_IDLE_SECS` out of band,
+  the DSN winning, `0` to keep the previous never-reap behaviour) is closed by
+  one process-wide reaper thread, and a pool whose connections have all gone —
+  with no handle and no statement holding it — is dropped from the registry,
+  releasing its runtime's worker threads too. An idle memory now genuinely
+  holds nothing; reopening one whose pool was reaped costs one dial and emits
+  no warning. `?pool=` semantics are unchanged, and the parameter is stripped
+  before the DSN reaches the driver like every other store parameter. Proven
+  by a new case in `tests/pg_pool.rs` — eight memories on eight DSNs (the
+  shape eight roles would have) holding eight connections after every handle
+  is dropped, then zero, with all eight pools gone — and by the whole Pg
+  conformance suite, chaos hook included, running with a one-second TTL.
+  `docs/deployment-profile.md` now states the retained-connection model a
+  capacity plan needs.
+
 ## [1.8.0] — 2026-09-11
 
 ### Added

--- a/crates/areev-conformance/tests/pg_pool.rs
+++ b/crates/areev-conformance/tests/pg_pool.rs
@@ -1,4 +1,6 @@
-//! #181, the pool: N memories in one process hold at most `?pool=` connections.
+//! #181, the pool: N memories in one process hold at most `?pool=`
+//! connections — and #229, the reaper: a pool that has gone quiet gives them
+//! back, and then goes itself.
 #![cfg(feature = "postgres")]
 
 use areev_conformance::{fact, Backend, PgBackend};
@@ -15,24 +17,29 @@ fn with_param(url: &str, p: &str) -> String {
     if url.contains('?') { format!("{url}&{p}") } else { format!("{url}?{p}") }
 }
 
-/// This process's own connections carry a unique `application_name`, so the
+/// This test's own connections carry a unique `application_name`, so the
 /// count is not polluted by the other test binaries cargo runs in parallel
-/// against the same server (each is its own process and its own pool).
-fn app_name() -> String {
-    format!("areev_pool_{}", std::process::id())
+/// against the same server (each is its own process and its own pool) — nor
+/// by the other test in THIS binary, which cargo runs on a parallel thread
+/// against the same registry. `application_name` is not one of the store's
+/// parameters, so a DSN naming one is its own pool.
+fn app_name(test: &str) -> String {
+    format!("areev_pool_{test}_{}", std::process::id())
 }
 
-/// Every connection this process holds, counted from a probe that names
-/// itself differently (and pools separately).
-fn live(url: &str) -> i64 {
+/// Every connection this process holds under `test`'s name — or under any
+/// name extending it, which is how the reaping test spells one pool per
+/// tenant. Counted from a probe that names itself differently (and pools
+/// separately).
+fn live(url: &str, test: &str) -> i64 {
     let sep = if url.contains('?') { "&" } else { "?" };
     let probe = format!("{url}{sep}application_name=areev-probe&pool=1");
     areev_store::pg::query_raw_i64(
         &probe,
         &format!(
             "SELECT count(*) FROM pg_stat_activity \
-              WHERE application_name = '{}' AND datname = current_database()",
-            app_name()
+              WHERE application_name LIKE '{}%' AND datname = current_database()",
+            app_name(test)
         ),
     )
     .unwrap()
@@ -44,7 +51,12 @@ fn n_memories_hold_at_most_p_connections() {
         eprintln!("skipping: no DATABASE_URL/AREEV_PG_URL");
         return;
     };
-    let pooled = with_param(&url, &format!("pool=3&application_name={}", app_name()));
+    // `pool_idle_secs=0`: this test is about the cap, so nothing may be
+    // reaped under it (#229).
+    let pooled = with_param(
+        &url,
+        &format!("pool=3&pool_idle_secs=0&application_name={}", app_name("cap")),
+    );
     let b = PgBackend::new(&pooled);
 
     // Twelve handles, telemetry on — twenty-four connections before #181.
@@ -59,7 +71,7 @@ fn n_memories_hold_at_most_p_connections() {
         m.add(&fact("ns", &format!("s{i}"), "r", "o")).unwrap();
         assert_eq!(m.count().unwrap(), 1);
     }
-    assert!(live(&url) <= 3, "the cap is the cap: {} live", live(&url));
+    assert!(live(&url, "cap") <= 3, "the cap is the cap: {} live", live(&url, "cap"));
 
     // Overlapping transactions from more threads than the cap: everything
     // lands, nothing crosses, the count never exceeds the cap.
@@ -78,7 +90,7 @@ fn n_memories_hold_at_most_p_connections() {
         .collect();
     let mut peak = 0;
     for _ in 0..20 {
-        peak = peak.max(live(&url));
+        peak = peak.max(live(&url, "cap"));
         std::thread::sleep(std::time::Duration::from_millis(10));
     }
     for w in writers {
@@ -102,4 +114,85 @@ fn n_memories_hold_at_most_p_connections() {
         "{:?}",
         m.open_warnings()
     );
+}
+
+/// #229: the pool gives its connections back, and then goes itself.
+///
+/// In the topology the issue was measured on, `?pool=` bounds nothing: a
+/// host that gives every tenant its own ROLE has one POOL per tenant, and
+/// eight memories opened and closed left eight connections held whatever
+/// `?pool=` said. This reproduces that shape — the pool key is the DSN, so
+/// eight DSNs differing in a non-store parameter are eight pools, exactly as
+/// eight roles would be — and then asserts the property the issue asks for:
+/// with no handle open, an idle memory holds nothing.
+#[test]
+fn idle_connections_are_reaped_and_the_pool_goes_with_them() {
+    let Some(url) = pg_url() else {
+        eprintln!("skipping: no DATABASE_URL/AREEV_PG_URL");
+        return;
+    };
+    let ttl = std::time::Duration::from_secs(3);
+    // One DSN — and therefore one pool — per memory.
+    let dsn = |i: usize| {
+        with_param(
+            &url,
+            &format!("pool=8&pool_idle_secs=3&application_name={}_{i}", app_name("reap")),
+        )
+    };
+    let b = PgBackend::new(&url);
+
+    let mut handles: Vec<Areev> = (0..8)
+        .map(|i| Areev::open_postgres(&dsn(i), &b.schema_for(&format!("reap_{i}"))).unwrap())
+        .collect();
+    for (i, m) in handles.iter_mut().enumerate() {
+        m.add(&fact("ns", &format!("s{i}"), "r", "o")).unwrap();
+        assert_eq!(m.count().unwrap(), 1);
+    }
+    // One cheap read each, so all eight connections are freshly idle and the
+    // count below is not racing the TTL of whichever memory was opened first.
+    for m in handles.iter_mut() {
+        m.count().unwrap();
+    }
+    assert_eq!(live(&url, "reap"), 8, "one pool per tenant means one connection per tenant");
+    drop(handles);
+
+    // Still held right after close — the pool keeps them for the TTL, which
+    // is the whole point of pooling. This is the state the issue measured:
+    // eight memories closed, eight connections retained.
+    assert_eq!(
+        live(&url, "reap"),
+        8,
+        "a closed handle returns its connection to the pool, it does not close it"
+    );
+
+    // …and given back after it. Generously bounded: the reaper looks every
+    // half-TTL, and a loaded CI box is allowed to be slow.
+    let deadline = std::time::Instant::now() + ttl * 10;
+    while live(&url, "reap") > 0 && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    assert_eq!(
+        live(&url, "reap"),
+        0,
+        "an idle memory must hold NO connection once the TTL has passed"
+    );
+    // The pools themselves went with them, so the process is not
+    // accumulating one runtime (and its worker threads) per role either.
+    for i in 0..8 {
+        assert!(
+            !areev_store::pg::pool_is_registered(&dsn(i)),
+            "a pool holding nothing, that nothing holds, must not outlive the sweep"
+        );
+    }
+
+    // Reopening after the reaping is an ordinary open: it works, it sees
+    // what was written, and it says nothing about any of this.
+    let mut m = Areev::open_postgres(&dsn(3), &b.schema_for("reap_3")).unwrap();
+    assert_eq!(m.count().unwrap(), 1);
+    assert_eq!(
+        m.latest("ns", "s3", "r").unwrap().unwrap().get_str("object"),
+        Some("o"),
+        "the memory is unchanged by its pool's lifetime"
+    );
+    assert!(m.open_warnings().is_empty(), "{:?}", m.open_warnings());
 }

--- a/crates/areev-store/CLAUDE.md
+++ b/crates/areev-store/CLAUDE.md
@@ -39,8 +39,9 @@ transports implement it:
   drops the statements at every `BEGIN` instead, the two halves `pg_stale.rs`
   pins) and through a real transaction-mode PgBouncer. **A handle owns no
   connection** (#181): `PgPool`, one per DSN per process (keyed with
-  `schema`/`provision`/`pool` stripped), owns a one-worker multi-thread
-  runtime, a fair `Semaphore` sized by `?pool=` / `$AREEV_PG_POOL` (default
+  `schema`/`provision`/`pool`/`pool_idle_secs` stripped — `pool_key`), owns a
+  multi-thread runtime, a fair `Semaphore` sized by `?pool=` /
+  `$AREEV_PG_POOL` (default
   `DEFAULT_POOL_SIZE`), and the idle connections. `with_conn` borrows one
   per statement; `begin` pins one on the handle until `commit`/`rollback`
   (`Drop` rolls back a forgotten one). Per-connection state lives on
@@ -52,10 +53,26 @@ transports implement it:
   on a `search_path`, and that is `SET LOCAL` to its transaction; a dialled
   connection carries `public, ext` for pgvector's type only. A dead
   connection is discarded (`Checkout::note`), never returned; reads outside
-  a transaction replay once on a fresh one, writes never. Pinned by
+  a transaction replay once on a fresh one, writes never.
+  **A quiet pool is reaped** (#229): each idle connection is stamped when it
+  goes back (`idle: Vec<(Instant, PooledConn)>`, popped from the END so the
+  cold ones age out), one process-wide `areev-pg-reap` thread closes what has
+  been idle past `?pool_idle_secs=` / `$AREEV_PG_POOL_IDLE_SECS` (default
+  `DEFAULT_POOL_IDLE_SECS`, `0` = never) every half-TTL, and `sweep` then
+  evicts the pool itself — runtime threads included — once its idle list is
+  empty and `Arc::strong_count == 1` under the registry lock, which is what
+  proves nothing holds it (a handle or a `Checkout` is a clone only
+  obtainable there). Reaping is what bounds a host that gives every tenant
+  its own ROLE, where one pool per tenant makes `?pool=` bound nothing in
+  aggregate. A plain OS thread, not a task per pool: a task per pool
+  re-creates the accumulation in thread form, and dropping a `Runtime` from
+  inside itself panics. Pinned by
   `tests/pg_pool.rs` (N handles ≤ P connections, counted in
-  `pg_stat_activity` by `application_name = areev`) and the two-backend
-  `memories_in_one_process_share_nothing` case. The `vector(dim)` column is
+  `pg_stat_activity` by `application_name = areev`; plus eight one-pool-each
+  memories going 8 → 8-after-close → 0-after-TTL, pools evicted) and the
+  two-backend
+  `memories_in_one_process_share_nothing` case. The whole Pg suite also
+  passes with `AREEV_PG_POOL_IDLE_SECS=1`, re-dialling throughout. The `vector(dim)` column is
   added at the first `set_embedder` (dim mismatch = hard refusal), CAS blobs
   live in an in-schema table, and `prefers_batched_reads = true`. Page
   cipher and the telemetry sidecar are file-backend-only and rejected at

--- a/crates/areev-store/src/pg.rs
+++ b/crates/areev-store/src/pg.rs
@@ -24,6 +24,14 @@
 //! none. Every statement is schema-qualified and every per-transaction
 //! setting is `SET LOCAL`, which is what lets any connection serve any
 //! schema.
+//!
+//! A pool that has gone quiet gives its connections BACK (#229): one reaper
+//! thread per process closes a connection idle past `?pool_idle_secs=`
+//! (default [`DEFAULT_POOL_IDLE_SECS`]) and then evicts the pool itself once
+//! nothing holds it. Without that, "N memories hold at most P connections"
+//! bounds nothing on a host that gives every tenant its own ROLE — a
+//! different role is a different pool, so a long-lived worker accumulated one
+//! pool, and one connection, per tenant it had ever touched.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -390,6 +398,73 @@ pub fn strip_pool(url: &str) -> String {
     strip_param(url, "pool")
 }
 
+/// How long a pooled connection may sit idle before the reaper closes it,
+/// when neither `?pool_idle_secs=` nor `$AREEV_PG_POOL_IDLE_SECS` says
+/// otherwise. Five minutes: long enough that a process doing steady work
+/// re-dials approximately never, short enough that a host handing every
+/// tenant its own role gets its connections back on a human timescale
+/// rather than at the next restart (#229).
+pub const DEFAULT_POOL_IDLE_SECS: u64 = 300;
+
+/// The out-of-band spelling of `?pool_idle_secs=`, for a DSN that is not
+/// yours to edit.
+pub const POOL_IDLE_ENV: &str = "AREEV_PG_POOL_IDLE_SECS";
+
+/// Our name for the parameter, in the two places that must agree: the reader
+/// below and the pool key.
+const POOL_IDLE_PARAM: &str = "pool_idle_secs";
+
+/// How long `url`'s pool keeps an idle connection: `?pool_idle_secs=N` on the
+/// DSN, else `$AREEV_PG_POOL_IDLE_SECS`, else [`DEFAULT_POOL_IDLE_SECS`]. The
+/// DSN wins, as everywhere.
+///
+/// `0` is `None` — never reap, hold every connection dialled until the
+/// process ends, which is what every build before #229 did.
+pub fn pool_idle_ttl(url: &str) -> Result<Option<std::time::Duration>> {
+    if let Some((_, query)) = url.split_once('?') {
+        let mut from_dsn = None;
+        for pair in query.split('&') {
+            if let Some((k, v)) = pair.split_once('=') {
+                if k == POOL_IDLE_PARAM {
+                    from_dsn = Some(parse_idle_secs(&format!("postgres URL: {POOL_IDLE_PARAM}"), v)?);
+                }
+            }
+        }
+        if let Some(t) = from_dsn {
+            return Ok(t);
+        }
+    }
+    match std::env::var(POOL_IDLE_ENV) {
+        Ok(v) if !v.trim().is_empty() => parse_idle_secs(&format!("${POOL_IDLE_ENV}"), v.trim()),
+        _ => Ok(Some(std::time::Duration::from_secs(DEFAULT_POOL_IDLE_SECS))),
+    }
+}
+
+fn parse_idle_secs(what: &str, v: &str) -> Result<Option<std::time::Duration>> {
+    match v.parse::<u64>() {
+        Ok(0) => Ok(None),
+        Ok(n) => Ok(Some(std::time::Duration::from_secs(n))),
+        Err(_) => Err(AreevError::Validation(format!(
+            "{what}={v:?} must be a whole number of seconds an idle connection is kept \
+             (0 to keep them for the life of the process)"
+        ))),
+    }
+}
+
+/// Strip `?pool_idle_secs=` from a DSN.
+pub fn strip_pool_idle(url: &str) -> String {
+    strip_param(url, POOL_IDLE_PARAM)
+}
+
+/// How the two pool knobs read back in a warning — `None` is a setting, not
+/// an absence.
+fn describe_ttl(ttl: Option<std::time::Duration>) -> String {
+    match ttl {
+        Some(d) => format!("{}s", d.as_secs()),
+        None => "never".to_string(),
+    }
+}
+
 /// One connection, with the state that belongs to it rather than to any
 /// memory handle: its prepared statements (a `Statement` names a server-side
 /// object of ONE session) and the two GUCs a handle may want set.
@@ -406,14 +481,19 @@ pub(crate) struct PooledConn {
 }
 
 /// The per-DSN pool: one runtime driving every connection, a fair semaphore
-/// as the cap, and the idle connections. Lives for the process; a handle
-/// borrows from it per statement, or per transaction.
+/// as the cap, and the idle connections (each stamped with when it went
+/// idle, which is what the reaper reads). A handle borrows from it per
+/// statement, or per transaction; the pool outlives every handle, but no
+/// longer outlives its own usefulness (#229).
 pub(crate) struct PgPool {
     rt: tokio::runtime::Runtime,
     url: String,
     cap: usize,
+    /// How long an idle connection is kept before the reaper closes it.
+    /// `None` = for the life of the process.
+    idle_ttl: Option<std::time::Duration>,
     sem: std::sync::Arc<tokio::sync::Semaphore>,
-    idle: std::sync::Mutex<Vec<PooledConn>>,
+    idle: std::sync::Mutex<Vec<(std::time::Instant, PooledConn)>>,
 }
 
 /// A borrowed connection. Returned to the pool on drop unless it broke.
@@ -444,39 +524,147 @@ impl Drop for Checkout {
         if let Some(c) = self.conn.take() {
             if !self.broken && !c.client.is_closed() {
                 if let Ok(mut idle) = self.pool.idle.lock() {
-                    idle.push(c);
+                    // Stamped as it goes back, and taken from the END on the
+                    // way out: the hot connection stays hot and the cold ones
+                    // age out, which is what makes an idle TTL bite.
+                    idle.push((std::time::Instant::now(), c));
                 }
             }
         }
     }
 }
 
-static POOLS: std::sync::OnceLock<
-    std::sync::Mutex<HashMap<String, std::sync::Arc<PgPool>>>,
-> = std::sync::OnceLock::new();
+/// The live pools, plus whether the reaper thread is running. One lock over
+/// both, deliberately: the reaper decides to stop in the same critical
+/// section an opener uses to insert a pool, so a pool can never be left with
+/// nobody to reap it.
+#[derive(Default)]
+struct Registry {
+    pools: HashMap<String, std::sync::Arc<PgPool>>,
+    reaping: bool,
+}
+
+static POOLS: std::sync::OnceLock<std::sync::Mutex<Registry>> = std::sync::OnceLock::new();
+
+fn registry() -> std::sync::MutexGuard<'static, Registry> {
+    POOLS.get_or_init(Default::default).lock().unwrap_or_else(|p| p.into_inner())
+}
+
+/// What keys a pool: the DSN with the store's own parameters stripped. One
+/// server, role and TLS setting, however many memories and whatever each of
+/// them asked for in `?pool=` / `?pool_idle_secs=`.
+fn pool_key(url: &str) -> String {
+    strip_param(
+        &strip_param(&strip_param(&strip_param(url, "pool"), POOL_IDLE_PARAM), "provision"),
+        "schema",
+    )
+}
+
+/// Does this process still hold a pool for `url`? The reaper's effect on the
+/// pool itself — the connection count is the server's side of the same story
+/// — for the test that pins #229.
+#[cfg(feature = "conformance")]
+pub fn pool_is_registered(url: &str) -> bool {
+    registry().pools.contains_key(&pool_key(url))
+}
+
+/// How often the reaper looks: half the shortest TTL in the process, bounded
+/// so a long TTL costs nothing and a short one is still observed promptly.
+/// A connection therefore lives at most `ttl + MAX_REAP_TICK`.
+const MIN_REAP_TICK: std::time::Duration = std::time::Duration::from_millis(250);
+const MAX_REAP_TICK: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Start the reaper if some pool now wants one. Called with the registry
+/// locked, so the flag it sets cannot race the sweep that clears it.
+fn start_reaper(reg: &mut Registry) {
+    if reg.reaping || !reg.pools.values().any(|p| p.idle_ttl.is_some()) {
+        return;
+    }
+    // ONE thread for every pool in the process — the accumulation this fixes
+    // would otherwise be re-created in thread form — and a plain OS thread
+    // rather than a task on a pool's own runtime, because it DROPS pools and
+    // dropping a `Runtime` from inside that runtime panics.
+    let spawned = std::thread::Builder::new().name("areev-pg-reap".into()).spawn(|| {
+        while let Some(tick) = sweep() {
+            std::thread::sleep(tick);
+        }
+    });
+    // Out of threads: this open still works, unreaped, and the next one tries
+    // again. Never a reason to fail an open.
+    reg.reaping = spawned.is_ok();
+}
+
+/// One pass: close what has been idle too long, then evict a pool that holds
+/// nothing and that nothing holds. Returns how long to sleep, or `None` when
+/// no pool wants reaping any more — the thread exits and the next open
+/// starts a new one.
+fn sweep() -> Option<std::time::Duration> {
+    let mut evicted: Vec<std::sync::Arc<PgPool>> = Vec::new();
+    let tick = {
+        let mut reg = registry();
+        let now = std::time::Instant::now();
+        let mut keep = HashMap::with_capacity(reg.pools.len());
+        for (key, p) in std::mem::take(&mut reg.pools) {
+            let left = p.reap_idle(now);
+            // Nothing left to hand out and nobody holding it: the pool goes
+            // too, and its runtime's worker threads with it. Sound under this
+            // lock and only under it — every other reference (a handle, a
+            // checkout) is an `Arc` clone that can only be made from here, so
+            // a count of one means this map is the last owner.
+            if left == 0 && p.idle_ttl.is_some() && std::sync::Arc::strong_count(&p) == 1 {
+                evicted.push(p);
+            } else {
+                keep.insert(key, p);
+            }
+        }
+        reg.pools = keep;
+        match reg.pools.values().filter_map(|p| p.idle_ttl).min() {
+            Some(ttl) => Some((ttl / 2).clamp(MIN_REAP_TICK, MAX_REAP_TICK)),
+            None => {
+                reg.reaping = false;
+                None
+            }
+        }
+    };
+    // Off the lock: dropping a pool drops its runtime, which waits for its
+    // worker threads — not something to do while every opener in the process
+    // is queued behind the registry.
+    drop(evicted);
+    tick
+}
 
 impl PgPool {
     /// The pool for `url`, made on first use. Keyed by the DSN with the
-    /// store's own parameters (`schema`, `provision`, `pool`) stripped, so
-    /// every memory on one server and role shares one pool; a different
-    /// role or TLS setting is a different pool. The first open sizes it;
-    /// a later open asking for another size gets the warning back.
+    /// store's own parameters (`schema`, `provision`, `pool`,
+    /// `pool_idle_secs`) stripped, so every memory on one server and role
+    /// shares one pool; a different role or TLS setting is a different pool.
+    /// The first open sizes it and sets its idle TTL; a later open asking
+    /// for another size or TTL gets the warning back.
     pub(crate) fn for_url(url: &str) -> Result<(std::sync::Arc<PgPool>, Option<String>)> {
         let want = pool_size(url)?;
-        let key = strip_param(&strip_param(&strip_param(url, "pool"), "provision"), "schema");
-        let mut reg = POOLS
-            .get_or_init(Default::default)
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        if let Some(p) = reg.get(&key) {
-            let warn = (p.cap != want).then(|| {
-                format!(
+        let want_ttl = pool_idle_ttl(url)?;
+        let key = pool_key(url);
+        let mut reg = registry();
+        if let Some(p) = reg.pools.get(&key) {
+            let mut warn: Vec<String> = Vec::new();
+            if p.cap != want {
+                warn.push(format!(
                     "postgres pool for this DSN was sized at {} connections by an earlier open \
                      in this process; ?pool={want} (or ${POOL_ENV}) does not resize it",
                     p.cap
-                )
-            });
-            return Ok((std::sync::Arc::clone(p), warn));
+                ));
+            }
+            if p.idle_ttl != want_ttl {
+                warn.push(format!(
+                    "postgres pool for this DSN reaps idle connections after {} by an earlier \
+                     open in this process; ?{POOL_IDLE_PARAM}={} (or ${POOL_IDLE_ENV}) does not \
+                     change it",
+                    describe_ttl(p.idle_ttl),
+                    describe_ttl(want_ttl)
+                ));
+            }
+            let p = std::sync::Arc::clone(p);
+            return Ok((p, (!warn.is_empty()).then(|| warn.join("; "))));
         }
         // Multi-thread so callers on any thread `block_on` concurrently — a
         // current-thread runtime serializes its `block_on` callers, which
@@ -495,11 +683,40 @@ impl PgPool {
             rt,
             url: key.clone(),
             cap: want,
+            idle_ttl: want_ttl,
             sem: std::sync::Arc::new(tokio::sync::Semaphore::new(want)),
             idle: std::sync::Mutex::new(Vec::new()),
         });
-        reg.insert(key, std::sync::Arc::clone(&p));
+        reg.pools.insert(key, std::sync::Arc::clone(&p));
+        start_reaper(&mut reg);
         Ok((p, None))
+    }
+
+    /// Close every connection idle longer than this pool's TTL — and any the
+    /// server has already hung up on, whatever the TTL. Returns how many are
+    /// left, which is what tells the caller whether the pool itself is now
+    /// holding nothing.
+    fn reap_idle(&self, now: std::time::Instant) -> usize {
+        let mut idle = self.idle.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(ttl) = self.idle_ttl else {
+            return idle.len();
+        };
+        let mut kept = Vec::with_capacity(idle.len());
+        let mut doomed = Vec::new();
+        for (since, c) in idle.drain(..) {
+            if now.duration_since(since) < ttl && !c.client.is_closed() {
+                kept.push((since, c));
+            } else {
+                doomed.push(c);
+            }
+        }
+        *idle = kept;
+        let left = idle.len();
+        drop(idle);
+        // The sockets close here, off the pool's lock: dropping the `Client`
+        // is what ends its connection task.
+        drop(doomed);
+        left
     }
 
     pub(crate) fn block_on<F: std::future::Future>(&self, f: F) -> F::Output {
@@ -516,8 +733,8 @@ impl PgPool {
         let idle = loop {
             let next = self.idle.lock().unwrap_or_else(|p| p.into_inner()).pop();
             match next {
-                Some(c) if c.client.is_closed() => continue,
-                other => break other,
+                Some((_, c)) if c.client.is_closed() => continue,
+                other => break other.map(|(_, c)| c),
             }
         };
         let conn = match idle {
@@ -2479,6 +2696,74 @@ mod schema_version_tests {
         // The driver never sees it, whatever else rides along.
         let req = crate::pgtls::SslRequest::split("postgres://u@h/db?pool=3&sslmode=disable").unwrap();
         assert_eq!(req.dsn, "postgres://u@h/db");
+    }
+
+    #[test]
+    fn pool_idle_ttl_reads_the_dsn_then_the_environment() {
+        let secs = |u: &str| pool_idle_ttl(u).unwrap().map(|d| d.as_secs());
+        assert_eq!(secs("postgres://u@h/db?schema=x"), Some(DEFAULT_POOL_IDLE_SECS));
+        assert_eq!(secs("postgres://u@h/db?pool_idle_secs=30&schema=x"), Some(30));
+        // 0 is a setting, not an absence: keep every connection dialled for
+        // the life of the process, which is what every build before #229 did.
+        assert_eq!(secs("postgres://u@h/db?pool_idle_secs=0"), None);
+        assert!(pool_idle_ttl("postgres://u@h/db?pool_idle_secs=soon").is_err());
+        std::env::set_var(POOL_IDLE_ENV, "45");
+        assert_eq!(secs("postgres://u@h/db"), Some(45));
+        assert_eq!(secs("postgres://u@h/db?pool_idle_secs=10"), Some(10), "the DSN wins");
+        std::env::set_var(POOL_IDLE_ENV, "whenever");
+        assert!(pool_idle_ttl("postgres://u@h/db").is_err());
+        std::env::remove_var(POOL_IDLE_ENV);
+        assert_eq!(
+            strip_pool_idle("postgres://u@h/db?pool_idle_secs=30&schema=x"),
+            "postgres://u@h/db?schema=x"
+        );
+        // The driver never sees it — `tokio_postgres` rejects unknown options.
+        let req =
+            crate::pgtls::SslRequest::split("postgres://u@h/db?pool_idle_secs=30&sslmode=disable")
+                .unwrap();
+        assert_eq!(req.dsn, "postgres://u@h/db");
+    }
+
+    /// No server needed: a pool is a runtime, a semaphore and an empty idle
+    /// list until somebody checks out, so the registry's own rules are
+    /// testable against a DSN that resolves nowhere.
+    #[test]
+    fn the_pool_key_ignores_the_idle_parameter_and_a_later_open_is_told_not_obeyed() {
+        let host = "pool-key.invalid";
+        let (first, w) =
+            PgPool::for_url(&format!("postgres://u@{host}/db?pool=4&pool_idle_secs=0&schema=one"))
+                .unwrap();
+        assert!(w.is_none(), "{w:?}");
+        let (second, w) =
+            PgPool::for_url(&format!("postgres://u@{host}/db?pool=4&pool_idle_secs=0&schema=two"))
+                .unwrap();
+        assert!(w.is_none(), "{w:?}");
+        assert!(std::sync::Arc::ptr_eq(&first, &second), "neither schema nor TTL keys the pool");
+
+        let (third, w) =
+            PgPool::for_url(&format!("postgres://u@{host}/db?pool=9&pool_idle_secs=30&schema=c"))
+                .unwrap();
+        assert!(std::sync::Arc::ptr_eq(&first, &third));
+        assert_eq!(third.idle_ttl, None, "the first open set the TTL");
+        let w = w.unwrap();
+        assert!(w.contains("sized at 4"), "{w}");
+        assert!(w.contains("after never"), "{w}");
+    }
+
+    /// The #229 lifecycle, minus the connections: a pool nothing holds, with
+    /// nothing idle in it, does not outlive the sweep.
+    #[test]
+    fn a_pool_that_holds_nothing_and_that_nothing_holds_is_evicted() {
+        let host = "pool-evict.invalid";
+        let (p, _) =
+            PgPool::for_url(&format!("postgres://u@{host}/db?pool=2&pool_idle_secs=1")).unwrap();
+        assert!(registry().pools.keys().any(|k| k.contains(host)));
+        drop(p);
+        sweep();
+        assert!(
+            !registry().pools.keys().any(|k| k.contains(host)),
+            "an unreferenced, empty pool must not survive a sweep"
+        );
     }
 
     #[test]

--- a/crates/areev-store/src/pgtls.rs
+++ b/crates/areev-store/src/pgtls.rs
@@ -127,7 +127,7 @@ impl SslRequest {
             match pair.split_once('=') {
                 Some(("sslmode", v)) => mode = SslMode::parse(v)?,
                 Some(("sslrootcert", v)) if !v.is_empty() => root_cert = Some(v.to_string()),
-                Some(("provision", _)) | Some(("pool", _)) => {}
+                Some(("provision", _)) | Some(("pool", _)) | Some(("pool_idle_secs", _)) => {}
                 _ => rest.push(pair),
             }
         }

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1524,7 +1524,11 @@ The third DSN parameter is `pool=P`: how many connections this *process*
 may hold to that server and role, shared by every memory it opens (default
 8; `$AREEV_PG_POOL` when the DSN is not yours to edit). A memory handle
 holds none while idle, so open as many as you like and size the pool for
-the transactions that run at once
+the transactions that run at once. The fourth is `pool_idle_secs=T`
+(default 300; `$AREEV_PG_POOL_IDLE_SECS`): a connection idle that long is
+closed, and a pool nothing is using goes with it — so a process that has
+gone quiet holds nothing, not one connection per role it has ever opened.
+`pool_idle_secs=0` keeps them for the life of the process
 ([deployment-profile.md](deployment-profile.md)).
 
 That is the upgrade contract too: after a build whose schema changed, the

--- a/docs/deployment-profile.md
+++ b/docs/deployment-profile.md
@@ -126,6 +126,39 @@ The old advice — cache handles in an LRU and close idle ones — is
 withdrawn: handles are cheap to hold open now, since holding one costs no
 connection.
 
+**What a process actually holds, for a capacity plan.** A pool is keyed by
+the DSN, so the unit that multiplies is not the memory but the *pool*:
+
+> connections held ≈ distinct DSNs opened × that pool's peak concurrency,
+> until reaped.
+
+"Distinct DSNs" means distinct server, role and TLS setting — every memory on
+one role shares one pool and `?pool=P` caps it, which is the shape #181 was
+designed for. **Give every tenant its own role and the multiplier is the
+tenant count**: 500 tenants on one worker are 500 pools, and `?pool=` bounds
+each of them separately, not their sum. That is the topology to size for if
+you use one.
+
+**Idle connections are reaped: `?pool_idle_secs=T` (default 300).** A
+connection that has sat idle for T seconds is closed, and a pool whose
+connections have all gone — with no handle and no statement holding it — is
+dropped entirely, releasing its runtime's worker threads too (#229). So an
+idle memory holds no connection *and* an idle process trends to zero, rather
+than to one connection per role it has ever touched. One reaper thread per
+process does this, looking every half-T (at most every 30 s), so a connection
+outlives its TTL by at most that. Set T on the DSN or out of band with
+`$AREEV_PG_POOL_IDLE_SECS`, the DSN winning, on the same first-open-wins
+terms as `?pool=`; `pool_idle_secs=0` never reaps, which is what every build
+through 1.8.0 did. Reopening a memory whose pool was reaped costs one dial and
+nothing else — no warning, no bootstrap (the schema is stamped), no
+reconfiguration.
+
+Two sizing consequences. A short T on a busy process is a re-dial tax, not a
+saving — the connections it closes are about to be wanted again; T is there
+to bound what an *idle* process holds. And a long T is how you keep a
+latency-sensitive path warm: nothing is reaped while work keeps arriving, so
+steady-state traffic never pays for a dial.
+
 **A pooler may run in transaction mode, on one condition and with one
 caveat.** The store keeps nothing it needs on the session: every statement
 names its tables schema-qualified (`"tenant_7".grains`, never `grains`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -145,7 +145,9 @@ agent; memories separate *between* agents. Concretely:
   reviewer can run on one host without the host becoming the trust boundary.
 - **Budget the connections** on a shared Postgres: a process holds at most
   `?pool=` connections per DSN (default 8, `$AREEV_PG_POOL` out of band)
-  however many memories it opens, and first open of a new schema runs the
+  however many memories it opens — per DSN, so count roles rather than
+  memories if each tenant has its own — and gives them back after
+  `?pool_idle_secs=` (default 300). First open of a new schema runs the
   DDL bootstrap — provision schemas when the agent is created, not on its
   first turn ([deployment-profile.md](deployment-profile.md)).
 


### PR DESCRIPTION
`?pool=` bounds one pool, and a pool is keyed by the DSN. A host that gives every tenant its own Postgres role therefore has **one pool per tenant**, and nothing ever released one: `POOLS` had no eviction and `PgPool.idle` had no TTL, so a worker's connection count grew with the number of distinct roles it had *ever touched* rather than with how many were in use. Only a restart brought it down. The bound that used to exist by accident — the handle LRU — is what #181 correctly withdrew.

## What changed

- **Idle reaping.** A connection idle past `?pool_idle_secs=T` is closed. Default 300 s; `$AREEV_PG_POOL_IDLE_SECS` out of band, the DSN winning, on the same first-open-wins terms as `?pool=`; `pool_idle_secs=0` keeps every connection for the life of the process, which is exactly today's behaviour.
- **Pool eviction.** A pool whose idle list has emptied while no handle and no checkout holds it is dropped from the registry — releasing its runtime's worker threads too, which is the same accumulation in another currency (8 threads per pool × one pool per tenant).
- **One reaper thread per process**, a plain OS thread. Not a task per pool: that rebuilds the accumulation in thread form, and a task on a pool's own runtime cannot drop that pool (dropping a `Runtime` from inside itself panics). It looks every half-TTL, bounded to 30 s, and exits when no pool wants reaping — the next open starts it again.
- The new parameter is stripped from the DSN before the driver sees it, like every other store parameter, and is not part of the pool key.

Eviction's safety is the `Arc` count read **under the registry lock**: every other reference to a pool (a handle, a `Checkout`) is a clone that can only be made while holding that lock, so a count of one proves the registry is the last owner. That is what makes it impossible to end up with two pools for one DSN, which would double the cap.

## Acceptance

| | |
|---|---|
| connections fall to ~0 after the TTL with no handle open | ✅ new case in `crates/areev-conformance/tests/pg_pool.rs` |
| a memory reopened after its pool was reaped works, no warning, no cliff beyond one dial | ✅ asserted in the same case (`open_warnings()` empty, content intact) |
| the deployment profile states the retained-connection model | ✅ `docs/deployment-profile.md`, "What a process actually holds, for a capacity plan" |
| `?pool=` semantics unchanged | ✅ the #181 case is untouched but for pinning `pool_idle_secs=0`, since it is a test about the cap |

The new case reproduces the issue's own topology — eight memories on eight DSNs, which is the shape eight roles have — and measures what the issue measured: **8 connections at work → 8 still held after every handle is dropped → 0 once the TTL passes**, with all eight pools gone from the registry. It fails on the pre-change behaviour (verified: `left: 1, right: 0` with reaping off), so it is measuring reaping and not something trivially true.

## Testing

- `cargo test -p areev-conformance --features postgres` — all six binaries green (pg 85, chaos 71, turso 71, stale 2, pool 2, cal_smoke 1), against pgvector/pg16.
- The same suite again with `AREEV_PG_POOL_IDLE_SECS=1`, so every pool in it reaps and re-dials throughout — including the `RESET ALL` chaos runner. Green.
- `cargo test --workspace` green; `cargo clippy --workspace --all-targets` and the store with `postgres,postgres-tls,conformance` clean.
- Embedded-path perf gates not re-run: `pg.rs` is behind a non-default feature and the file backend does not compile it.

## Not done, deliberately

The third option in the issue, a process-wide `$AREEV_PG_MAX_CONNS` ceiling. It bounds the same number, but a cap shared across pools can deadlock a caller holding one memory's transaction open while opening another's — which the per-pool semaphore cannot. Happy to revisit if the reaping bound turns out not to be enough in the cell.

Closes #229.

https://claude.ai/code/session_01AcXRh9A9PAx9NZ6bFrWNyF